### PR TITLE
feat(core): implement financial functions (7) — issue #6

### DIFF
--- a/crates/core/src/eval/functions/financial/fv/mod.rs
+++ b/crates/core/src/eval/functions/financial/fv/mod.rs
@@ -1,0 +1,38 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+fn opt_number(args: &[Value], idx: usize, default: f64) -> Result<f64, Value> {
+    if idx < args.len() {
+        to_number(args[idx].clone())
+    } else {
+        Ok(default)
+    }
+}
+
+/// `FV(rate, nper, pmt, [pv], [type])` — future value of an investment.
+pub fn fv_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 3, 5) {
+        return err;
+    }
+    let rate = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let nper = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    let pmt  = match to_number(args[2].clone()) { Ok(n) => n, Err(e) => return e };
+    let pv   = match opt_number(args, 3, 0.0)   { Ok(n) => n, Err(e) => return e };
+    let typ  = match opt_number(args, 4, 0.0)   { Ok(n) => n, Err(e) => return e };
+
+    let result = if rate == 0.0 {
+        -(pv + pmt * nper)
+    } else {
+        let factor = (1.0 + rate).powf(nper);
+        -(pv * factor + pmt * (1.0 + rate * typ) * (factor - 1.0) / rate)
+    };
+
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/financial/fv/tests/edge.rs
+++ b/crates/core/src/eval/functions/financial/fv/tests/edge.rs
@@ -1,0 +1,36 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn type1_vs_type0() {
+    let args0 = [Value::Number(0.05), Value::Number(5.0), Value::Number(-100.0), Value::Number(0.0), Value::Number(0.0)];
+    let args1 = [Value::Number(0.05), Value::Number(5.0), Value::Number(-100.0), Value::Number(0.0), Value::Number(1.0)];
+    let fv0 = fv_fn(&args0);
+    let fv1 = fv_fn(&args1);
+    assert!(matches!(fv0, Value::Number(_)));
+    assert!(matches!(fv1, Value::Number(_)));
+    assert_ne!(fv0, fv1);
+}
+
+#[test]
+fn pv_defaults_to_zero() {
+    let args3 = [Value::Number(0.05), Value::Number(10.0), Value::Number(-100.0)];
+    let args4 = [Value::Number(0.05), Value::Number(10.0), Value::Number(-100.0), Value::Number(0.0)];
+    assert_eq!(fv_fn(&args3), fv_fn(&args4));
+}
+
+#[test]
+fn zero_rate_with_pv() {
+    // FV(0, 5, -100, -200) = 200 + 500 = 700
+    let args = [
+        Value::Number(0.0),
+        Value::Number(5.0),
+        Value::Number(-100.0),
+        Value::Number(-200.0),
+    ];
+    assert!(approx(fv_fn(&args), 700.0, 1e-9));
+}

--- a/crates/core/src/eval/functions/financial/fv/tests/failure.rs
+++ b/crates/core/src/eval/functions/financial/fv/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    assert_eq!(fv_fn(&[Value::Number(0.1), Value::Number(5.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_many_args() {
+    let args = vec![Value::Number(0.1), Value::Number(0.1), Value::Number(0.1),
+                    Value::Number(0.1), Value::Number(0.1), Value::Number(0.1)];
+    assert_eq!(fv_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_pmt() {
+    let args = [Value::Number(0.05), Value::Number(10.0), Value::Text("bad".to_string())];
+    assert_eq!(fv_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/financial/fv/tests/mod.rs
+++ b/crates/core/src/eval/functions/financial/fv/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/financial/fv/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/fv/tests/success.rs
@@ -14,7 +14,7 @@ fn savings_plan() {
         Value::Number(60.0),
         Value::Number(-200.0),
     ];
-    assert!(approx(fv_fn(&args), 13601.22, 1.0));
+    assert!(approx(fv_fn(&args), 13601.22, 0.01));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/financial/fv/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/fv/tests/success.rs
@@ -1,0 +1,37 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn savings_plan() {
+    // FV(0.05/12, 60, -200) — save 200/month for 5 years at 5%/year
+    // ≈ 13601.22
+    let args = [
+        Value::Number(0.05 / 12.0),
+        Value::Number(60.0),
+        Value::Number(-200.0),
+    ];
+    assert!(approx(fv_fn(&args), 13601.22, 1.0));
+}
+
+#[test]
+fn zero_rate() {
+    // FV(0, 10, -100) = 1000
+    let args = [Value::Number(0.0), Value::Number(10.0), Value::Number(-100.0)];
+    assert!(approx(fv_fn(&args), 1000.0, 1e-9));
+}
+
+#[test]
+fn with_present_value() {
+    // FV(0.1, 5, 0, -1000) = 1000 * 1.1^5 ≈ 1610.51
+    let args = [
+        Value::Number(0.1),
+        Value::Number(5.0),
+        Value::Number(0.0),
+        Value::Number(-1000.0),
+    ];
+    assert!(approx(fv_fn(&args), 1610.51, 0.01));
+}

--- a/crates/core/src/eval/functions/financial/irr/mod.rs
+++ b/crates/core/src/eval/functions/financial/irr/mod.rs
@@ -1,0 +1,69 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `IRR(value1, value2, ..., [guess])` — internal rate of return.
+///
+/// All positional args are treated as cash flows except the last if there
+/// are only 2 args total (ambiguous). We require at least 2 cash flow values,
+/// so min arity is 2. The optional guess is NOT a separate named arg here —
+/// instead we treat all args as cash flows by default. To pass a guess, callers
+/// should be aware this implementation uses 0.1 as the default guess.
+///
+/// Per the spec: min 2 args (cash flows). A guess arg is accepted as the
+/// last arg when arity allows, but for simplicity and matching spreadsheet
+/// behavior, all args are treated as cash flows and guess defaults to 0.1.
+pub fn irr_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 255) {
+        return err;
+    }
+
+    // Collect cash flows
+    let mut cfs = Vec::with_capacity(args.len());
+    for arg in args {
+        match to_number(arg.clone()) {
+            Ok(n)  => cfs.push(n),
+            Err(e) => return e,
+        }
+    }
+
+    // Must have at least one positive and one negative cash flow
+    let has_positive = cfs.iter().any(|&n| n > 0.0);
+    let has_negative = cfs.iter().any(|&n| n < 0.0);
+    if !has_positive || !has_negative {
+        return Value::Error(ErrorKind::Num);
+    }
+
+    // Newton-Raphson iteration
+    let mut rate = 0.1_f64;
+    for _ in 0..100 {
+        let (npv, dnpv) = npv_and_derivative(&cfs, rate);
+        if !npv.is_finite() || !dnpv.is_finite() || dnpv == 0.0 {
+            return Value::Error(ErrorKind::Num);
+        }
+        let new_rate = rate - npv / dnpv;
+        if (new_rate - rate).abs() < 1e-7 {
+            if !new_rate.is_finite() {
+                return Value::Error(ErrorKind::Num);
+            }
+            return Value::Number(new_rate);
+        }
+        rate = new_rate;
+    }
+    Value::Error(ErrorKind::Num)
+}
+
+fn npv_and_derivative(cfs: &[f64], rate: f64) -> (f64, f64) {
+    let mut npv = 0.0;
+    let mut dnpv = 0.0;
+    for (i, &cf) in cfs.iter().enumerate() {
+        let t = i as f64;
+        let denom = (1.0 + rate).powf(t);
+        npv  += cf / denom;
+        dnpv -= t * cf / ((1.0 + rate).powf(t + 1.0));
+    }
+    (npv, dnpv)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/financial/irr/tests/edge.rs
+++ b/crates/core/src/eval/functions/financial/irr/tests/edge.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn zero_initial_cash_flow() {
+    // First cash flow zero — still computable if mixed signs exist
+    // IRR(0, -100, 150) — Newton-Raphson should converge
+    let args = [Value::Number(0.0), Value::Number(-100.0), Value::Number(150.0)];
+    // Just verify it returns a Number (convergence behavior may vary)
+    assert!(matches!(irr_fn(&args), Value::Number(_)));
+}
+
+#[test]
+fn large_series() {
+    // 10-period series: invest 1000, get back 150/year for 10 years ≈ 8.14%
+    let mut args = vec![Value::Number(-1000.0)];
+    for _ in 0..10 {
+        args.push(Value::Number(150.0));
+    }
+    let result = irr_fn(&args);
+    assert!(approx(result, 0.0814, 0.001));
+}
+
+#[test]
+fn exact_zero_irr() {
+    // IRR(-100, 100) = 0% since NPV at 0% = -100+100=0
+    let args = [Value::Number(-100.0), Value::Number(100.0)];
+    assert!(approx(irr_fn(&args), 0.0, 1e-6));
+}

--- a/crates/core/src/eval/functions/financial/irr/tests/failure.rs
+++ b/crates/core/src/eval/functions/financial/irr/tests/failure.rs
@@ -1,0 +1,25 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    assert_eq!(irr_fn(&[Value::Number(-100.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn all_positive_returns_num() {
+    let args = [Value::Number(100.0), Value::Number(200.0)];
+    assert_eq!(irr_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn all_negative_returns_num() {
+    let args = [Value::Number(-100.0), Value::Number(-200.0)];
+    assert_eq!(irr_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_numeric_arg() {
+    let args = [Value::Number(-100.0), Value::Text("bad".to_string())];
+    assert_eq!(irr_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/financial/irr/tests/mod.rs
+++ b/crates/core/src/eval/functions/financial/irr/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/financial/irr/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/irr/tests/success.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn basic_irr() {
+    // IRR(-1000, 200, 300, 400, 500) ≈ 0.12826 (12.83%)
+    let args = [
+        Value::Number(-1000.0),
+        Value::Number(200.0),
+        Value::Number(300.0),
+        Value::Number(400.0),
+        Value::Number(500.0),
+    ];
+    assert!(approx(irr_fn(&args), 0.12826, 0.001));
+}
+
+#[test]
+fn simple_irr_known_result() {
+    // IRR(-100, 110) = 10%
+    let args = [Value::Number(-100.0), Value::Number(110.0)];
+    assert!(approx(irr_fn(&args), 0.1, 1e-6));
+}
+
+#[test]
+fn irr_two_periods() {
+    // IRR(-100, 0, 121) = 10% (sqrt(1.21)-1 = 0.1)
+    let args = [Value::Number(-100.0), Value::Number(0.0), Value::Number(121.0)];
+    assert!(approx(irr_fn(&args), 0.1, 1e-6));
+}

--- a/crates/core/src/eval/functions/financial/mod.rs
+++ b/crates/core/src/eval/functions/financial/mod.rs
@@ -1,0 +1,19 @@
+use super::super::Registry;
+
+pub mod fv;
+pub mod irr;
+pub mod npv;
+pub mod nper;
+pub mod pmt;
+pub mod pv;
+pub mod rate;
+
+pub fn register_financial(registry: &mut Registry) {
+    registry.register_eager("PMT", pmt::pmt_fn);
+    registry.register_eager("NPV", npv::npv_fn);
+    registry.register_eager("IRR", irr::irr_fn);
+    registry.register_eager("PV", pv::pv_fn);
+    registry.register_eager("FV", fv::fv_fn);
+    registry.register_eager("RATE", rate::rate_fn);
+    registry.register_eager("NPER", nper::nper_fn);
+}

--- a/crates/core/src/eval/functions/financial/nper/mod.rs
+++ b/crates/core/src/eval/functions/financial/nper/mod.rs
@@ -1,0 +1,50 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+fn opt_number(args: &[Value], idx: usize, default: f64) -> Result<f64, Value> {
+    if idx < args.len() {
+        to_number(args[idx].clone())
+    } else {
+        Ok(default)
+    }
+}
+
+/// `NPER(rate, pmt, pv, [fv], [type])` — number of periods.
+pub fn nper_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 3, 5) {
+        return err;
+    }
+    let rate = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let pmt  = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    let pv   = match to_number(args[2].clone()) { Ok(n) => n, Err(e) => return e };
+    let fv   = match opt_number(args, 3, 0.0)   { Ok(n) => n, Err(e) => return e };
+    let typ  = match opt_number(args, 4, 0.0)   { Ok(n) => n, Err(e) => return e };
+
+    let result = if rate == 0.0 {
+        if pmt == 0.0 {
+            return Value::Error(ErrorKind::DivByZero);
+        }
+        -(pv + fv) / pmt
+    } else {
+        let adjusted_pmt = pmt * (1.0 + rate * typ);
+        let numerator   = adjusted_pmt - fv * rate;
+        let denominator = pv * rate + adjusted_pmt;
+        if denominator == 0.0 {
+            return Value::Error(ErrorKind::Num);
+        }
+        let ratio = numerator / denominator;
+        if ratio <= 0.0 {
+            return Value::Error(ErrorKind::Num);
+        }
+        ratio.ln() / (1.0 + rate).ln()
+    };
+
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/financial/nper/tests/edge.rs
+++ b/crates/core/src/eval/functions/financial/nper/tests/edge.rs
@@ -1,0 +1,48 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn type1_beginning_of_period() {
+    let args = [
+        Value::Number(0.1),
+        Value::Number(-100.0),
+        Value::Number(500.0),
+        Value::Number(0.0),
+        Value::Number(1.0),
+    ];
+    let result = nper_fn(&args);
+    assert!(matches!(result, Value::Number(_)));
+}
+
+#[test]
+fn impossible_ratio_returns_num() {
+    // pmt=0, pv=1000, fv=10000, rate=0.1 → ratio = -10 → #NUM!
+    let args = [
+        Value::Number(0.1),
+        Value::Number(0.0),
+        Value::Number(1000.0),
+        Value::Number(10000.0),
+    ];
+    assert_eq!(nper_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn fv_defaults_to_zero() {
+    let args3 = [Value::Number(0.05), Value::Number(-100.0), Value::Number(500.0)];
+    let args4 = [Value::Number(0.05), Value::Number(-100.0), Value::Number(500.0), Value::Number(0.0)];
+    assert!(approx(nper_fn(&args3), nper_fn(&args4).into_f64(), 1e-9));
+}
+
+trait IntoF64 {
+    fn into_f64(self) -> f64;
+}
+
+impl IntoF64 for Value {
+    fn into_f64(self) -> f64 {
+        if let Value::Number(n) = self { n } else { f64::NAN }
+    }
+}

--- a/crates/core/src/eval/functions/financial/nper/tests/failure.rs
+++ b/crates/core/src/eval/functions/financial/nper/tests/failure.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    assert_eq!(nper_fn(&[Value::Number(0.1), Value::Number(-100.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_many_args() {
+    let args = vec![Value::Number(0.1), Value::Number(0.1), Value::Number(0.1),
+                    Value::Number(0.1), Value::Number(0.1), Value::Number(0.1)];
+    assert_eq!(nper_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn zero_rate_zero_pmt_div_by_zero() {
+    let args = [Value::Number(0.0), Value::Number(0.0), Value::Number(1000.0)];
+    assert_eq!(nper_fn(&args), Value::Error(ErrorKind::DivByZero));
+}
+
+#[test]
+fn non_numeric_arg() {
+    let args = [Value::Text("bad".to_string()), Value::Number(-100.0), Value::Number(1000.0)];
+    assert_eq!(nper_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/financial/nper/tests/mod.rs
+++ b/crates/core/src/eval/functions/financial/nper/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/financial/nper/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/nper/tests/success.rs
@@ -13,7 +13,7 @@ fn nper_for_loan() {
         Value::Number(-188.71),
         Value::Number(10000.0),
     ];
-    assert!(approx(nper_fn(&args), 60.0, 0.5));
+    assert!(approx(nper_fn(&args), 60.0, 0.01));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/financial/nper/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/nper/tests/success.rs
@@ -1,0 +1,37 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn nper_for_loan() {
+    // NPER(0.05/12, -188.71, 10000) ≈ 60
+    let args = [
+        Value::Number(0.05 / 12.0),
+        Value::Number(-188.71),
+        Value::Number(10000.0),
+    ];
+    assert!(approx(nper_fn(&args), 60.0, 0.5));
+}
+
+#[test]
+fn zero_rate() {
+    // NPER(0, -100, 1000) = 10
+    let args = [Value::Number(0.0), Value::Number(-100.0), Value::Number(1000.0)];
+    assert!(approx(nper_fn(&args), 10.0, 1e-9));
+}
+
+#[test]
+fn nper_with_fv() {
+    // NPER(0.1, -100, 500, 0) — should return a positive number
+    let args = [
+        Value::Number(0.1),
+        Value::Number(-100.0),
+        Value::Number(500.0),
+        Value::Number(0.0),
+    ];
+    let result = nper_fn(&args);
+    assert!(matches!(result, Value::Number(n) if n > 0.0));
+}

--- a/crates/core/src/eval/functions/financial/npv/mod.rs
+++ b/crates/core/src/eval/functions/financial/npv/mod.rs
@@ -1,0 +1,23 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `NPV(rate, value1, [value2, ...])` — net present value of cash flows.
+pub fn npv_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 256) {
+        return err;
+    }
+    let rate = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let mut npv = 0.0_f64;
+    for (i, arg) in args[1..].iter().enumerate() {
+        let cf = match to_number(arg.clone()) { Ok(n) => n, Err(e) => return e };
+        npv += cf / (1.0 + rate).powi(i as i32 + 1);
+    }
+    if !npv.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(npv)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/financial/npv/tests/edge.rs
+++ b/crates/core/src/eval/functions/financial/npv/tests/edge.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn negative_rate() {
+    // Negative discount rate is valid math — should return a Number
+    let args = [Value::Number(-0.05), Value::Number(100.0), Value::Number(100.0)];
+    assert!(matches!(npv_fn(&args), Value::Number(_)));
+}
+
+#[test]
+fn rate_minus_one_returns_num() {
+    // rate = -1.0 causes division by zero → #NUM!
+    let args = [Value::Number(-1.0), Value::Number(100.0)];
+    assert_eq!(npv_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn all_positive_cash_flows() {
+    let args = [Value::Number(0.05), Value::Number(100.0), Value::Number(200.0)];
+    let result = npv_fn(&args);
+    assert!(approx(result, 100.0 / 1.05 + 200.0 / 1.05_f64.powi(2), 1e-9));
+}

--- a/crates/core/src/eval/functions/financial/npv/tests/failure.rs
+++ b/crates/core/src/eval/functions/financial/npv/tests/failure.rs
@@ -1,0 +1,24 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args_one() {
+    assert_eq!(npv_fn(&[Value::Number(0.1)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_few_args_zero() {
+    assert_eq!(npv_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_rate() {
+    let args = [Value::Text("bad".to_string()), Value::Number(100.0)];
+    assert_eq!(npv_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_cash_flow() {
+    let args = [Value::Number(0.1), Value::Text("bad".to_string())];
+    assert_eq!(npv_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/financial/npv/tests/mod.rs
+++ b/crates/core/src/eval/functions/financial/npv/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/financial/npv/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/npv/tests/success.rs
@@ -1,0 +1,41 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn basic_npv() {
+    // NPV(0.1, -1000, 200, 300, 400, 500)
+    // = -1000/1.1 + 200/1.1^2 + 300/1.1^3 + 400/1.1^4 + 500/1.1^5
+    // ≈ -909.09 + 165.29 + 225.39 + 273.21 + 310.46 ≈ 65.26
+    let args = [
+        Value::Number(0.1),
+        Value::Number(-1000.0),
+        Value::Number(200.0),
+        Value::Number(300.0),
+        Value::Number(400.0),
+        Value::Number(500.0),
+    ];
+    assert!(approx(npv_fn(&args), 65.26, 0.1));
+}
+
+#[test]
+fn zero_rate_sums_cash_flows() {
+    // At rate=0, NPV = sum of all cash flows
+    let args = [
+        Value::Number(0.0),
+        Value::Number(-100.0),
+        Value::Number(50.0),
+        Value::Number(80.0),
+    ];
+    assert!(approx(npv_fn(&args), 30.0, 1e-9));
+}
+
+#[test]
+fn single_cash_flow() {
+    // NPV(0.1, 110) = 110/1.1 = 100
+    let args = [Value::Number(0.1), Value::Number(110.0)];
+    assert!(approx(npv_fn(&args), 100.0, 1e-9));
+}

--- a/crates/core/src/eval/functions/financial/pmt/mod.rs
+++ b/crates/core/src/eval/functions/financial/pmt/mod.rs
@@ -33,7 +33,7 @@ pub fn pmt_fn(args: &[Value]) -> Value {
         if denom == 0.0 {
             return Value::Error(ErrorKind::Num);
         }
-        (pv * rate * factor + fv * rate) / denom * -(1.0 + rate * typ)
+        -(pv * rate * factor + fv * rate) / denom / (1.0 + rate * typ)
     };
 
     if !result.is_finite() {

--- a/crates/core/src/eval/functions/financial/pmt/mod.rs
+++ b/crates/core/src/eval/functions/financial/pmt/mod.rs
@@ -1,0 +1,46 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+fn opt_number(args: &[Value], idx: usize, default: f64) -> Result<f64, Value> {
+    if idx < args.len() {
+        to_number(args[idx].clone())
+    } else {
+        Ok(default)
+    }
+}
+
+/// `PMT(rate, nper, pv, [fv], [type])` — payment for a loan.
+pub fn pmt_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 3, 5) {
+        return err;
+    }
+    let rate = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let nper = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    let pv   = match to_number(args[2].clone()) { Ok(n) => n, Err(e) => return e };
+    let fv   = match opt_number(args, 3, 0.0)   { Ok(n) => n, Err(e) => return e };
+    let typ  = match opt_number(args, 4, 0.0)   { Ok(n) => n, Err(e) => return e };
+
+    if nper == 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+
+    let result = if rate == 0.0 {
+        -(pv + fv) / nper
+    } else {
+        let factor = (1.0 + rate).powf(nper);
+        let denom = factor - 1.0;
+        if denom == 0.0 {
+            return Value::Error(ErrorKind::Num);
+        }
+        (pv * rate * factor + fv * rate) / denom * -(1.0 + rate * typ)
+    };
+
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/financial/pmt/tests/edge.rs
+++ b/crates/core/src/eval/functions/financial/pmt/tests/edge.rs
@@ -1,0 +1,56 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn negative_pv_gives_positive_payment() {
+    // If pv is negative (investment), payment should be positive
+    let args = [Value::Number(0.1), Value::Number(5.0), Value::Number(-1000.0)];
+    let result = pmt_fn(&args);
+    assert!(matches!(result, Value::Number(n) if n > 0.0));
+}
+
+#[test]
+fn very_small_rate() {
+    // Near-zero rate should still converge
+    let args = [Value::Number(1e-10), Value::Number(12.0), Value::Number(1200.0)];
+    let result = pmt_fn(&args);
+    assert!(approx(result, -100.0, 0.1));
+}
+
+#[test]
+fn fv_defaults_to_zero() {
+    // PMT with explicit fv=0 should equal PMT without fv
+    let args3 = [Value::Number(0.05), Value::Number(10.0), Value::Number(1000.0)];
+    let args4 = [Value::Number(0.05), Value::Number(10.0), Value::Number(1000.0), Value::Number(0.0)];
+    let r3 = pmt_fn(&args3);
+    let r4 = pmt_fn(&args4);
+    assert_eq!(r3, r4);
+}
+
+#[test]
+fn denom_zero_returns_num() {
+    // rate such that (1+rate)^nper == 1 would give #NUM!
+    // This is hard to trigger exactly; verify we handle it when denom == 0
+    // Use nper=0 as an alternative degenerate case (already tested),
+    // test with negative rate that could cause denom=0 (not trivially doable),
+    // so instead verify very large nper with tiny rate still returns a Number.
+    let args = [Value::Number(0.001), Value::Number(1000.0), Value::Number(1000.0)];
+    let result = pmt_fn(&args);
+    assert!(matches!(result, Value::Number(_)));
+}
+
+#[test]
+fn rate_zero_pv_and_fv() {
+    // PMT(0, 5, 100, 50) = -(100+50)/5 = -30
+    let args = [
+        Value::Number(0.0),
+        Value::Number(5.0),
+        Value::Number(100.0),
+        Value::Number(50.0),
+    ];
+    assert_eq!(pmt_fn(&args), Value::Number(-30.0));
+}

--- a/crates/core/src/eval/functions/financial/pmt/tests/failure.rs
+++ b/crates/core/src/eval/functions/financial/pmt/tests/failure.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    assert_eq!(pmt_fn(&[Value::Number(0.1), Value::Number(5.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_many_args() {
+    let args = vec![Value::Number(0.1), Value::Number(0.1), Value::Number(0.1),
+                    Value::Number(0.1), Value::Number(0.1), Value::Number(0.1)];
+    assert_eq!(pmt_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn nper_zero_returns_num() {
+    let args = [Value::Number(0.1), Value::Number(0.0), Value::Number(1000.0)];
+    assert_eq!(pmt_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_numeric_rate_returns_value_error() {
+    let args = [Value::Text("bad".to_string()), Value::Number(5.0), Value::Number(1000.0)];
+    assert_eq!(pmt_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/financial/pmt/tests/mod.rs
+++ b/crates/core/src/eval/functions/financial/pmt/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/financial/pmt/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/pmt/tests/success.rs
@@ -36,14 +36,17 @@ fn with_future_value() {
 
 #[test]
 fn beginning_of_period_type1() {
-    // type=1 adjusts payment to beginning of period
+    // type=1 (annuity-due): payment at beginning of period is smaller in abs value
+    // PMT(0.1, 5, 1000, 0, 0) ≈ -263.80, PMT(0.1, 5, 1000, 0, 1) ≈ -239.82
     let args_end   = [Value::Number(0.1), Value::Number(5.0), Value::Number(1000.0), Value::Number(0.0), Value::Number(0.0)];
     let args_begin = [Value::Number(0.1), Value::Number(5.0), Value::Number(1000.0), Value::Number(0.0), Value::Number(1.0)];
     let end   = pmt_fn(&args_end);
     let begin = pmt_fn(&args_begin);
-    // beginning-of-period payment has a larger absolute value (factor of 1+rate)
+    // beginning-of-period payment has a smaller absolute value (one fewer compounding period)
     if let (Value::Number(e), Value::Number(b)) = (end, begin) {
-        assert!(b.abs() > e.abs());
+        assert!(approx(Value::Number(e), -263.80, 0.01), "type0 expected ≈ -263.80, got {e}");
+        assert!(approx(Value::Number(b), -239.82, 0.01), "type1 expected ≈ -239.82, got {b}");
+        assert!(b.abs() < e.abs(), "type=1 abs value should be smaller than type=0");
     } else {
         panic!("expected numbers");
     }

--- a/crates/core/src/eval/functions/financial/pmt/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/pmt/tests/success.rs
@@ -1,0 +1,50 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn monthly_loan_payment() {
+    // PMT(0.05/12, 60, 10000) ≈ -188.71
+    let rate = Value::Number(0.05 / 12.0);
+    let nper = Value::Number(60.0);
+    let pv   = Value::Number(10000.0);
+    assert!(approx(pmt_fn(&[rate, nper, pv]), -188.71, 0.01));
+}
+
+#[test]
+fn zero_rate_loan() {
+    // PMT(0, 10, 1000) = -100
+    let args = [Value::Number(0.0), Value::Number(10.0), Value::Number(1000.0)];
+    assert_eq!(pmt_fn(&args), Value::Number(-100.0));
+}
+
+#[test]
+fn with_future_value() {
+    // PMT(0.1, 5, 1000, 500) — should be negative payment
+    let args = [
+        Value::Number(0.1),
+        Value::Number(5.0),
+        Value::Number(1000.0),
+        Value::Number(500.0),
+    ];
+    let result = pmt_fn(&args);
+    assert!(matches!(result, Value::Number(n) if n < 0.0));
+}
+
+#[test]
+fn beginning_of_period_type1() {
+    // type=1 adjusts payment to beginning of period
+    let args_end   = [Value::Number(0.1), Value::Number(5.0), Value::Number(1000.0), Value::Number(0.0), Value::Number(0.0)];
+    let args_begin = [Value::Number(0.1), Value::Number(5.0), Value::Number(1000.0), Value::Number(0.0), Value::Number(1.0)];
+    let end   = pmt_fn(&args_end);
+    let begin = pmt_fn(&args_begin);
+    // beginning-of-period payment has a larger absolute value (factor of 1+rate)
+    if let (Value::Number(e), Value::Number(b)) = (end, begin) {
+        assert!(b.abs() > e.abs());
+    } else {
+        panic!("expected numbers");
+    }
+}

--- a/crates/core/src/eval/functions/financial/pv/mod.rs
+++ b/crates/core/src/eval/functions/financial/pv/mod.rs
@@ -1,0 +1,38 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+fn opt_number(args: &[Value], idx: usize, default: f64) -> Result<f64, Value> {
+    if idx < args.len() {
+        to_number(args[idx].clone())
+    } else {
+        Ok(default)
+    }
+}
+
+/// `PV(rate, nper, pmt, [fv], [type])` — present value of an investment.
+pub fn pv_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 3, 5) {
+        return err;
+    }
+    let rate = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let nper = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    let pmt  = match to_number(args[2].clone()) { Ok(n) => n, Err(e) => return e };
+    let fv   = match opt_number(args, 3, 0.0)   { Ok(n) => n, Err(e) => return e };
+    let typ  = match opt_number(args, 4, 0.0)   { Ok(n) => n, Err(e) => return e };
+
+    let result = if rate == 0.0 {
+        -(pmt * nper + fv)
+    } else {
+        let factor = (1.0 + rate).powf(-nper);
+        -(pmt * (1.0 + rate * typ) * (1.0 - factor) / rate + fv * factor)
+    };
+
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/financial/pv/tests/edge.rs
+++ b/crates/core/src/eval/functions/financial/pv/tests/edge.rs
@@ -1,0 +1,37 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn type1_beginning_of_period() {
+    // With type=1, PV should differ from type=0
+    let args0 = [Value::Number(0.05), Value::Number(5.0), Value::Number(-100.0), Value::Number(0.0), Value::Number(0.0)];
+    let args1 = [Value::Number(0.05), Value::Number(5.0), Value::Number(-100.0), Value::Number(0.0), Value::Number(1.0)];
+    let pv0 = pv_fn(&args0);
+    let pv1 = pv_fn(&args1);
+    assert!(matches!(pv0, Value::Number(_)));
+    assert!(matches!(pv1, Value::Number(_)));
+    assert_ne!(pv0, pv1);
+}
+
+#[test]
+fn zero_pmt_with_fv() {
+    // PV(0.1, 5, 0, 100) = -100/(1.1^5) ≈ -62.09
+    let args = [
+        Value::Number(0.1),
+        Value::Number(5.0),
+        Value::Number(0.0),
+        Value::Number(100.0),
+    ];
+    assert!(approx(pv_fn(&args), -62.09, 0.01));
+}
+
+#[test]
+fn fv_defaults_to_zero() {
+    let args3 = [Value::Number(0.05), Value::Number(10.0), Value::Number(-100.0)];
+    let args4 = [Value::Number(0.05), Value::Number(10.0), Value::Number(-100.0), Value::Number(0.0)];
+    assert_eq!(pv_fn(&args3), pv_fn(&args4));
+}

--- a/crates/core/src/eval/functions/financial/pv/tests/failure.rs
+++ b/crates/core/src/eval/functions/financial/pv/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    assert_eq!(pv_fn(&[Value::Number(0.1), Value::Number(5.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_many_args() {
+    let args = vec![Value::Number(0.1), Value::Number(0.1), Value::Number(0.1),
+                    Value::Number(0.1), Value::Number(0.1), Value::Number(0.1)];
+    assert_eq!(pv_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_rate() {
+    let args = [Value::Text("bad".to_string()), Value::Number(5.0), Value::Number(100.0)];
+    assert_eq!(pv_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/financial/pv/tests/mod.rs
+++ b/crates/core/src/eval/functions/financial/pv/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/financial/pv/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/pv/tests/success.rs
@@ -1,0 +1,36 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn round_trip_with_pmt() {
+    // PV(0.05/12, 60, -188.71) ≈ 10000
+    let args = [
+        Value::Number(0.05 / 12.0),
+        Value::Number(60.0),
+        Value::Number(-188.71),
+    ];
+    assert!(approx(pv_fn(&args), 10000.0, 1.0));
+}
+
+#[test]
+fn zero_rate() {
+    // PV(0, 10, -100) = 1000
+    let args = [Value::Number(0.0), Value::Number(10.0), Value::Number(-100.0)];
+    assert!(approx(pv_fn(&args), 1000.0, 1e-9));
+}
+
+#[test]
+fn with_future_value() {
+    // PV(0.05, 5, 0, 1000) = -1000/(1.05^5) ≈ -783.53
+    let args = [
+        Value::Number(0.05),
+        Value::Number(5.0),
+        Value::Number(0.0),
+        Value::Number(1000.0),
+    ];
+    assert!(approx(pv_fn(&args), -783.53, 0.01));
+}

--- a/crates/core/src/eval/functions/financial/rate/mod.rs
+++ b/crates/core/src/eval/functions/financial/rate/mod.rs
@@ -46,7 +46,7 @@ fn rate_f_and_df(r: f64, nper: f64, pmt: f64, pv: f64, fv: f64, typ: f64) -> (f6
     if r == 0.0 {
         // Degenerate: use limit
         let f = pv + pmt * nper + fv;
-        let df = pmt * nper * (nper - 1.0) / 2.0;
+        let df = pv * nper + pmt * nper * (nper - 1.0) / 2.0;
         return (f, df);
     }
     let factor = (1.0 + r).powf(nper);

--- a/crates/core/src/eval/functions/financial/rate/mod.rs
+++ b/crates/core/src/eval/functions/financial/rate/mod.rs
@@ -1,0 +1,65 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+fn opt_number(args: &[Value], idx: usize, default: f64) -> Result<f64, Value> {
+    if idx < args.len() {
+        to_number(args[idx].clone())
+    } else {
+        Ok(default)
+    }
+}
+
+/// `RATE(nper, pmt, pv, [fv], [type], [guess])` — interest rate per period.
+pub fn rate_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 3, 6) {
+        return err;
+    }
+    let nper  = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let pmt   = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    let pv    = match to_number(args[2].clone()) { Ok(n) => n, Err(e) => return e };
+    let fv    = match opt_number(args, 3, 0.0)   { Ok(n) => n, Err(e) => return e };
+    let typ   = match opt_number(args, 4, 0.0)   { Ok(n) => n, Err(e) => return e };
+    let guess = match opt_number(args, 5, 0.1)   { Ok(n) => n, Err(e) => return e };
+
+    // Newton-Raphson: find rate such that PV equation = 0
+    // f(r) = pv*(1+r)^nper + pmt*(1+r*type)*((1+r)^nper - 1)/r + fv = 0
+    let mut rate = guess;
+    for _ in 0..100 {
+        let (f, df) = rate_f_and_df(rate, nper, pmt, pv, fv, typ);
+        if !f.is_finite() || !df.is_finite() || df == 0.0 {
+            return Value::Error(ErrorKind::Num);
+        }
+        let new_rate = rate - f / df;
+        if (new_rate - rate).abs() < 1e-7 {
+            if !new_rate.is_finite() {
+                return Value::Error(ErrorKind::Num);
+            }
+            return Value::Number(new_rate);
+        }
+        rate = new_rate;
+    }
+    Value::Error(ErrorKind::Num)
+}
+
+fn rate_f_and_df(r: f64, nper: f64, pmt: f64, pv: f64, fv: f64, typ: f64) -> (f64, f64) {
+    if r == 0.0 {
+        // Degenerate: use limit
+        let f = pv + pmt * nper + fv;
+        let df = pmt * nper * (nper - 1.0) / 2.0;
+        return (f, df);
+    }
+    let factor = (1.0 + r).powf(nper);
+    let annuity = pmt * (1.0 + r * typ) * (factor - 1.0) / r;
+    let f = pv * factor + annuity + fv;
+
+    // Derivative wrt r
+    let dfactor = nper * (1.0 + r).powf(nper - 1.0);
+    let dann = pmt * (typ * (factor - 1.0) / r
+        + (1.0 + r * typ) * (dfactor * r - (factor - 1.0)) / (r * r));
+    let df = pv * dfactor + dann;
+    (f, df)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/financial/rate/tests/edge.rs
+++ b/crates/core/src/eval/functions/financial/rate/tests/edge.rs
@@ -45,3 +45,18 @@ fn fv_non_zero() {
     let result = rate_fn(&args);
     assert!(matches!(result, Value::Number(_)));
 }
+
+#[test]
+fn guess_zero_forces_r0_branch() {
+    // RATE with guess=0 forces the r=0 branch on first iteration
+    // RATE(60, -188.71, 10000, 0, 0, 0.0) should converge to ≈ 0.05/12 ≈ 0.004167
+    let args = [
+        Value::Number(60.0),
+        Value::Number(-188.71),
+        Value::Number(10000.0),
+        Value::Number(0.0),
+        Value::Number(0.0),
+        Value::Number(0.0),
+    ];
+    assert!(approx(rate_fn(&args), 0.05 / 12.0, 1e-4));
+}

--- a/crates/core/src/eval/functions/financial/rate/tests/edge.rs
+++ b/crates/core/src/eval/functions/financial/rate/tests/edge.rs
@@ -1,0 +1,47 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn custom_guess() {
+    // Provide a guess closer to the answer for faster convergence
+    let args = [
+        Value::Number(60.0),
+        Value::Number(-188.71),
+        Value::Number(10000.0),
+        Value::Number(0.0),
+        Value::Number(0.0),
+        Value::Number(0.004), // guess near 0.05/12
+    ];
+    assert!(approx(rate_fn(&args), 0.05 / 12.0, 0.0001));
+}
+
+#[test]
+fn type1_rate() {
+    // type=1 (beginning of period) should still converge
+    let args = [
+        Value::Number(5.0),
+        Value::Number(-250.0),
+        Value::Number(1000.0),
+        Value::Number(0.0),
+        Value::Number(1.0),
+    ];
+    let result = rate_fn(&args);
+    assert!(matches!(result, Value::Number(_)));
+}
+
+#[test]
+fn fv_non_zero() {
+    // RATE with non-zero fv should still converge
+    let args = [
+        Value::Number(10.0),
+        Value::Number(-100.0),
+        Value::Number(500.0),
+        Value::Number(200.0),
+    ];
+    let result = rate_fn(&args);
+    assert!(matches!(result, Value::Number(_)));
+}

--- a/crates/core/src/eval/functions/financial/rate/tests/failure.rs
+++ b/crates/core/src/eval/functions/financial/rate/tests/failure.rs
@@ -1,0 +1,30 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    assert_eq!(rate_fn(&[Value::Number(5.0), Value::Number(-100.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_many_args() {
+    let args = vec![Value::Number(0.1), Value::Number(0.1), Value::Number(0.1),
+                    Value::Number(0.1), Value::Number(0.1), Value::Number(0.1),
+                    Value::Number(0.1)];
+    assert_eq!(rate_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_nper() {
+    let args = [Value::Text("bad".to_string()), Value::Number(-100.0), Value::Number(1000.0)];
+    assert_eq!(rate_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn no_convergence_bad_inputs() {
+    // Nonsensical inputs: pv=0, pmt=0, fv=0 — no convergence
+    let args = [Value::Number(5.0), Value::Number(0.0), Value::Number(0.0)];
+    // May converge to 0 or fail — just confirm it returns Number or Num error
+    let result = rate_fn(&args);
+    assert!(matches!(result, Value::Number(_) | Value::Error(ErrorKind::Num)));
+}

--- a/crates/core/src/eval/functions/financial/rate/tests/mod.rs
+++ b/crates/core/src/eval/functions/financial/rate/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/financial/rate/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/rate/tests/success.rs
@@ -1,0 +1,42 @@
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn monthly_rate_for_loan() {
+    // RATE(60, -188.71, 10000) ≈ 0.05/12 ≈ 0.004167
+    let args = [
+        Value::Number(60.0),
+        Value::Number(-188.71),
+        Value::Number(10000.0),
+    ];
+    assert!(approx(rate_fn(&args), 0.05 / 12.0, 0.0001));
+}
+
+#[test]
+fn annual_rate_simple() {
+    // RATE(5, -263.80, 1000) should be ≈ 10%
+    // PMT(0.1, 5, 1000) ≈ -263.80
+    let args = [
+        Value::Number(5.0),
+        Value::Number(-263.80),
+        Value::Number(1000.0),
+    ];
+    assert!(approx(rate_fn(&args), 0.1, 0.001));
+}
+
+#[test]
+fn rate_with_fv() {
+    // Round-trip: compute PMT then recover RATE
+    // PMT(0.05, 10, 1000, 0) ≈ -129.50
+    // RATE(10, -129.50, 1000) ≈ 0.05
+    let args = [
+        Value::Number(10.0),
+        Value::Number(-129.50),
+        Value::Number(1000.0),
+    ];
+    assert!(approx(rate_fn(&args), 0.05, 0.001));
+}

--- a/crates/core/src/eval/functions/mod.rs
+++ b/crates/core/src/eval/functions/mod.rs
@@ -1,3 +1,4 @@
+pub mod financial;
 pub mod logical;
 pub mod math;
 pub mod text;
@@ -50,6 +51,7 @@ impl Registry {
         math::register_math(&mut r);
         logical::register_logical(&mut r);
         text::register_text(&mut r);
+        financial::register_financial(&mut r);
         r
     }
 


### PR DESCRIPTION
## Summary

Closes #6

- Added 7 financial functions under `crates/core/src/eval/functions/financial/`: `PMT`, `NPV`, `IRR`, `PV`, `FV`, `RATE`, `NPER`
- `IRR` and `RATE` use Newton-Raphson iteration for convergence
- Each function lives in its own sub-module with structured test directories (`success/`, `failure/`, `edge/`)
- 201 tests pass, clippy clean

## Test plan

- [x] `cargo test` — 201 tests pass
- [x] `cargo clippy` — no warnings