### PR TITLE
feat(core): implement math functions (25) — issue #3

### DIFF
--- a/crates/core/src/eval/functions/math/abs/mod.rs
+++ b/crates/core/src/eval/functions/math/abs/mod.rs
@@ -1,0 +1,21 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+pub fn abs_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let result = n.abs();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/abs/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/abs/tests/edge.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn abs_large_negative() {
+    assert_eq!(abs_fn(&[Value::Number(-1e308)]), Value::Number(1e308));
+}
+
+#[test]
+fn abs_bool_true() {
+    assert_eq!(abs_fn(&[Value::Bool(true)]), Value::Number(1.0));
+}
+
+#[test]
+fn abs_numeric_text() {
+    assert_eq!(
+        abs_fn(&[Value::Text("-3.5".to_string())]),
+        Value::Number(3.5)
+    );
+}

--- a/crates/core/src/eval/functions/math/abs/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/abs/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(abs_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_many_args_returns_value_error() {
+    assert_eq!(
+        abs_fn(&[Value::Number(1.0), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn non_numeric_text_returns_value_error() {
+    assert_eq!(
+        abs_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/abs/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/abs/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/abs/tests/success.rs
+++ b/crates/core/src/eval/functions/math/abs/tests/success.rs
@@ -1,0 +1,17 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn abs_positive() {
+    assert_eq!(abs_fn(&[Value::Number(5.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn abs_negative() {
+    assert_eq!(abs_fn(&[Value::Number(-5.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn abs_zero() {
+    assert_eq!(abs_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/math/average/mod.rs
+++ b/crates/core/src/eval/functions/math/average/mod.rs
@@ -1,0 +1,31 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+pub fn average_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 255) {
+        return err;
+    }
+    let mut sum = 0.0_f64;
+    let mut count = 0usize;
+    for arg in args {
+        match to_number(arg.clone()) {
+            Err(e) => return e,
+            Ok(n) => {
+                sum += n;
+                count += 1;
+            }
+        }
+    }
+    if count == 0 {
+        return Value::Error(ErrorKind::DivByZero);
+    }
+    let result = sum / count as f64;
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/average/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/average/tests/edge.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn average_negatives() {
+    assert_eq!(
+        average_fn(&[Value::Number(-3.0), Value::Number(-1.0)]),
+        Value::Number(-2.0)
+    );
+}
+
+#[test]
+fn average_empty_treated_as_zero() {
+    // Empty coerces to 0.0, count still increments
+    assert_eq!(
+        average_fn(&[Value::Empty, Value::Number(4.0)]),
+        Value::Number(2.0)
+    );
+}
+
+#[test]
+fn overflow_returns_num_error() {
+    assert_eq!(
+        average_fn(&[Value::Number(f64::MAX), Value::Number(f64::MAX)]),
+        Value::Error(ErrorKind::Num)
+    );
+}

--- a/crates/core/src/eval/functions/math/average/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/average/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(average_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_text_returns_value_error() {
+    assert_eq!(
+        average_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn propagates_error_arg() {
+    assert_eq!(
+        average_fn(&[Value::Error(ErrorKind::Ref)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}

--- a/crates/core/src/eval/functions/math/average/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/average/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/average/tests/success.rs
+++ b/crates/core/src/eval/functions/math/average/tests/success.rs
@@ -1,0 +1,32 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn average_of_three() {
+    assert_eq!(
+        average_fn(&[Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]),
+        Value::Number(2.0)
+    );
+}
+
+#[test]
+fn average_single() {
+    assert_eq!(average_fn(&[Value::Number(5.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn average_with_bool() {
+    // TRUE=1, FALSE=0 → (1+0)/2 = 0.5
+    assert_eq!(
+        average_fn(&[Value::Bool(true), Value::Bool(false)]),
+        Value::Number(0.5)
+    );
+}
+
+#[test]
+fn average_with_numeric_text() {
+    assert_eq!(
+        average_fn(&[Value::Text("4.0".to_string()), Value::Number(2.0)]),
+        Value::Number(3.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/ceiling_floor/mod.rs
+++ b/crates/core/src/eval/functions/math/ceiling_floor/mod.rs
@@ -16,7 +16,7 @@ pub fn ceiling_fn(args: &[Value]) -> Value {
         Ok(v) => v,
     };
     if sig == 0.0 {
-        return Value::Number(0.0);
+        return Value::Error(ErrorKind::DivByZero);
     }
     let result = (n / sig).ceil() * sig;
     if !result.is_finite() {
@@ -39,7 +39,7 @@ pub fn floor_fn(args: &[Value]) -> Value {
         Ok(v) => v,
     };
     if sig == 0.0 {
-        return Value::Number(0.0);
+        return Value::Error(ErrorKind::DivByZero);
     }
     let result = (n / sig).floor() * sig;
     if !result.is_finite() {

--- a/crates/core/src/eval/functions/math/ceiling_floor/mod.rs
+++ b/crates/core/src/eval/functions/math/ceiling_floor/mod.rs
@@ -1,0 +1,52 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `CEILING(number, significance)` — round up to nearest multiple of significance.
+pub fn ceiling_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let sig = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if sig == 0.0 {
+        return Value::Number(0.0);
+    }
+    let result = (n / sig).ceil() * sig;
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+/// `FLOOR(number, significance)` — round down to nearest multiple of significance.
+pub fn floor_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let sig = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if sig == 0.0 {
+        return Value::Number(0.0);
+    }
+    let result = (n / sig).floor() * sig;
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/ceiling_floor/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/ceiling_floor/tests/edge.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use crate::types::Value;
+use crate::types::{ErrorKind, Value};
 
 #[test]
 fn ceiling_negative_both_negative_sig() {
@@ -20,17 +20,17 @@ fn floor_negative_both_negative_sig() {
 }
 
 #[test]
-fn ceiling_significance_zero_returns_zero() {
+fn ceiling_significance_zero_returns_div_by_zero() {
     assert_eq!(
         ceiling_fn(&[Value::Number(5.0), Value::Number(0.0)]),
-        Value::Number(0.0)
+        Value::Error(ErrorKind::DivByZero)
     );
 }
 
 #[test]
-fn floor_significance_zero_returns_zero() {
+fn floor_significance_zero_returns_div_by_zero() {
     assert_eq!(
         floor_fn(&[Value::Number(5.0), Value::Number(0.0)]),
-        Value::Number(0.0)
+        Value::Error(ErrorKind::DivByZero)
     );
 }

--- a/crates/core/src/eval/functions/math/ceiling_floor/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/ceiling_floor/tests/edge.rs
@@ -1,0 +1,36 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn ceiling_negative_both_negative_sig() {
+    // CEILING(-4.5, -1) → -5
+    assert_eq!(
+        ceiling_fn(&[Value::Number(-4.5), Value::Number(-1.0)]),
+        Value::Number(-5.0)
+    );
+}
+
+#[test]
+fn floor_negative_both_negative_sig() {
+    // FLOOR(-4.5, -1) → -4
+    assert_eq!(
+        floor_fn(&[Value::Number(-4.5), Value::Number(-1.0)]),
+        Value::Number(-4.0)
+    );
+}
+
+#[test]
+fn ceiling_significance_zero_returns_zero() {
+    assert_eq!(
+        ceiling_fn(&[Value::Number(5.0), Value::Number(0.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn floor_significance_zero_returns_zero() {
+    assert_eq!(
+        floor_fn(&[Value::Number(5.0), Value::Number(0.0)]),
+        Value::Number(0.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/ceiling_floor/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/ceiling_floor/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn ceiling_no_args_returns_value_error() {
+    assert_eq!(ceiling_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn floor_no_args_returns_value_error() {
+    assert_eq!(floor_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn ceiling_non_numeric_returns_value_error() {
+    assert_eq!(
+        ceiling_fn(&[Value::Text("abc".to_string()), Value::Number(1.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/ceiling_floor/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/ceiling_floor/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/ceiling_floor/tests/success.rs
+++ b/crates/core/src/eval/functions/math/ceiling_floor/tests/success.rs
@@ -1,0 +1,34 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn ceiling_basic() {
+    assert_eq!(
+        ceiling_fn(&[Value::Number(4.2), Value::Number(1.0)]),
+        Value::Number(5.0)
+    );
+}
+
+#[test]
+fn ceiling_to_nearest_5() {
+    assert_eq!(
+        ceiling_fn(&[Value::Number(11.0), Value::Number(5.0)]),
+        Value::Number(15.0)
+    );
+}
+
+#[test]
+fn floor_basic() {
+    assert_eq!(
+        floor_fn(&[Value::Number(4.8), Value::Number(1.0)]),
+        Value::Number(4.0)
+    );
+}
+
+#[test]
+fn floor_to_nearest_5() {
+    assert_eq!(
+        floor_fn(&[Value::Number(11.0), Value::Number(5.0)]),
+        Value::Number(10.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/exp/mod.rs
+++ b/crates/core/src/eval/functions/math/exp/mod.rs
@@ -1,0 +1,21 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+pub fn exp_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let result = n.exp();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/exp/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/exp/tests/edge.rs
@@ -1,0 +1,31 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn exp_large_arg_overflows() {
+    // e^1000 overflows to infinity
+    assert_eq!(
+        exp_fn(&[Value::Number(1000.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn exp_large_negative_is_near_zero() {
+    // e^(-1000) is very small but finite
+    if let Value::Number(n) = exp_fn(&[Value::Number(-1000.0)]) {
+        assert!(n >= 0.0);
+    } else {
+        panic!("Expected Number");
+    }
+}
+
+#[test]
+fn exp_bool_true() {
+    // e^1 = e
+    if let Value::Number(n) = exp_fn(&[Value::Bool(true)]) {
+        assert!((n - std::f64::consts::E).abs() < 1e-10);
+    } else {
+        panic!("Expected Number");
+    }
+}

--- a/crates/core/src/eval/functions/math/exp/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/exp/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(exp_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_many_args_returns_value_error() {
+    assert_eq!(
+        exp_fn(&[Value::Number(1.0), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn non_numeric_text_returns_value_error() {
+    assert_eq!(
+        exp_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/exp/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/exp/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/exp/tests/success.rs
+++ b/crates/core/src/eval/functions/math/exp/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn exp_zero_is_one() {
+    assert_eq!(exp_fn(&[Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn exp_one_is_e() {
+    if let Value::Number(n) = exp_fn(&[Value::Number(1.0)]) {
+        assert!((n - std::f64::consts::E).abs() < 1e-10);
+    } else {
+        panic!("Expected Number");
+    }
+}
+
+#[test]
+fn exp_negative_arg() {
+    // e^(-1) ≈ 0.3679
+    if let Value::Number(n) = exp_fn(&[Value::Number(-1.0)]) {
+        assert!((n - 1.0 / std::f64::consts::E).abs() < 1e-10);
+    } else {
+        panic!("Expected Number");
+    }
+}

--- a/crates/core/src/eval/functions/math/int_fn/mod.rs
+++ b/crates/core/src/eval/functions/math/int_fn/mod.rs
@@ -1,0 +1,22 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `INT(number)` — floor toward negative infinity.
+pub fn int_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let result = n.floor();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/int_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/int_fn/tests/edge.rs
@@ -1,0 +1,17 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn int_zero() {
+    assert_eq!(int_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn int_negative_exact() {
+    assert_eq!(int_fn(&[Value::Number(-3.0)]), Value::Number(-3.0));
+}
+
+#[test]
+fn int_very_small_positive() {
+    assert_eq!(int_fn(&[Value::Number(0.9999)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/math/int_fn/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/int_fn/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(int_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_many_args_returns_value_error() {
+    assert_eq!(
+        int_fn(&[Value::Number(1.0), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn non_numeric_text_returns_value_error() {
+    assert_eq!(
+        int_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/int_fn/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/int_fn/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/int_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/math/int_fn/tests/success.rs
@@ -1,0 +1,18 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn int_positive_fraction() {
+    assert_eq!(int_fn(&[Value::Number(3.7)]), Value::Number(3.0));
+}
+
+#[test]
+fn int_positive_exact() {
+    assert_eq!(int_fn(&[Value::Number(5.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn int_negative_fraction() {
+    // INT(-1.5) → -2 (floor toward negative infinity)
+    assert_eq!(int_fn(&[Value::Number(-1.5)]), Value::Number(-2.0));
+}

--- a/crates/core/src/eval/functions/math/log/mod.rs
+++ b/crates/core/src/eval/functions/math/log/mod.rs
@@ -1,0 +1,74 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `LOG(number, [base])` — logarithm, default base 10.
+pub fn log_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if n <= 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let result = if args.len() == 2 {
+        let base = match to_number(args[1].clone()) {
+            Err(e) => return e,
+            Ok(v) => v,
+        };
+        if base <= 0.0 || base == 1.0 {
+            return Value::Error(ErrorKind::Num);
+        }
+        n.log(base)
+    } else {
+        n.log10()
+    };
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+/// `LOG10(number)` — base-10 logarithm.
+pub fn log10_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if n <= 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let result = n.log10();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+/// `LN(number)` — natural logarithm.
+pub fn ln_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if n <= 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let result = n.ln();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/log/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/log/tests/edge.rs
@@ -1,0 +1,21 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn log_of_one_is_zero() {
+    assert_eq!(log_fn(&[Value::Number(1.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn log_base_one_returns_num_error() {
+    // log base 1 is undefined
+    assert_eq!(
+        log_fn(&[Value::Number(10.0), Value::Number(1.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn ln_of_one_is_zero() {
+    assert_eq!(ln_fn(&[Value::Number(1.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/math/log/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/log/tests/failure.rs
@@ -1,0 +1,30 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn log_of_zero_returns_num_error() {
+    assert_eq!(log_fn(&[Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn log_of_negative_returns_num_error() {
+    assert_eq!(log_fn(&[Value::Number(-1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn ln_of_zero_returns_num_error() {
+    assert_eq!(ln_fn(&[Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn log10_of_negative_returns_num_error() {
+    assert_eq!(
+        log10_fn(&[Value::Number(-5.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(log_fn(&[]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/math/log/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/log/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/log/tests/success.rs
+++ b/crates/core/src/eval/functions/math/log/tests/success.rs
@@ -1,0 +1,30 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn log10_of_100() {
+    assert_eq!(log_fn(&[Value::Number(100.0)]), Value::Number(2.0));
+}
+
+#[test]
+fn log_with_base_2() {
+    assert_eq!(
+        log_fn(&[Value::Number(8.0), Value::Number(2.0)]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn log10_function() {
+    assert_eq!(log10_fn(&[Value::Number(1000.0)]), Value::Number(3.0));
+}
+
+#[test]
+fn ln_of_e() {
+    let result = ln_fn(&[Value::Number(std::f64::consts::E)]);
+    if let Value::Number(n) = result {
+        assert!((n - 1.0).abs() < 1e-10);
+    } else {
+        panic!("Expected Number");
+    }
+}

--- a/crates/core/src/eval/functions/math/mod.rs
+++ b/crates/core/src/eval/functions/math/mod.rs
@@ -1,7 +1,46 @@
 use super::super::Registry;
 
+pub mod abs;
+pub mod average;
+pub mod ceiling_floor;
+pub mod exp;
+pub mod int_fn;
+pub mod log;
+pub mod mod_fn;
+pub mod power;
+pub mod product;
+pub mod quotient;
+pub mod rand;
+pub mod round;
+pub mod sign;
+pub mod sqrt;
 pub mod sum;
+pub mod trig;
 
 pub fn register_math(registry: &mut Registry) {
     registry.register_eager("SUM", sum::sum_fn);
+    registry.register_eager("AVERAGE", average::average_fn);
+    registry.register_eager("PRODUCT", product::product_fn);
+    registry.register_eager("ROUND", round::round_fn);
+    registry.register_eager("ROUNDUP", round::roundup_fn);
+    registry.register_eager("ROUNDDOWN", round::rounddown_fn);
+    registry.register_eager("INT", int_fn::int_fn);
+    registry.register_eager("ABS", abs::abs_fn);
+    registry.register_eager("SIGN", sign::sign_fn);
+    registry.register_eager("MOD", mod_fn::mod_fn);
+    registry.register_eager("POWER", power::power_fn);
+    registry.register_eager("SQRT", sqrt::sqrt_fn);
+    registry.register_eager("LOG", log::log_fn);
+    registry.register_eager("LOG10", log::log10_fn);
+    registry.register_eager("LN", log::ln_fn);
+    registry.register_eager("EXP", exp::exp_fn);
+    registry.register_eager("CEILING", ceiling_floor::ceiling_fn);
+    registry.register_eager("FLOOR", ceiling_floor::floor_fn);
+    registry.register_eager("RAND", rand::rand_fn);
+    registry.register_eager("RANDBETWEEN", rand::randbetween_fn);
+    registry.register_eager("PI", trig::pi_fn);
+    registry.register_eager("SIN", trig::sin_fn);
+    registry.register_eager("COS", trig::cos_fn);
+    registry.register_eager("TAN", trig::tan_fn);
+    registry.register_eager("QUOTIENT", quotient::quotient_fn);
 }

--- a/crates/core/src/eval/functions/math/mod_fn/mod.rs
+++ b/crates/core/src/eval/functions/math/mod_fn/mod.rs
@@ -1,0 +1,30 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `MOD(number, divisor)` — result sign follows divisor (Excel semantics).
+/// Formula: n - divisor * floor(n / divisor)
+pub fn mod_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let d = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if d == 0.0 {
+        return Value::Error(ErrorKind::DivByZero);
+    }
+    let result = n - d * (n / d).floor();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/mod_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/mod_fn/tests/edge.rs
@@ -1,0 +1,29 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn mod_positive_n_negative_divisor() {
+    // MOD(7, -3) → -2 (sign follows divisor)
+    assert_eq!(
+        mod_fn(&[Value::Number(7.0), Value::Number(-3.0)]),
+        Value::Number(-2.0)
+    );
+}
+
+#[test]
+fn mod_both_negative() {
+    // MOD(-7, -3) → -1
+    assert_eq!(
+        mod_fn(&[Value::Number(-7.0), Value::Number(-3.0)]),
+        Value::Number(-1.0)
+    );
+}
+
+#[test]
+fn mod_fractional() {
+    // MOD(5.5, 2.0) → 1.5
+    assert_eq!(
+        mod_fn(&[Value::Number(5.5), Value::Number(2.0)]),
+        Value::Number(1.5)
+    );
+}

--- a/crates/core/src/eval/functions/math/mod_fn/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/mod_fn/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn divisor_zero_returns_div_by_zero() {
+    assert_eq!(
+        mod_fn(&[Value::Number(5.0), Value::Number(0.0)]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(mod_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_first_arg() {
+    assert_eq!(
+        mod_fn(&[Value::Text("abc".to_string()), Value::Number(3.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/mod_fn/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/mod_fn/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/mod_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/math/mod_fn/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn mod_basic() {
+    assert_eq!(
+        mod_fn(&[Value::Number(7.0), Value::Number(3.0)]),
+        Value::Number(1.0)
+    );
+}
+
+#[test]
+fn mod_exact_divisible() {
+    assert_eq!(
+        mod_fn(&[Value::Number(6.0), Value::Number(3.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn mod_negative_n_positive_divisor() {
+    // MOD(-7, 3) → 2 (sign follows divisor)
+    assert_eq!(
+        mod_fn(&[Value::Number(-7.0), Value::Number(3.0)]),
+        Value::Number(2.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/power/mod.rs
+++ b/crates/core/src/eval/functions/math/power/mod.rs
@@ -1,0 +1,25 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+pub fn power_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let base = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let exp = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let result = base.powf(exp);
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/power/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/power/tests/edge.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn power_negative_base_integer_exp() {
+    assert_eq!(
+        power_fn(&[Value::Number(-2.0), Value::Number(3.0)]),
+        Value::Number(-8.0)
+    );
+}
+
+#[test]
+fn power_fractional_exponent() {
+    // 4^0.5 = 2
+    assert_eq!(
+        power_fn(&[Value::Number(4.0), Value::Number(0.5)]),
+        Value::Number(2.0)
+    );
+}
+
+#[test]
+fn power_overflow_returns_num_error() {
+    assert_eq!(
+        power_fn(&[Value::Number(f64::MAX), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}

--- a/crates/core/src/eval/functions/math/power/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/power/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(power_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn one_arg_returns_value_error() {
+    assert_eq!(power_fn(&[Value::Number(2.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_base_returns_value_error() {
+    assert_eq!(
+        power_fn(&[Value::Text("abc".to_string()), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/power/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/power/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/power/tests/success.rs
+++ b/crates/core/src/eval/functions/math/power/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn power_basic() {
+    assert_eq!(
+        power_fn(&[Value::Number(2.0), Value::Number(3.0)]),
+        Value::Number(8.0)
+    );
+}
+
+#[test]
+fn power_of_one() {
+    assert_eq!(
+        power_fn(&[Value::Number(5.0), Value::Number(1.0)]),
+        Value::Number(5.0)
+    );
+}
+
+#[test]
+fn power_zero_exponent() {
+    assert_eq!(
+        power_fn(&[Value::Number(7.0), Value::Number(0.0)]),
+        Value::Number(1.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/product/mod.rs
+++ b/crates/core/src/eval/functions/math/product/mod.rs
@@ -1,0 +1,23 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+pub fn product_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 255) {
+        return err;
+    }
+    let mut product = 1.0_f64;
+    for arg in args {
+        match to_number(arg.clone()) {
+            Err(e) => return e,
+            Ok(n) => product *= n,
+        }
+    }
+    if !product.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(product)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/product/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/product/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn product_with_zero() {
+    assert_eq!(
+        product_fn(&[Value::Number(5.0), Value::Number(0.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn product_with_negatives() {
+    assert_eq!(
+        product_fn(&[Value::Number(-2.0), Value::Number(-3.0)]),
+        Value::Number(6.0)
+    );
+}
+
+#[test]
+fn overflow_returns_num_error() {
+    assert_eq!(
+        product_fn(&[Value::Number(f64::MAX), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}

--- a/crates/core/src/eval/functions/math/product/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/product/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(product_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_text_returns_value_error() {
+    assert_eq!(
+        product_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn propagates_error_arg() {
+    assert_eq!(
+        product_fn(&[Value::Error(ErrorKind::Name)]),
+        Value::Error(ErrorKind::Name)
+    );
+}

--- a/crates/core/src/eval/functions/math/product/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/product/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/product/tests/success.rs
+++ b/crates/core/src/eval/functions/math/product/tests/success.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn product_of_three() {
+    assert_eq!(
+        product_fn(&[Value::Number(2.0), Value::Number(3.0), Value::Number(4.0)]),
+        Value::Number(24.0)
+    );
+}
+
+#[test]
+fn product_single() {
+    assert_eq!(product_fn(&[Value::Number(7.0)]), Value::Number(7.0));
+}
+
+#[test]
+fn product_with_one() {
+    assert_eq!(
+        product_fn(&[Value::Number(1.0), Value::Number(5.0)]),
+        Value::Number(5.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/quotient/mod.rs
+++ b/crates/core/src/eval/functions/math/quotient/mod.rs
@@ -1,0 +1,29 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `QUOTIENT(numerator, denominator)` — integer portion of division.
+pub fn quotient_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let num = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let den = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if den == 0.0 {
+        return Value::Error(ErrorKind::DivByZero);
+    }
+    let result = (num / den).trunc();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/quotient/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/quotient/tests/edge.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn quotient_both_negative() {
+    assert_eq!(
+        quotient_fn(&[Value::Number(-7.0), Value::Number(-2.0)]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn quotient_less_than_one() {
+    assert_eq!(
+        quotient_fn(&[Value::Number(1.0), Value::Number(5.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn quotient_fractional_numerator() {
+    // 7.9 / 2 → trunc(3.95) = 3
+    assert_eq!(
+        quotient_fn(&[Value::Number(7.9), Value::Number(2.0)]),
+        Value::Number(3.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/quotient/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/quotient/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn denominator_zero_returns_div_by_zero() {
+    assert_eq!(
+        quotient_fn(&[Value::Number(5.0), Value::Number(0.0)]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(quotient_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_arg_returns_value_error() {
+    assert_eq!(
+        quotient_fn(&[Value::Text("abc".to_string()), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/quotient/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/quotient/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/quotient/tests/success.rs
+++ b/crates/core/src/eval/functions/math/quotient/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn quotient_basic() {
+    assert_eq!(
+        quotient_fn(&[Value::Number(5.0), Value::Number(2.0)]),
+        Value::Number(2.0)
+    );
+}
+
+#[test]
+fn quotient_exact() {
+    assert_eq!(
+        quotient_fn(&[Value::Number(6.0), Value::Number(3.0)]),
+        Value::Number(2.0)
+    );
+}
+
+#[test]
+fn quotient_with_negatives() {
+    assert_eq!(
+        quotient_fn(&[Value::Number(-7.0), Value::Number(2.0)]),
+        Value::Number(-3.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/rand/mod.rs
+++ b/crates/core/src/eval/functions/math/rand/mod.rs
@@ -1,0 +1,52 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `RAND()` — returns a random number in [0, 1).
+pub fn rand_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 0, 0) {
+        return err;
+    }
+    // Use a simple LCG seeded from system time for no-dependency randomness.
+    // For a real spreadsheet engine a proper RNG would be used, but this avoids
+    // adding external crates.
+    let seed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(12345);
+    // LCG: multiplier 1664525, addend 1013904223 (Numerical Recipes)
+    let val = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+    let f = (val as f64) / (u32::MAX as f64 + 1.0);
+    Value::Number(f)
+}
+
+/// `RANDBETWEEN(low, high)` — returns a random integer in [low, high] inclusive.
+pub fn randbetween_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let low = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let high = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let lo = low.ceil() as i64;
+    let hi = high.floor() as i64;
+    if lo > hi {
+        return Value::Error(ErrorKind::Num);
+    }
+    let seed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(12345);
+    let val = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+    let range = (hi - lo + 1) as u64;
+    let result = lo + (val as u64 % range) as i64;
+    Value::Number(result as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/rand/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/rand/tests/edge.rs
@@ -1,0 +1,29 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn rand_result_is_finite() {
+    let result = rand_fn(&[]);
+    if let Value::Number(n) = result {
+        assert!(n.is_finite());
+    } else {
+        panic!("Expected Number");
+    }
+}
+
+#[test]
+fn randbetween_negative_range() {
+    let result = randbetween_fn(&[Value::Number(-5.0), Value::Number(-1.0)]);
+    if let Value::Number(n) = result {
+        assert!(n >= -5.0 && n <= -1.0);
+        assert_eq!(n, n.floor());
+    } else {
+        panic!("Expected Number");
+    }
+}
+
+#[test]
+fn randbetween_zero_range() {
+    let result = randbetween_fn(&[Value::Number(0.0), Value::Number(0.0)]);
+    assert_eq!(result, Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/math/rand/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/rand/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn rand_with_args_returns_value_error() {
+    assert_eq!(rand_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn randbetween_no_args_returns_value_error() {
+    assert_eq!(randbetween_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn randbetween_low_greater_than_high_returns_num_error() {
+    assert_eq!(
+        randbetween_fn(&[Value::Number(10.0), Value::Number(1.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}

--- a/crates/core/src/eval/functions/math/rand/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/rand/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/rand/tests/success.rs
+++ b/crates/core/src/eval/functions/math/rand/tests/success.rs
@@ -1,0 +1,29 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn rand_returns_number_in_range() {
+    let result = rand_fn(&[]);
+    if let Value::Number(n) = result {
+        assert!(n >= 0.0 && n < 1.0, "RAND() must be in [0, 1), got {}", n);
+    } else {
+        panic!("Expected Number from RAND()");
+    }
+}
+
+#[test]
+fn randbetween_returns_number_in_range() {
+    let result = randbetween_fn(&[Value::Number(1.0), Value::Number(10.0)]);
+    if let Value::Number(n) = result {
+        assert!(n >= 1.0 && n <= 10.0, "RANDBETWEEN must be in [1,10], got {}", n);
+        assert_eq!(n, n.floor(), "RANDBETWEEN must return an integer");
+    } else {
+        panic!("Expected Number from RANDBETWEEN()");
+    }
+}
+
+#[test]
+fn randbetween_same_low_high() {
+    let result = randbetween_fn(&[Value::Number(5.0), Value::Number(5.0)]);
+    assert_eq!(result, Value::Number(5.0));
+}

--- a/crates/core/src/eval/functions/math/round/mod.rs
+++ b/crates/core/src/eval/functions/math/round/mod.rs
@@ -1,0 +1,88 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// Round `n` to `digits` decimal places, Excel-style (0.5 rounds away from zero).
+pub fn round_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let digits = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let d = digits.trunc() as i32;
+    let result = round_half_away(n, d);
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+/// Round `n` up (away from zero) to `digits` decimal places.
+pub fn roundup_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let digits = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let d = digits.trunc() as i32;
+    let result = round_away_from_zero(n, d);
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+/// Round `n` down (toward zero) to `digits` decimal places.
+pub fn rounddown_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let digits = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let d = digits.trunc() as i32;
+    let result = round_toward_zero(n, d);
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+fn scale(d: i32) -> f64 {
+    10f64.powi(d)
+}
+
+fn round_half_away(n: f64, d: i32) -> f64 {
+    let s = scale(d);
+    (n * s).signum() * ((n * s).abs() + 0.5).floor() / s
+}
+
+fn round_away_from_zero(n: f64, d: i32) -> f64 {
+    let s = scale(d);
+    (n * s).signum() * ((n * s).abs()).ceil() / s
+}
+
+fn round_toward_zero(n: f64, d: i32) -> f64 {
+    let s = scale(d);
+    (n * s).signum() * ((n * s).abs()).floor() / s
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/round/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/round/tests/edge.rs
@@ -1,0 +1,38 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn round_negative_digits_rounds_to_tens() {
+    // ROUND(1234, -2) → 1200
+    assert_eq!(
+        round_fn(&[Value::Number(1234.0), Value::Number(-2.0)]),
+        Value::Number(1200.0)
+    );
+}
+
+#[test]
+fn round_negative_half_away() {
+    // ROUND(-2.5, 0) → -3 (away from zero)
+    assert_eq!(
+        round_fn(&[Value::Number(-2.5), Value::Number(0.0)]),
+        Value::Number(-3.0)
+    );
+}
+
+#[test]
+fn roundup_already_integer() {
+    // ROUNDUP(3.0, 0) → 3 (no change needed)
+    assert_eq!(
+        roundup_fn(&[Value::Number(3.0), Value::Number(0.0)]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn rounddown_fractional_negative_digits() {
+    // ROUNDDOWN(1567, -2) → 1500
+    assert_eq!(
+        rounddown_fn(&[Value::Number(1567.0), Value::Number(-2.0)]),
+        Value::Number(1500.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/round/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/round/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn round_wrong_arity() {
+    assert_eq!(round_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn roundup_wrong_arity() {
+    assert_eq!(roundup_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn rounddown_non_numeric_first_arg() {
+    assert_eq!(
+        rounddown_fn(&[Value::Text("abc".to_string()), Value::Number(0.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/round/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/round/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/round/tests/success.rs
+++ b/crates/core/src/eval/functions/math/round/tests/success.rs
@@ -1,0 +1,52 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn round_to_two_decimals() {
+    assert_eq!(
+        round_fn(&[Value::Number(3.14159), Value::Number(2.0)]),
+        Value::Number(3.14)
+    );
+}
+
+#[test]
+fn roundup_basic() {
+    assert_eq!(
+        roundup_fn(&[Value::Number(3.1), Value::Number(0.0)]),
+        Value::Number(4.0)
+    );
+}
+
+#[test]
+fn rounddown_basic() {
+    assert_eq!(
+        rounddown_fn(&[Value::Number(3.9), Value::Number(0.0)]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn round_half_point_five_away_from_zero() {
+    assert_eq!(
+        round_fn(&[Value::Number(2.5), Value::Number(0.0)]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn roundup_negative() {
+    // away from zero → more negative
+    assert_eq!(
+        roundup_fn(&[Value::Number(-3.1), Value::Number(0.0)]),
+        Value::Number(-4.0)
+    );
+}
+
+#[test]
+fn rounddown_negative() {
+    // toward zero → less negative
+    assert_eq!(
+        rounddown_fn(&[Value::Number(-3.9), Value::Number(0.0)]),
+        Value::Number(-3.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/sign/mod.rs
+++ b/crates/core/src/eval/functions/math/sign/mod.rs
@@ -1,0 +1,24 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+pub fn sign_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let result = if n > 0.0 {
+        1.0
+    } else if n < 0.0 {
+        -1.0
+    } else {
+        0.0
+    };
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/sign/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/sign/tests/edge.rs
@@ -1,0 +1,17 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn sign_very_small_positive() {
+    assert_eq!(sign_fn(&[Value::Number(1e-300)]), Value::Number(1.0));
+}
+
+#[test]
+fn sign_very_small_negative() {
+    assert_eq!(sign_fn(&[Value::Number(-1e-300)]), Value::Number(-1.0));
+}
+
+#[test]
+fn sign_bool_false_is_zero() {
+    assert_eq!(sign_fn(&[Value::Bool(false)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/math/sign/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/sign/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(sign_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_many_args_returns_value_error() {
+    assert_eq!(
+        sign_fn(&[Value::Number(1.0), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn non_numeric_text_returns_value_error() {
+    assert_eq!(
+        sign_fn(&[Value::Text("xyz".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/sign/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/sign/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/sign/tests/success.rs
+++ b/crates/core/src/eval/functions/math/sign/tests/success.rs
@@ -1,0 +1,17 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn sign_positive() {
+    assert_eq!(sign_fn(&[Value::Number(5.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn sign_negative() {
+    assert_eq!(sign_fn(&[Value::Number(-3.0)]), Value::Number(-1.0));
+}
+
+#[test]
+fn sign_zero() {
+    assert_eq!(sign_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/math/sqrt/mod.rs
+++ b/crates/core/src/eval/functions/math/sqrt/mod.rs
@@ -1,0 +1,24 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+pub fn sqrt_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if n < 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let result = n.sqrt();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/sqrt/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/sqrt/tests/edge.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn sqrt_large_number() {
+    assert_eq!(sqrt_fn(&[Value::Number(1e8)]), Value::Number(1e4));
+}
+
+#[test]
+fn sqrt_one() {
+    assert_eq!(sqrt_fn(&[Value::Number(1.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn sqrt_large_negative_returns_num_error() {
+    assert_eq!(
+        sqrt_fn(&[Value::Number(-1e100)]),
+        Value::Error(ErrorKind::Num)
+    );
+}

--- a/crates/core/src/eval/functions/math/sqrt/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/sqrt/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn sqrt_negative_returns_num_error() {
+    assert_eq!(
+        sqrt_fn(&[Value::Number(-1.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(sqrt_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_text_returns_value_error() {
+    assert_eq!(
+        sqrt_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/sqrt/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/sqrt/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/sqrt/tests/success.rs
+++ b/crates/core/src/eval/functions/math/sqrt/tests/success.rs
@@ -1,0 +1,17 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn sqrt_perfect_square() {
+    assert_eq!(sqrt_fn(&[Value::Number(9.0)]), Value::Number(3.0));
+}
+
+#[test]
+fn sqrt_of_four() {
+    assert_eq!(sqrt_fn(&[Value::Number(4.0)]), Value::Number(2.0));
+}
+
+#[test]
+fn sqrt_of_zero() {
+    assert_eq!(sqrt_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/math/trig/mod.rs
+++ b/crates/core/src/eval/functions/math/trig/mod.rs
@@ -1,0 +1,58 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+pub fn pi_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 0, 0) {
+        return err;
+    }
+    Value::Number(std::f64::consts::PI)
+}
+
+pub fn sin_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let result = n.sin();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+pub fn cos_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let result = n.cos();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+pub fn tan_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let result = n.tan();
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/trig/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/trig/tests/edge.rs
@@ -1,0 +1,29 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn cos_of_pi() {
+    if let Value::Number(n) = cos_fn(&[Value::Number(std::f64::consts::PI)]) {
+        assert!((n - (-1.0)).abs() < 1e-10);
+    } else {
+        panic!("Expected Number");
+    }
+}
+
+#[test]
+fn sin_of_pi_is_near_zero() {
+    if let Value::Number(n) = sin_fn(&[Value::Number(std::f64::consts::PI)]) {
+        assert!(n.abs() < 1e-10);
+    } else {
+        panic!("Expected Number");
+    }
+}
+
+#[test]
+fn tan_of_pi_over_4_is_near_one() {
+    if let Value::Number(n) = tan_fn(&[Value::Number(std::f64::consts::FRAC_PI_4)]) {
+        assert!((n - 1.0).abs() < 1e-10);
+    } else {
+        panic!("Expected Number");
+    }
+}

--- a/crates/core/src/eval/functions/math/trig/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/trig/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn pi_with_args_returns_value_error() {
+    assert_eq!(pi_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn sin_no_args_returns_value_error() {
+    assert_eq!(sin_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn cos_non_numeric_returns_value_error() {
+    assert_eq!(
+        cos_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/trig/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/trig/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/trig/tests/success.rs
+++ b/crates/core/src/eval/functions/math/trig/tests/success.rs
@@ -1,0 +1,31 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn pi_returns_pi() {
+    assert_eq!(pi_fn(&[]), Value::Number(std::f64::consts::PI));
+}
+
+#[test]
+fn sin_of_zero() {
+    assert_eq!(sin_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn cos_of_zero() {
+    assert_eq!(cos_fn(&[Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn tan_of_zero() {
+    assert_eq!(tan_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn sin_of_pi_over_2() {
+    if let Value::Number(n) = sin_fn(&[Value::Number(std::f64::consts::FRAC_PI_2)]) {
+        assert!((n - 1.0).abs() < 1e-10);
+    } else {
+        panic!("Expected Number");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3

- Added 25 math functions under `crates/core/src/eval/functions/math/`: `AVERAGE`, `PRODUCT`, `ROUND`, `ROUNDUP`, `ROUNDDOWN`, `INT`, `ABS`, `SIGN`, `MOD`, `POWER`, `SQRT`, `LOG`, `LOG10`, `LN`, `EXP`, `CEILING`, `FLOOR`, `RAND`, `RANDBETWEEN`, `PI`, `SIN`, `COS`, `TAN`, `QUOTIENT`
- Each function lives in its own subdirectory following the established directory structure (`mod.rs` + `tests/{success,failure,edge}.rs`)
- 277 tests pass; clippy reports no warnings

## Test plan

- [ ] `cargo test -p core` — all 277 tests pass
- [ ] `cargo clippy -p core` — zero warnings
- [ ] Spot-check a few functions (e.g. `ROUND`, `LOG`, `RANDBETWEEN`) against spreadsheet-equivalent expected values

🤖 Generated with [Claude Code](https://claude.com/claude-code)