### PR TITLE
feat(core): implement text functions (14) — issue #5

### DIFF
--- a/crates/core/src/eval/functions/mod.rs
+++ b/crates/core/src/eval/functions/mod.rs
@@ -1,5 +1,6 @@
 pub mod logical;
 pub mod math;
+pub mod text;
 
 use std::collections::HashMap;
 use crate::eval::context::Context;
@@ -48,6 +49,7 @@ impl Registry {
         let mut r = Self { functions: HashMap::new() };
         math::register_math(&mut r);
         logical::register_logical(&mut r);
+        text::register_text(&mut r);
         r
     }
 

--- a/crates/core/src/eval/functions/text/concatenate/mod.rs
+++ b/crates/core/src/eval/functions/text/concatenate/mod.rs
@@ -1,0 +1,21 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// `CONCATENATE(text1, ...)` — joins all arguments as strings.
+pub fn concatenate_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 255) {
+        return err;
+    }
+    let mut result = String::new();
+    for arg in args {
+        match to_string_val(arg.clone()) {
+            Ok(s) => result.push_str(&s),
+            Err(e) => return e,
+        }
+    }
+    Value::Text(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/concatenate/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/concatenate/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn empty_strings() {
+    assert_eq!(
+        concatenate_fn(&[Value::Text("".to_string()), Value::Text("".to_string())]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn bool_coerced() {
+    assert_eq!(
+        concatenate_fn(&[Value::Bool(true), Value::Text("!".to_string())]),
+        Value::Text("TRUE!".to_string())
+    );
+}
+
+#[test]
+fn empty_value_coerced() {
+    assert_eq!(
+        concatenate_fn(&[Value::Text("a".to_string()), Value::Empty, Value::Text("b".to_string())]),
+        Value::Text("ab".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/concatenate/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/concatenate/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn wrong_arity_no_args() {
+    assert_eq!(concatenate_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn error_propagated() {
+    assert_eq!(
+        concatenate_fn(&[Value::Text("a".to_string()), Value::Error(ErrorKind::Ref)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}
+
+#[test]
+fn array_causes_error() {
+    assert_eq!(
+        concatenate_fn(&[Value::Array(vec![Value::Number(1.0)])]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/text/concatenate/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/concatenate/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/concatenate/tests/success.rs
+++ b/crates/core/src/eval/functions/text/concatenate/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn two_strings() {
+    assert_eq!(
+        concatenate_fn(&[Value::Text("Hello".to_string()), Value::Text(" World".to_string())]),
+        Value::Text("Hello World".to_string())
+    );
+}
+
+#[test]
+fn single_string() {
+    assert_eq!(
+        concatenate_fn(&[Value::Text("Hello".to_string())]),
+        Value::Text("Hello".to_string())
+    );
+}
+
+#[test]
+fn number_coerced() {
+    assert_eq!(
+        concatenate_fn(&[Value::Text("Value: ".to_string()), Value::Number(42.0)]),
+        Value::Text("Value: 42".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/find/mod.rs
+++ b/crates/core/src/eval/functions/text/find/mod.rs
@@ -1,0 +1,47 @@
+use crate::eval::coercion::{to_number, to_string_val};
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `FIND(find_text, within_text, [start_num])` — returns the 1-based position of find_text.
+/// Case-sensitive. Returns `#VALUE!` if not found or start_num < 1.
+pub fn find_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 3) {
+        return err;
+    }
+    let find_text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let within_text = match to_string_val(args[1].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let start_num = if args.len() == 3 {
+        match to_number(args[2].clone()) {
+            Ok(n) => n,
+            Err(e) => return e,
+        }
+    } else {
+        1.0
+    };
+    if start_num < 1.0 {
+        return Value::Error(ErrorKind::Value);
+    }
+    let start_idx = (start_num as usize) - 1;
+    let within_chars: Vec<char> = within_text.chars().collect();
+    if start_idx > within_chars.len() {
+        return Value::Error(ErrorKind::Value);
+    }
+    let search_in: String = within_chars[start_idx..].iter().collect();
+    match search_in.find(&find_text) {
+        Some(byte_pos) => {
+            // Convert byte offset to char offset
+            let char_offset = search_in[..byte_pos].chars().count();
+            Value::Number((start_idx + char_offset + 1) as f64)
+        }
+        None => Value::Error(ErrorKind::Value),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/find/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/find/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn start_beyond_end() {
+    assert_eq!(
+        find_fn(&[Value::Text("l".to_string()), Value::Text("Hello".to_string()), Value::Number(10.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn find_empty_string() {
+    assert_eq!(
+        find_fn(&[Value::Text("".to_string()), Value::Text("Hello".to_string())]),
+        Value::Number(1.0)
+    );
+}
+
+#[test]
+fn start_zero_is_error() {
+    assert_eq!(
+        find_fn(&[Value::Text("l".to_string()), Value::Text("Hello".to_string()), Value::Number(0.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/text/find/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/find/tests/failure.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn not_found() {
+    assert_eq!(
+        find_fn(&[Value::Text("x".to_string()), Value::Text("Hello".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn case_sensitive_not_found() {
+    assert_eq!(
+        find_fn(&[Value::Text("h".to_string()), Value::Text("Hello".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn wrong_arity() {
+    assert_eq!(
+        find_fn(&[Value::Text("x".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/text/find/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/find/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/find/tests/success.rs
+++ b/crates/core/src/eval/functions/text/find/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_find() {
+    assert_eq!(
+        find_fn(&[Value::Text("l".to_string()), Value::Text("Hello".to_string())]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn find_with_start() {
+    assert_eq!(
+        find_fn(&[Value::Text("l".to_string()), Value::Text("Hello".to_string()), Value::Number(4.0)]),
+        Value::Number(4.0)
+    );
+}
+
+#[test]
+fn find_at_beginning() {
+    assert_eq!(
+        find_fn(&[Value::Text("H".to_string()), Value::Text("Hello".to_string())]),
+        Value::Number(1.0)
+    );
+}

--- a/crates/core/src/eval/functions/text/left/mod.rs
+++ b/crates/core/src/eval/functions/text/left/mod.rs
@@ -1,0 +1,32 @@
+use crate::eval::coercion::{to_number, to_string_val};
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `LEFT(text, [num_chars])` — returns the first N characters of a string.
+/// Default N=1. Returns `#VALUE!` if N < 0.
+pub fn left_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let n = if args.len() == 2 {
+        match to_number(args[1].clone()) {
+            Ok(n) => n,
+            Err(e) => return e,
+        }
+    } else {
+        1.0
+    };
+    if n < 0.0 {
+        return Value::Error(ErrorKind::Value);
+    }
+    let n = n as usize;
+    let result: String = text.chars().take(n).collect();
+    Value::Text(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/left/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/left/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn zero_chars() {
+    assert_eq!(
+        left_fn(&[Value::Text("Hello".to_string()), Value::Number(0.0)]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn clamp_beyond_length() {
+    assert_eq!(
+        left_fn(&[Value::Text("Hello".to_string()), Value::Number(100.0)]),
+        Value::Text("Hello".to_string())
+    );
+}
+
+#[test]
+fn empty_string() {
+    assert_eq!(
+        left_fn(&[Value::Text("".to_string()), Value::Number(3.0)]),
+        Value::Text("".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/left/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/left/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn negative_num_chars() {
+    assert_eq!(
+        left_fn(&[Value::Text("Hello".to_string()), Value::Number(-1.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn wrong_arity_zero_args() {
+    assert_eq!(left_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn error_propagated() {
+    assert_eq!(
+        left_fn(&[Value::Error(ErrorKind::Ref), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}

--- a/crates/core/src/eval/functions/text/left/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/left/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/left/tests/success.rs
+++ b/crates/core/src/eval/functions/text/left/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_left() {
+    assert_eq!(
+        left_fn(&[Value::Text("Hello".to_string()), Value::Number(3.0)]),
+        Value::Text("Hel".to_string())
+    );
+}
+
+#[test]
+fn default_one_char() {
+    assert_eq!(
+        left_fn(&[Value::Text("Hello".to_string())]),
+        Value::Text("H".to_string())
+    );
+}
+
+#[test]
+fn number_coerced_to_text() {
+    assert_eq!(
+        left_fn(&[Value::Number(123.0), Value::Number(2.0)]),
+        Value::Text("12".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/len/mod.rs
+++ b/crates/core/src/eval/functions/text/len/mod.rs
@@ -1,0 +1,18 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// `LEN(text)` — returns the number of characters in a string.
+pub fn len_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    Value::Number(text.chars().count() as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/len/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/len/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn bool_coerced() {
+    assert_eq!(
+        len_fn(&[Value::Bool(true)]),
+        Value::Number(4.0) // "TRUE"
+    );
+}
+
+#[test]
+fn empty_value() {
+    assert_eq!(
+        len_fn(&[Value::Empty]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn spaces_count() {
+    assert_eq!(
+        len_fn(&[Value::Text("  a  ".to_string())]),
+        Value::Number(5.0)
+    );
+}

--- a/crates/core/src/eval/functions/text/len/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/len/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn wrong_arity_no_args() {
+    assert_eq!(len_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn wrong_arity_too_many() {
+    assert_eq!(
+        len_fn(&[Value::Text("a".to_string()), Value::Text("b".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn error_propagated() {
+    assert_eq!(
+        len_fn(&[Value::Error(ErrorKind::NA)]),
+        Value::Error(ErrorKind::NA)
+    );
+}

--- a/crates/core/src/eval/functions/text/len/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/len/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/len/tests/success.rs
+++ b/crates/core/src/eval/functions/text/len/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_len() {
+    assert_eq!(
+        len_fn(&[Value::Text("Hello".to_string())]),
+        Value::Number(5.0)
+    );
+}
+
+#[test]
+fn empty_string() {
+    assert_eq!(
+        len_fn(&[Value::Text("".to_string())]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn number_coerced() {
+    assert_eq!(
+        len_fn(&[Value::Number(123.0)]),
+        Value::Number(3.0)
+    );
+}

--- a/crates/core/src/eval/functions/text/lower/mod.rs
+++ b/crates/core/src/eval/functions/text/lower/mod.rs
@@ -1,0 +1,18 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// `LOWER(text)` — converts a string to lowercase.
+pub fn lower_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    Value::Text(text.to_lowercase())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/lower/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/lower/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn empty_string() {
+    assert_eq!(
+        lower_fn(&[Value::Text("".to_string())]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn numbers_unchanged() {
+    assert_eq!(
+        lower_fn(&[Value::Text("Hello123".to_string())]),
+        Value::Text("hello123".to_string())
+    );
+}
+
+#[test]
+fn bool_coerced() {
+    assert_eq!(
+        lower_fn(&[Value::Bool(true)]),
+        Value::Text("true".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/lower/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/lower/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn wrong_arity_no_args() {
+    assert_eq!(lower_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn wrong_arity_too_many() {
+    assert_eq!(
+        lower_fn(&[Value::Text("a".to_string()), Value::Text("b".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn error_propagated() {
+    assert_eq!(
+        lower_fn(&[Value::Error(ErrorKind::Name)]),
+        Value::Error(ErrorKind::Name)
+    );
+}

--- a/crates/core/src/eval/functions/text/lower/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/lower/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/lower/tests/success.rs
+++ b/crates/core/src/eval/functions/text/lower/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_lower() {
+    assert_eq!(
+        lower_fn(&[Value::Text("HELLO".to_string())]),
+        Value::Text("hello".to_string())
+    );
+}
+
+#[test]
+fn mixed_case() {
+    assert_eq!(
+        lower_fn(&[Value::Text("HeLLo WoRLd".to_string())]),
+        Value::Text("hello world".to_string())
+    );
+}
+
+#[test]
+fn already_lowercase() {
+    assert_eq!(
+        lower_fn(&[Value::Text("hello".to_string())]),
+        Value::Text("hello".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/mid/mod.rs
+++ b/crates/core/src/eval/functions/text/mid/mod.rs
@@ -1,0 +1,33 @@
+use crate::eval::coercion::{to_number, to_string_val};
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `MID(text, start_num, num_chars)` — returns a substring starting at `start_num` (1-based).
+/// Returns `#VALUE!` if start_num < 1 or num_chars < 0.
+pub fn mid_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 3, 3) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let start = match to_number(args[1].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let num_chars = match to_number(args[2].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    if start < 1.0 || num_chars < 0.0 {
+        return Value::Error(ErrorKind::Value);
+    }
+    let start = (start as usize) - 1;
+    let num_chars = num_chars as usize;
+    let result: String = text.chars().skip(start).take(num_chars).collect();
+    Value::Text(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/mid/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/mid/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn start_beyond_end() {
+    assert_eq!(
+        mid_fn(&[Value::Text("Hello".to_string()), Value::Number(6.0), Value::Number(3.0)]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn zero_num_chars() {
+    assert_eq!(
+        mid_fn(&[Value::Text("Hello".to_string()), Value::Number(2.0), Value::Number(0.0)]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn clamp_beyond_length() {
+    assert_eq!(
+        mid_fn(&[Value::Text("Hello".to_string()), Value::Number(3.0), Value::Number(100.0)]),
+        Value::Text("llo".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/mid/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/mid/tests/failure.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn start_less_than_one() {
+    assert_eq!(
+        mid_fn(&[Value::Text("Hello".to_string()), Value::Number(0.0), Value::Number(3.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn negative_num_chars() {
+    assert_eq!(
+        mid_fn(&[Value::Text("Hello".to_string()), Value::Number(1.0), Value::Number(-1.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn wrong_arity() {
+    assert_eq!(
+        mid_fn(&[Value::Text("Hello".to_string()), Value::Number(1.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/text/mid/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/mid/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/mid/tests/success.rs
+++ b/crates/core/src/eval/functions/text/mid/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_mid() {
+    assert_eq!(
+        mid_fn(&[Value::Text("Hello".to_string()), Value::Number(1.0), Value::Number(3.0)]),
+        Value::Text("Hel".to_string())
+    );
+}
+
+#[test]
+fn mid_from_middle() {
+    assert_eq!(
+        mid_fn(&[Value::Text("Hello".to_string()), Value::Number(2.0), Value::Number(3.0)]),
+        Value::Text("ell".to_string())
+    );
+}
+
+#[test]
+fn mid_with_num_coercion() {
+    assert_eq!(
+        mid_fn(&[Value::Number(12345.0), Value::Number(2.0), Value::Number(3.0)]),
+        Value::Text("234".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/mod.rs
+++ b/crates/core/src/eval/functions/text/mod.rs
@@ -1,0 +1,33 @@
+use super::Registry;
+
+pub mod left;
+pub mod mid;
+pub mod right;
+pub mod len;
+pub mod lower;
+pub mod upper;
+pub mod trim;
+pub mod concatenate;
+pub mod find;
+pub mod substitute;
+pub mod replace;
+pub mod text_fn;
+pub mod value_fn;
+pub mod rept;
+
+pub fn register_text(registry: &mut Registry) {
+    registry.register_eager("LEFT", left::left_fn);
+    registry.register_eager("MID", mid::mid_fn);
+    registry.register_eager("RIGHT", right::right_fn);
+    registry.register_eager("LEN", len::len_fn);
+    registry.register_eager("LOWER", lower::lower_fn);
+    registry.register_eager("UPPER", upper::upper_fn);
+    registry.register_eager("TRIM", trim::trim_fn);
+    registry.register_eager("CONCATENATE", concatenate::concatenate_fn);
+    registry.register_eager("FIND", find::find_fn);
+    registry.register_eager("SUBSTITUTE", substitute::substitute_fn);
+    registry.register_eager("REPLACE", replace::replace_fn);
+    registry.register_eager("TEXT", text_fn::text_fn);
+    registry.register_eager("VALUE", value_fn::value_fn);
+    registry.register_eager("REPT", rept::rept_fn);
+}

--- a/crates/core/src/eval/functions/text/replace/mod.rs
+++ b/crates/core/src/eval/functions/text/replace/mod.rs
@@ -1,0 +1,40 @@
+use crate::eval::coercion::{to_number, to_string_val};
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `REPLACE(old_text, start_num, num_chars, new_text)` — replaces N chars starting at position.
+/// start_num is 1-based. Returns `#VALUE!` if start_num < 1 or num_chars < 0.
+pub fn replace_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 4, 4) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let start_num = match to_number(args[1].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let num_chars = match to_number(args[2].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let new_text = match to_string_val(args[3].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    if start_num < 1.0 || num_chars < 0.0 {
+        return Value::Error(ErrorKind::Value);
+    }
+    let start = (start_num as usize) - 1;
+    let num_chars = num_chars as usize;
+    let chars: Vec<char> = text.chars().collect();
+    let before: String = chars[..start.min(chars.len())].iter().collect();
+    let after_start = (start + num_chars).min(chars.len());
+    let after: String = chars[after_start..].iter().collect();
+    Value::Text(format!("{}{}{}", before, new_text, after))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/replace/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/replace/tests/edge.rs
@@ -1,0 +1,41 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn start_beyond_end() {
+    assert_eq!(
+        replace_fn(&[
+            Value::Text("Hello".to_string()),
+            Value::Number(10.0),
+            Value::Number(2.0),
+            Value::Text("X".to_string()),
+        ]),
+        Value::Text("HelloX".to_string())
+    );
+}
+
+#[test]
+fn clamp_num_chars_beyond_end() {
+    assert_eq!(
+        replace_fn(&[
+            Value::Text("Hello".to_string()),
+            Value::Number(3.0),
+            Value::Number(100.0),
+            Value::Text("X".to_string()),
+        ]),
+        Value::Text("HeX".to_string())
+    );
+}
+
+#[test]
+fn empty_new_text_deletes() {
+    assert_eq!(
+        replace_fn(&[
+            Value::Text("Hello".to_string()),
+            Value::Number(2.0),
+            Value::Number(3.0),
+            Value::Text("".to_string()),
+        ]),
+        Value::Text("Ho".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/replace/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/replace/tests/failure.rs
@@ -1,0 +1,36 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn start_less_than_one() {
+    assert_eq!(
+        replace_fn(&[
+            Value::Text("Hello".to_string()),
+            Value::Number(0.0),
+            Value::Number(2.0),
+            Value::Text("X".to_string()),
+        ]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn negative_num_chars() {
+    assert_eq!(
+        replace_fn(&[
+            Value::Text("Hello".to_string()),
+            Value::Number(1.0),
+            Value::Number(-1.0),
+            Value::Text("X".to_string()),
+        ]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn wrong_arity() {
+    assert_eq!(
+        replace_fn(&[Value::Text("Hello".to_string()), Value::Number(1.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/text/replace/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/replace/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/replace/tests/success.rs
+++ b/crates/core/src/eval/functions/text/replace/tests/success.rs
@@ -1,0 +1,41 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_replace() {
+    assert_eq!(
+        replace_fn(&[
+            Value::Text("Hello World".to_string()),
+            Value::Number(7.0),
+            Value::Number(5.0),
+            Value::Text("Rust".to_string()),
+        ]),
+        Value::Text("Hello Rust".to_string())
+    );
+}
+
+#[test]
+fn replace_at_start() {
+    assert_eq!(
+        replace_fn(&[
+            Value::Text("Hello".to_string()),
+            Value::Number(1.0),
+            Value::Number(2.0),
+            Value::Text("XY".to_string()),
+        ]),
+        Value::Text("XYllo".to_string())
+    );
+}
+
+#[test]
+fn insert_without_removing() {
+    assert_eq!(
+        replace_fn(&[
+            Value::Text("Hello".to_string()),
+            Value::Number(3.0),
+            Value::Number(0.0),
+            Value::Text("XX".to_string()),
+        ]),
+        Value::Text("HeXXllo".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/rept/mod.rs
+++ b/crates/core/src/eval/functions/text/rept/mod.rs
@@ -1,0 +1,25 @@
+use crate::eval::coercion::{to_number, to_string_val};
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `REPT(text, number_times)` — repeats text N times. Returns `#VALUE!` if N < 0.
+pub fn rept_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let n = match to_number(args[1].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    if n < 0.0 {
+        return Value::Error(ErrorKind::Value);
+    }
+    Value::Text(text.repeat(n as usize))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/rept/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/rept/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn zero_times() {
+    assert_eq!(
+        rept_fn(&[Value::Text("x".to_string()), Value::Number(0.0)]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn empty_text_repeated() {
+    assert_eq!(
+        rept_fn(&[Value::Text("".to_string()), Value::Number(5.0)]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn fractional_times_truncated() {
+    assert_eq!(
+        rept_fn(&[Value::Text("ab".to_string()), Value::Number(2.9)]),
+        Value::Text("abab".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/rept/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/rept/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn negative_times() {
+    assert_eq!(
+        rept_fn(&[Value::Text("x".to_string()), Value::Number(-1.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn wrong_arity_no_args() {
+    assert_eq!(rept_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn error_propagated() {
+    assert_eq!(
+        rept_fn(&[Value::Error(ErrorKind::Ref), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}

--- a/crates/core/src/eval/functions/text/rept/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/rept/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/rept/tests/success.rs
+++ b/crates/core/src/eval/functions/text/rept/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_rept() {
+    assert_eq!(
+        rept_fn(&[Value::Text("ab".to_string()), Value::Number(3.0)]),
+        Value::Text("ababab".to_string())
+    );
+}
+
+#[test]
+fn repeat_once() {
+    assert_eq!(
+        rept_fn(&[Value::Text("x".to_string()), Value::Number(1.0)]),
+        Value::Text("x".to_string())
+    );
+}
+
+#[test]
+fn repeat_word() {
+    assert_eq!(
+        rept_fn(&[Value::Text("ha".to_string()), Value::Number(4.0)]),
+        Value::Text("hahahaha".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/right/mod.rs
+++ b/crates/core/src/eval/functions/text/right/mod.rs
@@ -1,0 +1,34 @@
+use crate::eval::coercion::{to_number, to_string_val};
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `RIGHT(text, [num_chars])` — returns the last N characters of a string.
+/// Default N=1. Returns `#VALUE!` if N < 0.
+pub fn right_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let n = if args.len() == 2 {
+        match to_number(args[1].clone()) {
+            Ok(n) => n,
+            Err(e) => return e,
+        }
+    } else {
+        1.0
+    };
+    if n < 0.0 {
+        return Value::Error(ErrorKind::Value);
+    }
+    let n = n as usize;
+    let chars: Vec<char> = text.chars().collect();
+    let skip = chars.len().saturating_sub(n);
+    let result: String = chars[skip..].iter().collect();
+    Value::Text(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/right/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/right/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn zero_chars() {
+    assert_eq!(
+        right_fn(&[Value::Text("Hello".to_string()), Value::Number(0.0)]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn clamp_beyond_length() {
+    assert_eq!(
+        right_fn(&[Value::Text("Hello".to_string()), Value::Number(100.0)]),
+        Value::Text("Hello".to_string())
+    );
+}
+
+#[test]
+fn empty_string() {
+    assert_eq!(
+        right_fn(&[Value::Text("".to_string()), Value::Number(3.0)]),
+        Value::Text("".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/right/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/right/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn negative_num_chars() {
+    assert_eq!(
+        right_fn(&[Value::Text("Hello".to_string()), Value::Number(-1.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn wrong_arity_zero_args() {
+    assert_eq!(right_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn error_propagated() {
+    assert_eq!(
+        right_fn(&[Value::Error(ErrorKind::Ref)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}

--- a/crates/core/src/eval/functions/text/right/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/right/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/right/tests/success.rs
+++ b/crates/core/src/eval/functions/text/right/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_right() {
+    assert_eq!(
+        right_fn(&[Value::Text("Hello".to_string()), Value::Number(3.0)]),
+        Value::Text("llo".to_string())
+    );
+}
+
+#[test]
+fn default_one_char() {
+    assert_eq!(
+        right_fn(&[Value::Text("Hello".to_string())]),
+        Value::Text("o".to_string())
+    );
+}
+
+#[test]
+fn number_coerced_to_text() {
+    assert_eq!(
+        right_fn(&[Value::Number(123.0), Value::Number(2.0)]),
+        Value::Text("23".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/substitute/mod.rs
+++ b/crates/core/src/eval/functions/text/substitute/mod.rs
@@ -1,0 +1,62 @@
+use crate::eval::coercion::{to_number, to_string_val};
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `SUBSTITUTE(text, old_text, new_text, [instance_num])` — replaces occurrences of old_text with new_text.
+/// Optional instance_num targets a specific occurrence (1-based).
+pub fn substitute_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 3, 4) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let old_text = match to_string_val(args[1].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let new_text = match to_string_val(args[2].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let instance_num = if args.len() == 4 {
+        match to_number(args[3].clone()) {
+            Ok(n) => Some(n as usize),
+            Err(e) => return e,
+        }
+    } else {
+        None
+    };
+
+    if old_text.is_empty() {
+        return Value::Text(text);
+    }
+
+    match instance_num {
+        None => Value::Text(text.replace(&old_text, &new_text)),
+        Some(target) => {
+            if target == 0 {
+                return Value::Error(ErrorKind::Value);
+            }
+            let mut result = String::new();
+            let mut remaining = text.as_str();
+            let mut count = 0usize;
+            while let Some(pos) = remaining.find(&old_text) {
+                count += 1;
+                result.push_str(&remaining[..pos]);
+                if count == target {
+                    result.push_str(&new_text);
+                } else {
+                    result.push_str(&old_text);
+                }
+                remaining = &remaining[pos + old_text.len()..];
+            }
+            result.push_str(remaining);
+            Value::Text(result)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/substitute/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/substitute/tests/edge.rs
@@ -1,0 +1,40 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn old_not_found() {
+    assert_eq!(
+        substitute_fn(&[
+            Value::Text("Hello".to_string()),
+            Value::Text("xyz".to_string()),
+            Value::Text("abc".to_string()),
+        ]),
+        Value::Text("Hello".to_string())
+    );
+}
+
+#[test]
+fn instance_beyond_count() {
+    // Only 2 occurrences, instance 3 — no replacement
+    assert_eq!(
+        substitute_fn(&[
+            Value::Text("aa".to_string()),
+            Value::Text("a".to_string()),
+            Value::Text("b".to_string()),
+            Value::Number(3.0),
+        ]),
+        Value::Text("aa".to_string())
+    );
+}
+
+#[test]
+fn empty_old_text_no_change() {
+    assert_eq!(
+        substitute_fn(&[
+            Value::Text("Hello".to_string()),
+            Value::Text("".to_string()),
+            Value::Text("x".to_string()),
+        ]),
+        Value::Text("Hello".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/substitute/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/substitute/tests/failure.rs
@@ -1,0 +1,35 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn wrong_arity_too_few() {
+    assert_eq!(
+        substitute_fn(&[Value::Text("a".to_string()), Value::Text("b".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn instance_zero_is_error() {
+    assert_eq!(
+        substitute_fn(&[
+            Value::Text("aaa".to_string()),
+            Value::Text("a".to_string()),
+            Value::Text("b".to_string()),
+            Value::Number(0.0),
+        ]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn error_propagated() {
+    assert_eq!(
+        substitute_fn(&[
+            Value::Error(ErrorKind::Ref),
+            Value::Text("a".to_string()),
+            Value::Text("b".to_string()),
+        ]),
+        Value::Error(ErrorKind::Ref)
+    );
+}

--- a/crates/core/src/eval/functions/text/substitute/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/substitute/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/substitute/tests/success.rs
+++ b/crates/core/src/eval/functions/text/substitute/tests/success.rs
@@ -1,0 +1,39 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn replace_all() {
+    assert_eq!(
+        substitute_fn(&[
+            Value::Text("aaa".to_string()),
+            Value::Text("a".to_string()),
+            Value::Text("b".to_string()),
+        ]),
+        Value::Text("bbb".to_string())
+    );
+}
+
+#[test]
+fn replace_specific_instance() {
+    assert_eq!(
+        substitute_fn(&[
+            Value::Text("aaa".to_string()),
+            Value::Text("a".to_string()),
+            Value::Text("b".to_string()),
+            Value::Number(2.0),
+        ]),
+        Value::Text("aba".to_string())
+    );
+}
+
+#[test]
+fn replace_word() {
+    assert_eq!(
+        substitute_fn(&[
+            Value::Text("Hello World".to_string()),
+            Value::Text("World".to_string()),
+            Value::Text("Rust".to_string()),
+        ]),
+        Value::Text("Hello Rust".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/text_fn/mod.rs
+++ b/crates/core/src/eval/functions/text/text_fn/mod.rs
@@ -3,8 +3,22 @@ use crate::eval::coercion::{to_number, to_string_val};
 use crate::eval::functions::check_arity;
 use crate::types::Value;
 
+fn apply_format(n: f64, fmt: &str) -> String {
+    if let Some(dot_pos) = fmt.find('.') {
+        let decimal_part = &fmt[dot_pos + 1..];
+        if decimal_part.chars().all(|c| c == '0' || c == '#') {
+            let places = decimal_part.len();
+            return format!("{:.prec$}", n, prec = places);
+        }
+    } else if fmt.chars().all(|c| c == '0' || c == '#') {
+        return format!("{:.0}", n);
+    }
+    display_number(n)
+}
+
 /// `TEXT(value, format_text)` — converts a number to a formatted string.
-/// For format "0" returns integer string; otherwise uses display_number.
+/// Supports `"0"`, `"0.0"`, `"0.00"` etc. (and `#` variants).
+/// Falls back to `display_number` for unsupported formats.
 pub fn text_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 2) {
         return err;
@@ -17,12 +31,7 @@ pub fn text_fn(args: &[Value]) -> Value {
         Ok(s) => s,
         Err(e) => return e,
     };
-    let result = if format == "0" {
-        format!("{}", n as i64)
-    } else {
-        display_number(n)
-    };
-    Value::Text(result)
+    Value::Text(apply_format(n, &format))
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/text_fn/mod.rs
+++ b/crates/core/src/eval/functions/text/text_fn/mod.rs
@@ -1,0 +1,29 @@
+use crate::display::display_number;
+use crate::eval::coercion::{to_number, to_string_val};
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// `TEXT(value, format_text)` — converts a number to a formatted string.
+/// For format "0" returns integer string; otherwise uses display_number.
+pub fn text_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let format = match to_string_val(args[1].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let result = if format == "0" {
+        format!("{}", n as i64)
+    } else {
+        display_number(n)
+    };
+    Value::Text(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/text_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/text_fn/tests/edge.rs
@@ -5,7 +5,7 @@ use crate::types::Value;
 fn negative_number_integer_format() {
     assert_eq!(
         text_fn(&[Value::Number(-5.7), Value::Text("0".to_string())]),
-        Value::Text("-5".to_string())
+        Value::Text("-6".to_string())
     );
 }
 
@@ -22,5 +22,23 @@ fn bool_coerced_to_number() {
     assert_eq!(
         text_fn(&[Value::Bool(true), Value::Text("0".to_string())]),
         Value::Text("1".to_string())
+    );
+}
+
+#[test]
+fn unsupported_format_falls_back_to_display_number() {
+    // "General" is not a recognised pattern; should fall back to display_number
+    assert_eq!(
+        text_fn(&[Value::Number(3.5), Value::Text("General".to_string())]),
+        Value::Text("3.5".to_string())
+    );
+}
+
+#[test]
+fn hash_format_pads_decimal_places() {
+    // "0.##" — # treated same as 0 → two decimal places
+    assert_eq!(
+        text_fn(&[Value::Number(1.5), Value::Text("0.##".to_string())]),
+        Value::Text("1.50".to_string())
     );
 }

--- a/crates/core/src/eval/functions/text/text_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/text_fn/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn negative_number_integer_format() {
+    assert_eq!(
+        text_fn(&[Value::Number(-5.7), Value::Text("0".to_string())]),
+        Value::Text("-5".to_string())
+    );
+}
+
+#[test]
+fn zero_integer_format() {
+    assert_eq!(
+        text_fn(&[Value::Number(0.0), Value::Text("0".to_string())]),
+        Value::Text("0".to_string())
+    );
+}
+
+#[test]
+fn bool_coerced_to_number() {
+    assert_eq!(
+        text_fn(&[Value::Bool(true), Value::Text("0".to_string())]),
+        Value::Text("1".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/text_fn/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/text_fn/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn wrong_arity_no_args() {
+    assert_eq!(text_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn wrong_arity_one_arg() {
+    assert_eq!(
+        text_fn(&[Value::Number(1.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn non_number_text_arg() {
+    assert_eq!(
+        text_fn(&[Value::Text("hello".to_string()), Value::Text("0".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/text/text_fn/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/text_fn/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/text_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/text/text_fn/tests/success.rs
@@ -10,10 +10,35 @@ fn format_zero_integer() {
 }
 
 #[test]
-fn format_default_float() {
+fn format_two_decimal_places() {
+    // 3.1 must be padded to "3.10", not left as "3.1"
     assert_eq!(
-        text_fn(&[Value::Number(3.14), Value::Text("0.00".to_string())]),
+        text_fn(&[Value::Number(3.1), Value::Text("0.00".to_string())]),
+        Value::Text("3.10".to_string())
+    );
+}
+
+#[test]
+fn format_two_decimal_places_rounds() {
+    assert_eq!(
+        text_fn(&[Value::Number(3.14159), Value::Text("0.00".to_string())]),
         Value::Text("3.14".to_string())
+    );
+}
+
+#[test]
+fn format_integer_rounds() {
+    assert_eq!(
+        text_fn(&[Value::Number(1234.6), Value::Text("0".to_string())]),
+        Value::Text("1235".to_string())
+    );
+}
+
+#[test]
+fn format_three_decimal_places_zero() {
+    assert_eq!(
+        text_fn(&[Value::Number(3.0), Value::Text("0.000".to_string())]),
+        Value::Text("3.000".to_string())
     );
 }
 
@@ -21,6 +46,6 @@ fn format_default_float() {
 fn format_integer_truncated() {
     assert_eq!(
         text_fn(&[Value::Number(3.9), Value::Text("0".to_string())]),
-        Value::Text("3".to_string())
+        Value::Text("4".to_string())
     );
 }

--- a/crates/core/src/eval/functions/text/text_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/text/text_fn/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn format_zero_integer() {
+    assert_eq!(
+        text_fn(&[Value::Number(42.0), Value::Text("0".to_string())]),
+        Value::Text("42".to_string())
+    );
+}
+
+#[test]
+fn format_default_float() {
+    assert_eq!(
+        text_fn(&[Value::Number(3.14), Value::Text("0.00".to_string())]),
+        Value::Text("3.14".to_string())
+    );
+}
+
+#[test]
+fn format_integer_truncated() {
+    assert_eq!(
+        text_fn(&[Value::Number(3.9), Value::Text("0".to_string())]),
+        Value::Text("3".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/trim/mod.rs
+++ b/crates/core/src/eval/functions/text/trim/mod.rs
@@ -1,0 +1,19 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// `TRIM(text)` — removes leading/trailing whitespace and collapses internal spaces.
+pub fn trim_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let result = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    Value::Text(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/trim/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/trim/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn empty_string() {
+    assert_eq!(
+        trim_fn(&[Value::Text("".to_string())]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn only_spaces() {
+    assert_eq!(
+        trim_fn(&[Value::Text("   ".to_string())]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn tabs_and_newlines() {
+    assert_eq!(
+        trim_fn(&[Value::Text("\t a \n b \t".to_string())]),
+        Value::Text("a b".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/trim/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/trim/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn wrong_arity_no_args() {
+    assert_eq!(trim_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn wrong_arity_too_many() {
+    assert_eq!(
+        trim_fn(&[Value::Text("a".to_string()), Value::Text("b".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn error_propagated() {
+    assert_eq!(
+        trim_fn(&[Value::Error(ErrorKind::Value)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/text/trim/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/trim/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/trim/tests/success.rs
+++ b/crates/core/src/eval/functions/text/trim/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_trim() {
+    assert_eq!(
+        trim_fn(&[Value::Text("  Hello  ".to_string())]),
+        Value::Text("Hello".to_string())
+    );
+}
+
+#[test]
+fn internal_spaces_collapsed() {
+    assert_eq!(
+        trim_fn(&[Value::Text("  a  b  ".to_string())]),
+        Value::Text("a b".to_string())
+    );
+}
+
+#[test]
+fn no_change_needed() {
+    assert_eq!(
+        trim_fn(&[Value::Text("Hello World".to_string())]),
+        Value::Text("Hello World".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/upper/mod.rs
+++ b/crates/core/src/eval/functions/text/upper/mod.rs
@@ -1,0 +1,18 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// `UPPER(text)` — converts a string to uppercase.
+pub fn upper_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    Value::Text(text.to_uppercase())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/upper/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/upper/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn empty_string() {
+    assert_eq!(
+        upper_fn(&[Value::Text("".to_string())]),
+        Value::Text("".to_string())
+    );
+}
+
+#[test]
+fn numbers_unchanged() {
+    assert_eq!(
+        upper_fn(&[Value::Text("Hello123".to_string())]),
+        Value::Text("HELLO123".to_string())
+    );
+}
+
+#[test]
+fn bool_coerced() {
+    assert_eq!(
+        upper_fn(&[Value::Bool(false)]),
+        Value::Text("FALSE".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/upper/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/upper/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn wrong_arity_no_args() {
+    assert_eq!(upper_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn wrong_arity_too_many() {
+    assert_eq!(
+        upper_fn(&[Value::Text("a".to_string()), Value::Text("b".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn error_propagated() {
+    assert_eq!(
+        upper_fn(&[Value::Error(ErrorKind::Num)]),
+        Value::Error(ErrorKind::Num)
+    );
+}

--- a/crates/core/src/eval/functions/text/upper/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/upper/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/upper/tests/success.rs
+++ b/crates/core/src/eval/functions/text/upper/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_upper() {
+    assert_eq!(
+        upper_fn(&[Value::Text("hello".to_string())]),
+        Value::Text("HELLO".to_string())
+    );
+}
+
+#[test]
+fn mixed_case() {
+    assert_eq!(
+        upper_fn(&[Value::Text("HeLLo WoRLd".to_string())]),
+        Value::Text("HELLO WORLD".to_string())
+    );
+}
+
+#[test]
+fn already_uppercase() {
+    assert_eq!(
+        upper_fn(&[Value::Text("HELLO".to_string())]),
+        Value::Text("HELLO".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/value_fn/mod.rs
+++ b/crates/core/src/eval/functions/text/value_fn/mod.rs
@@ -1,0 +1,21 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `VALUE(text)` — parses a text string to a number. Returns `#VALUE!` if unparseable.
+pub fn value_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    match text.trim().parse::<f64>() {
+        Ok(n) => Value::Number(n),
+        Err(_) => Value::Error(ErrorKind::Value),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/value_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/value_fn/tests/edge.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn whitespace_trimmed() {
+    assert_eq!(
+        value_fn(&[Value::Text("  42  ".to_string())]),
+        Value::Number(42.0)
+    );
+}
+
+#[test]
+fn empty_string_fails() {
+    assert_eq!(
+        value_fn(&[Value::Text("".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn number_passthrough() {
+    // Number coerced to string "42" then re-parsed
+    assert_eq!(
+        value_fn(&[Value::Number(42.0)]),
+        Value::Number(42.0)
+    );
+}

--- a/crates/core/src/eval/functions/text/value_fn/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/value_fn/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn unparseable_text() {
+    assert_eq!(
+        value_fn(&[Value::Text("hello".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn wrong_arity_no_args() {
+    assert_eq!(value_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn error_propagated() {
+    assert_eq!(
+        value_fn(&[Value::Error(ErrorKind::NA)]),
+        Value::Error(ErrorKind::NA)
+    );
+}

--- a/crates/core/src/eval/functions/text/value_fn/tests/mod.rs
+++ b/crates/core/src/eval/functions/text/value_fn/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/text/value_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/text/value_fn/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn parse_integer() {
+    assert_eq!(
+        value_fn(&[Value::Text("42".to_string())]),
+        Value::Number(42.0)
+    );
+}
+
+#[test]
+fn parse_float() {
+    assert_eq!(
+        value_fn(&[Value::Text("3.14".to_string())]),
+        Value::Number(3.14)
+    );
+}
+
+#[test]
+fn parse_negative() {
+    assert_eq!(
+        value_fn(&[Value::Text("-5.5".to_string())]),
+        Value::Number(-5.5)
+    );
+}


### PR DESCRIPTION
## Summary

- Adds 14 Excel-compatible text functions to `crates/core/src/eval/functions/text/`: LEFT, MID, RIGHT, LEN, LOWER, UPPER, TRIM, CONCATENATE, FIND, SUBSTITUTE, REPLACE, TEXT, VALUE, REPT
- Each function is implemented in its own sub-module with success, failure, and edge-case test files following the existing project structure
- Registers all text functions into the shared function registry via `text::register_text()`

## Tests

256 tests pass, clippy clean.

## Test plan

- [ ] `cargo test -p core` passes with 256 tests
- [ ] `cargo clippy -p core -- -D warnings` reports no warnings
- [ ] Spot-check a few functions manually (e.g. `LEFT("hello", 3)` → `"hel"`, `UPPER("abc")` → `"ABC"`)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)