### PR TITLE
Add root .gitignore to exclude .worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/


### PR DESCRIPTION
Adds a root-level `.gitignore` to prevent `.worktrees/` from being tracked. Required for using git worktrees for feature development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)