### PR TITLE
feat(core): implement logical + info functions (12) — issue #4

### DIFF
--- a/crates/core/src/eval/functions/logical/and/mod.rs
+++ b/crates/core/src/eval/functions/logical/and/mod.rs
@@ -1,0 +1,27 @@
+use crate::eval::coercion::to_bool;
+use crate::eval::functions::{check_arity_len, EvalCtx};
+use crate::eval::evaluate_expr;
+use crate::parser::ast::Expr;
+use crate::types::Value;
+
+/// `AND(val1, ...)` — TRUE only if ALL arguments are truthy.
+///
+/// Short-circuits on the first false value. Returns `#VALUE!` with no args
+/// or if any arg cannot be coerced to bool.
+pub fn and_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if let Some(err) = check_arity_len(args.len(), 1, usize::MAX) {
+        return err;
+    }
+    for arg in args {
+        let val = evaluate_expr(arg, ctx);
+        match to_bool(val) {
+            Ok(false) => return Value::Bool(false),
+            Ok(true) => {}
+            Err(e) => return e,
+        }
+    }
+    Value::Bool(true)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/logical/and/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/and/tests/edge.rs
@@ -1,0 +1,37 @@
+use super::super::and_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{BinaryOp, Expr, Span};
+use crate::types::Value;
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    and_fn(&args, &mut ctx)
+}
+
+/// `AND(FALSE, 1/0)` must short-circuit — the division by zero is never evaluated.
+#[test]
+fn short_circuits_on_first_false() {
+    let div_by_zero = Expr::BinaryOp {
+        op: BinaryOp::Div,
+        left: Box::new(Expr::Number(1.0, span())),
+        right: Box::new(Expr::Number(0.0, span())),
+        span: span(),
+    };
+    let args = vec![Expr::Bool(false, span()), div_by_zero];
+    assert_eq!(run(args), Value::Bool(false));
+}
+
+#[test]
+fn zero_is_falsy() {
+    let args = vec![Expr::Number(0.0, span())];
+    assert_eq!(run(args), Value::Bool(false));
+}
+
+#[test]
+fn mixed_true_and_false() {
+    let args = vec![Expr::Bool(true, span()), Expr::Number(0.0, span())];
+    assert_eq!(run(args), Value::Bool(false));
+}

--- a/crates/core/src/eval/functions/logical/and/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/and/tests/failure.rs
@@ -1,0 +1,29 @@
+use super::super::and_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
+use crate::types::{ErrorKind, Value};
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    and_fn(&args, &mut ctx)
+}
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(run(vec![]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn one_false_returns_false() {
+    let args = vec![Expr::Bool(true, span()), Expr::Bool(false, span())];
+    assert_eq!(run(args), Value::Bool(false));
+}
+
+#[test]
+fn text_arg_returns_value_error() {
+    let args = vec![Expr::Text("hello".to_string(), span())];
+    assert_eq!(run(args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/logical/and/tests/mod.rs
+++ b/crates/core/src/eval/functions/logical/and/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/logical/and/tests/success.rs
+++ b/crates/core/src/eval/functions/logical/and/tests/success.rs
@@ -1,0 +1,30 @@
+use super::super::and_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
+use crate::types::Value;
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    and_fn(&args, &mut ctx)
+}
+
+#[test]
+fn all_true_booleans() {
+    let args = vec![Expr::Bool(true, span()), Expr::Bool(true, span())];
+    assert_eq!(run(args), Value::Bool(true));
+}
+
+#[test]
+fn single_true() {
+    let args = vec![Expr::Bool(true, span())];
+    assert_eq!(run(args), Value::Bool(true));
+}
+
+#[test]
+fn nonzero_numbers_are_truthy() {
+    let args = vec![Expr::Number(1.0, span()), Expr::Number(42.0, span())];
+    assert_eq!(run(args), Value::Bool(true));
+}

--- a/crates/core/src/eval/functions/logical/iferror/mod.rs
+++ b/crates/core/src/eval/functions/logical/iferror/mod.rs
@@ -1,25 +1,31 @@
-use crate::eval::functions::check_arity;
+use crate::eval::functions::{check_arity_len, EvalCtx};
+use crate::eval::evaluate_expr;
+use crate::parser::ast::Expr;
 use crate::types::{ErrorKind, Value};
 
 /// `IFERROR(value, error_val)` — returns value unless it is any error, then error_val.
-pub fn iferror_fn(args: &[Value]) -> Value {
-    if let Some(err) = check_arity(args, 2, 2) {
+pub fn iferror_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if let Some(err) = check_arity_len(args.len(), 2, 2) {
         return err;
     }
-    match &args[0] {
-        Value::Error(_) => args[1].clone(),
-        _ => args[0].clone(),
+    let val = evaluate_expr(&args[0], ctx);
+    if matches!(val, Value::Error(_)) {
+        evaluate_expr(&args[1], ctx)
+    } else {
+        val
     }
 }
 
 /// `IFNA(value, na_val)` — returns value unless it is `#N/A`, then na_val.
-pub fn ifna_fn(args: &[Value]) -> Value {
-    if let Some(err) = check_arity(args, 2, 2) {
+pub fn ifna_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if let Some(err) = check_arity_len(args.len(), 2, 2) {
         return err;
     }
-    match &args[0] {
-        Value::Error(ErrorKind::NA) => args[1].clone(),
-        _ => args[0].clone(),
+    let val = evaluate_expr(&args[0], ctx);
+    if matches!(val, Value::Error(ErrorKind::NA)) {
+        evaluate_expr(&args[1], ctx)
+    } else {
+        val
     }
 }
 

--- a/crates/core/src/eval/functions/logical/iferror/mod.rs
+++ b/crates/core/src/eval/functions/logical/iferror/mod.rs
@@ -1,0 +1,27 @@
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `IFERROR(value, error_val)` — returns value unless it is any error, then error_val.
+pub fn iferror_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    match &args[0] {
+        Value::Error(_) => args[1].clone(),
+        _ => args[0].clone(),
+    }
+}
+
+/// `IFNA(value, na_val)` — returns value unless it is `#N/A`, then na_val.
+pub fn ifna_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    match &args[0] {
+        Value::Error(ErrorKind::NA) => args[1].clone(),
+        _ => args[0].clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/logical/iferror/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/iferror/tests/edge.rs
@@ -1,29 +1,75 @@
 use super::super::{iferror_fn, ifna_fn};
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
 use crate::types::{ErrorKind, Value};
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run_iferror(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    iferror_fn(&args, &mut ctx)
+}
+
+fn run_ifna(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    ifna_fn(&args, &mut ctx)
+}
 
 /// IFERROR catches ALL error kinds including NA.
 #[test]
 fn iferror_catches_na() {
-    assert_eq!(
-        iferror_fn(&[Value::Error(ErrorKind::NA), Value::Bool(false)]),
-        Value::Bool(false)
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(
+        Context::new({
+            let mut m = std::collections::HashMap::new();
+            m.insert("X".to_string(), Value::Error(ErrorKind::NA));
+            m
+        }),
+        &reg,
     );
+    let args = vec![
+        Expr::Variable("X".to_string(), span()),
+        Expr::Bool(false, span()),
+    ];
+    assert_eq!(iferror_fn(&args, &mut ctx), Value::Bool(false));
 }
 
 /// IFNA does NOT catch non-NA errors — it passes them through.
 #[test]
 fn ifna_passes_through_non_na_error() {
-    assert_eq!(
-        ifna_fn(&[Value::Error(ErrorKind::DivByZero), Value::Number(0.0)]),
-        Value::Error(ErrorKind::DivByZero)
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(
+        Context::new({
+            let mut m = std::collections::HashMap::new();
+            m.insert("X".to_string(), Value::Error(ErrorKind::DivByZero));
+            m
+        }),
+        &reg,
     );
+    let args = vec![
+        Expr::Variable("X".to_string(), span()),
+        Expr::Number(0.0, span()),
+    ];
+    assert_eq!(ifna_fn(&args, &mut ctx), Value::Error(ErrorKind::DivByZero));
 }
 
 /// IFNA does NOT catch Value errors.
 #[test]
 fn ifna_passes_through_value_error() {
-    assert_eq!(
-        ifna_fn(&[Value::Error(ErrorKind::Value), Value::Number(0.0)]),
-        Value::Error(ErrorKind::Value)
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(
+        Context::new({
+            let mut m = std::collections::HashMap::new();
+            m.insert("X".to_string(), Value::Error(ErrorKind::Value));
+            m
+        }),
+        &reg,
     );
+    let args = vec![
+        Expr::Variable("X".to_string(), span()),
+        Expr::Number(0.0, span()),
+    ];
+    assert_eq!(ifna_fn(&args, &mut ctx), Value::Error(ErrorKind::Value));
 }

--- a/crates/core/src/eval/functions/logical/iferror/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/iferror/tests/edge.rs
@@ -1,0 +1,29 @@
+use super::super::{iferror_fn, ifna_fn};
+use crate::types::{ErrorKind, Value};
+
+/// IFERROR catches ALL error kinds including NA.
+#[test]
+fn iferror_catches_na() {
+    assert_eq!(
+        iferror_fn(&[Value::Error(ErrorKind::NA), Value::Bool(false)]),
+        Value::Bool(false)
+    );
+}
+
+/// IFNA does NOT catch non-NA errors — it passes them through.
+#[test]
+fn ifna_passes_through_non_na_error() {
+    assert_eq!(
+        ifna_fn(&[Value::Error(ErrorKind::DivByZero), Value::Number(0.0)]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}
+
+/// IFNA does NOT catch Value errors.
+#[test]
+fn ifna_passes_through_value_error() {
+    assert_eq!(
+        ifna_fn(&[Value::Error(ErrorKind::Value), Value::Number(0.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/logical/iferror/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/iferror/tests/failure.rs
@@ -1,20 +1,40 @@
 use super::super::{iferror_fn, ifna_fn};
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
 use crate::types::{ErrorKind, Value};
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run_iferror(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    iferror_fn(&args, &mut ctx)
+}
+
+fn run_ifna(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    ifna_fn(&args, &mut ctx)
+}
 
 #[test]
 fn iferror_too_few_args() {
-    assert_eq!(iferror_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+    let args = vec![Expr::Number(1.0, span())];
+    assert_eq!(run_iferror(args), Value::Error(ErrorKind::Value));
 }
 
 #[test]
 fn iferror_too_many_args() {
-    assert_eq!(
-        iferror_fn(&[Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]),
-        Value::Error(ErrorKind::Value)
-    );
+    let args = vec![
+        Expr::Number(1.0, span()),
+        Expr::Number(2.0, span()),
+        Expr::Number(3.0, span()),
+    ];
+    assert_eq!(run_iferror(args), Value::Error(ErrorKind::Value));
 }
 
 #[test]
 fn ifna_too_few_args() {
-    assert_eq!(ifna_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+    let args = vec![Expr::Number(1.0, span())];
+    assert_eq!(run_ifna(args), Value::Error(ErrorKind::Value));
 }

--- a/crates/core/src/eval/functions/logical/iferror/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/iferror/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::{iferror_fn, ifna_fn};
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn iferror_too_few_args() {
+    assert_eq!(iferror_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn iferror_too_many_args() {
+    assert_eq!(
+        iferror_fn(&[Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn ifna_too_few_args() {
+    assert_eq!(ifna_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/logical/iferror/tests/mod.rs
+++ b/crates/core/src/eval/functions/logical/iferror/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/logical/iferror/tests/success.rs
+++ b/crates/core/src/eval/functions/logical/iferror/tests/success.rs
@@ -1,28 +1,77 @@
 use super::super::{iferror_fn, ifna_fn};
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{BinaryOp, Expr, Span};
 use crate::types::{ErrorKind, Value};
 
-#[test]
-fn iferror_no_error_returns_value() {
-    assert_eq!(iferror_fn(&[Value::Number(1.0), Value::Number(0.0)]), Value::Number(1.0));
+fn span() -> Span { Span::new(0, 1) }
+
+fn run_iferror(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    iferror_fn(&args, &mut ctx)
+}
+
+fn run_ifna(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    ifna_fn(&args, &mut ctx)
 }
 
 #[test]
 fn iferror_on_error_returns_fallback() {
-    assert_eq!(
-        iferror_fn(&[Value::Error(ErrorKind::DivByZero), Value::Number(0.0)]),
-        Value::Number(0.0)
-    );
+    // IFERROR(1/0, "fallback") → "fallback"
+    let args = vec![
+        Expr::BinaryOp {
+            op: BinaryOp::Div,
+            left: Box::new(Expr::Number(1.0, span())),
+            right: Box::new(Expr::Number(0.0, span())),
+            span: span(),
+        },
+        Expr::Text("fallback".to_string(), span()),
+    ];
+    assert_eq!(run_iferror(args), Value::Text("fallback".to_string()));
 }
 
 #[test]
-fn ifna_no_error_returns_value() {
-    assert_eq!(ifna_fn(&[Value::Number(42.0), Value::Number(0.0)]), Value::Number(42.0));
+fn iferror_on_success_returns_value() {
+    // IFERROR(5, "fallback") → 5
+    let args = vec![
+        Expr::Number(5.0, span()),
+        Expr::Text("fallback".to_string(), span()),
+    ];
+    assert_eq!(run_iferror(args), Value::Number(5.0));
 }
 
 #[test]
 fn ifna_on_na_returns_fallback() {
-    assert_eq!(
-        ifna_fn(&[Value::Error(ErrorKind::NA), Value::Text("n/a".to_string())]),
-        Value::Text("n/a".to_string())
+    // Trigger #N/A via a variable set to Value::Error(ErrorKind::NA)
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(
+        Context::new({
+            let mut m = std::collections::HashMap::new();
+            m.insert("X".to_string(), Value::Error(ErrorKind::NA));
+            m
+        }),
+        &reg,
     );
+    let args = vec![
+        Expr::Variable("X".to_string(), span()),
+        Expr::Text("na_fallback".to_string(), span()),
+    ];
+    assert_eq!(ifna_fn(&args, &mut ctx), Value::Text("na_fallback".to_string()));
+}
+
+#[test]
+fn ifna_on_other_error_returns_error() {
+    // IFNA(1/0, "fallback") → #DIV/0! (IFNA does NOT catch it)
+    let args = vec![
+        Expr::BinaryOp {
+            op: BinaryOp::Div,
+            left: Box::new(Expr::Number(1.0, span())),
+            right: Box::new(Expr::Number(0.0, span())),
+            span: span(),
+        },
+        Expr::Text("fallback".to_string(), span()),
+    ];
+    assert_eq!(run_ifna(args), Value::Error(ErrorKind::DivByZero));
 }

--- a/crates/core/src/eval/functions/logical/iferror/tests/success.rs
+++ b/crates/core/src/eval/functions/logical/iferror/tests/success.rs
@@ -1,0 +1,28 @@
+use super::super::{iferror_fn, ifna_fn};
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn iferror_no_error_returns_value() {
+    assert_eq!(iferror_fn(&[Value::Number(1.0), Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn iferror_on_error_returns_fallback() {
+    assert_eq!(
+        iferror_fn(&[Value::Error(ErrorKind::DivByZero), Value::Number(0.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn ifna_no_error_returns_value() {
+    assert_eq!(ifna_fn(&[Value::Number(42.0), Value::Number(0.0)]), Value::Number(42.0));
+}
+
+#[test]
+fn ifna_on_na_returns_fallback() {
+    assert_eq!(
+        ifna_fn(&[Value::Error(ErrorKind::NA), Value::Text("n/a".to_string())]),
+        Value::Text("n/a".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/logical/ifs/mod.rs
+++ b/crates/core/src/eval/functions/logical/ifs/mod.rs
@@ -1,0 +1,31 @@
+use crate::eval::coercion::to_bool;
+use crate::eval::functions::EvalCtx;
+use crate::eval::evaluate_expr;
+use crate::parser::ast::Expr;
+use crate::types::{ErrorKind, Value};
+
+/// `IFS(cond1, val1, cond2, val2, ...)` — returns the value paired with the
+/// first true condition.
+///
+/// Requires an even number of args (≥ 2). Returns `#N/A` if no condition matches.
+/// Returns `#VALUE!` if the arg count is wrong or a condition cannot be coerced.
+pub fn ifs_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    let count = args.len();
+    if count < 2 || !count.is_multiple_of(2) {
+        return Value::Error(ErrorKind::Value);
+    }
+    let mut i = 0;
+    while i < count {
+        let cond_val = evaluate_expr(&args[i], ctx);
+        match to_bool(cond_val) {
+            Ok(true) => return evaluate_expr(&args[i + 1], ctx),
+            Ok(false) => {}
+            Err(e) => return e,
+        }
+        i += 2;
+    }
+    Value::Error(ErrorKind::NA)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/logical/ifs/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/ifs/tests/edge.rs
@@ -1,6 +1,6 @@
 use super::super::ifs_fn;
 use crate::eval::{Context, EvalCtx, Registry};
-use crate::parser::ast::{Expr, Span};
+use crate::parser::ast::{BinaryOp, Expr, Span};
 use crate::types::{ErrorKind, Value};
 
 fn span() -> Span { Span::new(0, 1) }
@@ -35,4 +35,21 @@ fn number_zero_condition_is_falsy() {
         Expr::Number(2.0, span()),
     ];
     assert_eq!(run(args), Value::Number(2.0));
+}
+
+#[test]
+fn matched_result_does_not_evaluate_later_branches() {
+    // IFS(TRUE, 42, FALSE, 1/0) → 42 (second result 1/0 is never evaluated)
+    let args = vec![
+        Expr::Bool(true, span()),
+        Expr::Number(42.0, span()),
+        Expr::Bool(false, span()),
+        Expr::BinaryOp {
+            op: BinaryOp::Div,
+            left: Box::new(Expr::Number(1.0, span())),
+            right: Box::new(Expr::Number(0.0, span())),
+            span: span(),
+        },
+    ];
+    assert_eq!(run(args), Value::Number(42.0));
 }

--- a/crates/core/src/eval/functions/logical/ifs/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/ifs/tests/edge.rs
@@ -1,0 +1,38 @@
+use super::super::ifs_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
+use crate::types::{ErrorKind, Value};
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    ifs_fn(&args, &mut ctx)
+}
+
+#[test]
+fn single_pair_false_returns_na() {
+    let args = vec![Expr::Bool(false, span()), Expr::Number(1.0, span())];
+    assert_eq!(run(args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn condition_coercion_error_propagates() {
+    let args = vec![
+        Expr::Text("bad".to_string(), span()),
+        Expr::Number(1.0, span()),
+    ];
+    assert_eq!(run(args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn number_zero_condition_is_falsy() {
+    let args = vec![
+        Expr::Number(0.0, span()),
+        Expr::Number(1.0, span()),
+        Expr::Bool(true, span()),
+        Expr::Number(2.0, span()),
+    ];
+    assert_eq!(run(args), Value::Number(2.0));
+}

--- a/crates/core/src/eval/functions/logical/ifs/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/ifs/tests/failure.rs
@@ -1,0 +1,38 @@
+use super::super::ifs_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
+use crate::types::{ErrorKind, Value};
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    ifs_fn(&args, &mut ctx)
+}
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(run(vec![]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn odd_arg_count_returns_value_error() {
+    let args = vec![
+        Expr::Bool(true, span()),
+        Expr::Number(1.0, span()),
+        Expr::Bool(false, span()),
+    ];
+    assert_eq!(run(args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn all_false_returns_na() {
+    let args = vec![
+        Expr::Bool(false, span()),
+        Expr::Number(1.0, span()),
+        Expr::Bool(false, span()),
+        Expr::Number(2.0, span()),
+    ];
+    assert_eq!(run(args), Value::Error(ErrorKind::NA));
+}

--- a/crates/core/src/eval/functions/logical/ifs/tests/mod.rs
+++ b/crates/core/src/eval/functions/logical/ifs/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/logical/ifs/tests/success.rs
+++ b/crates/core/src/eval/functions/logical/ifs/tests/success.rs
@@ -1,0 +1,40 @@
+use super::super::ifs_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
+use crate::types::Value;
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    ifs_fn(&args, &mut ctx)
+}
+
+#[test]
+fn first_condition_true_returns_first_value() {
+    let args = vec![
+        Expr::Bool(true, span()),
+        Expr::Number(1.0, span()),
+        Expr::Bool(false, span()),
+        Expr::Number(2.0, span()),
+    ];
+    assert_eq!(run(args), Value::Number(1.0));
+}
+
+#[test]
+fn second_condition_true_returns_second_value() {
+    let args = vec![
+        Expr::Bool(false, span()),
+        Expr::Number(1.0, span()),
+        Expr::Bool(true, span()),
+        Expr::Number(2.0, span()),
+    ];
+    assert_eq!(run(args), Value::Number(2.0));
+}
+
+#[test]
+fn single_pair_true() {
+    let args = vec![Expr::Bool(true, span()), Expr::Text("ok".to_string(), span())];
+    assert_eq!(run(args), Value::Text("ok".to_string()));
+}

--- a/crates/core/src/eval/functions/logical/is_checks/mod.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/mod.rs
@@ -1,0 +1,45 @@
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `ISNUMBER(value)` — TRUE if value is a Number.
+pub fn isnumber_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    Value::Bool(matches!(args[0], Value::Number(_)))
+}
+
+/// `ISTEXT(value)` — TRUE if value is a Text string.
+pub fn istext_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    Value::Bool(matches!(args[0], Value::Text(_)))
+}
+
+/// `ISERROR(value)` — TRUE if value is any Error.
+pub fn iserror_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    Value::Bool(matches!(args[0], Value::Error(_)))
+}
+
+/// `ISBLANK(value)` — TRUE if value is Empty.
+pub fn isblank_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    Value::Bool(matches!(args[0], Value::Empty))
+}
+
+/// `ISNA(value)` — TRUE if value is `Error(NA)` specifically.
+pub fn isna_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    Value::Bool(matches!(args[0], Value::Error(ErrorKind::NA)))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/logical/is_checks/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/tests/edge.rs
@@ -1,0 +1,28 @@
+use super::super::{isblank_fn, iserror_fn, isna_fn, isnumber_fn, istext_fn};
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn isnumber_false_for_bool() {
+    assert_eq!(isnumber_fn(&[Value::Bool(true)]), Value::Bool(false));
+}
+
+#[test]
+fn istext_false_for_number() {
+    assert_eq!(istext_fn(&[Value::Number(1.0)]), Value::Bool(false));
+}
+
+#[test]
+fn iserror_false_for_non_error() {
+    assert_eq!(iserror_fn(&[Value::Number(1.0)]), Value::Bool(false));
+}
+
+#[test]
+fn isblank_false_for_text() {
+    assert_eq!(isblank_fn(&[Value::Text(String::new())]), Value::Bool(false));
+}
+
+/// ISNA returns false for other error kinds (not just NA).
+#[test]
+fn isna_false_for_other_error() {
+    assert_eq!(isna_fn(&[Value::Error(ErrorKind::Value)]), Value::Bool(false));
+}

--- a/crates/core/src/eval/functions/logical/is_checks/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/tests/failure.rs
@@ -1,0 +1,33 @@
+use super::super::{isblank_fn, iserror_fn, isna_fn, isnumber_fn, istext_fn};
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn isnumber_too_many_args() {
+    assert_eq!(
+        isnumber_fn(&[Value::Number(1.0), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn istext_no_args() {
+    assert_eq!(istext_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn iserror_too_many_args() {
+    assert_eq!(
+        iserror_fn(&[Value::Bool(true), Value::Bool(false)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn isblank_no_args() {
+    assert_eq!(isblank_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn isna_no_args() {
+    assert_eq!(isna_fn(&[]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/logical/is_checks/tests/mod.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/logical/is_checks/tests/success.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::{isblank_fn, iserror_fn, isna_fn, isnumber_fn, istext_fn};
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn isnumber_with_number() {
+    assert_eq!(isnumber_fn(&[Value::Number(3.14)]), Value::Bool(true));
+}
+
+#[test]
+fn istext_with_text() {
+    assert_eq!(istext_fn(&[Value::Text("hello".to_string())]), Value::Bool(true));
+}
+
+#[test]
+fn iserror_with_error() {
+    assert_eq!(iserror_fn(&[Value::Error(ErrorKind::DivByZero)]), Value::Bool(true));
+}
+
+#[test]
+fn isblank_with_empty() {
+    assert_eq!(isblank_fn(&[Value::Empty]), Value::Bool(true));
+}
+
+#[test]
+fn isna_with_na() {
+    assert_eq!(isna_fn(&[Value::Error(ErrorKind::NA)]), Value::Bool(true));
+}

--- a/crates/core/src/eval/functions/logical/mod.rs
+++ b/crates/core/src/eval/functions/logical/mod.rs
@@ -14,8 +14,8 @@ pub fn register_logical(registry: &mut Registry) {
     registry.register_lazy("AND", and::and_fn);
     registry.register_lazy("OR", or::or_fn);
     registry.register_eager("NOT", not::not_fn);
-    registry.register_eager("IFERROR", iferror::iferror_fn);
-    registry.register_eager("IFNA", iferror::ifna_fn);
+    registry.register_lazy("IFERROR", iferror::iferror_fn);
+    registry.register_lazy("IFNA", iferror::ifna_fn);
     registry.register_lazy("IFS", ifs::ifs_fn);
     registry.register_lazy("SWITCH", switch::switch_fn);
     registry.register_eager("ISNUMBER", is_checks::isnumber_fn);

--- a/crates/core/src/eval/functions/logical/mod.rs
+++ b/crates/core/src/eval/functions/logical/mod.rs
@@ -1,7 +1,26 @@
 use super::super::Registry;
 
 pub mod if_fn;
+pub mod and;
+pub mod or;
+pub mod not;
+pub mod iferror;
+pub mod ifs;
+pub mod switch;
+pub mod is_checks;
 
 pub fn register_logical(registry: &mut Registry) {
     registry.register_lazy("IF", if_fn::if_fn);
+    registry.register_lazy("AND", and::and_fn);
+    registry.register_lazy("OR", or::or_fn);
+    registry.register_eager("NOT", not::not_fn);
+    registry.register_eager("IFERROR", iferror::iferror_fn);
+    registry.register_eager("IFNA", iferror::ifna_fn);
+    registry.register_lazy("IFS", ifs::ifs_fn);
+    registry.register_lazy("SWITCH", switch::switch_fn);
+    registry.register_eager("ISNUMBER", is_checks::isnumber_fn);
+    registry.register_eager("ISTEXT", is_checks::istext_fn);
+    registry.register_eager("ISERROR", is_checks::iserror_fn);
+    registry.register_eager("ISBLANK", is_checks::isblank_fn);
+    registry.register_eager("ISNA", is_checks::isna_fn);
 }

--- a/crates/core/src/eval/functions/logical/not/mod.rs
+++ b/crates/core/src/eval/functions/logical/not/mod.rs
@@ -1,0 +1,20 @@
+use crate::eval::coercion::to_bool;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// `NOT(value)` — inverts a boolean value.
+///
+/// Accepts exactly 1 argument. Returns `#VALUE!` if the argument cannot be
+/// coerced to bool (e.g. Text, Empty, Array).
+pub fn not_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match to_bool(args[0].clone()) {
+        Ok(b) => Value::Bool(!b),
+        Err(e) => e,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/logical/not/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/not/tests/edge.rs
@@ -1,0 +1,17 @@
+use super::super::not_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn not_zero_returns_true() {
+    assert_eq!(not_fn(&[Value::Number(0.0)]), Value::Bool(true));
+}
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(not_fn(&[]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn array_returns_value_error() {
+    assert_eq!(not_fn(&[Value::Array(vec![Value::Bool(true)])]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/logical/not/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/not/tests/failure.rs
@@ -1,0 +1,17 @@
+use super::super::not_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn text_returns_value_error() {
+    assert_eq!(not_fn(&[Value::Text("hello".to_string())]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn empty_returns_value_error() {
+    assert_eq!(not_fn(&[Value::Empty]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_many_args_returns_value_error() {
+    assert_eq!(not_fn(&[Value::Bool(true), Value::Bool(false)]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/logical/not/tests/mod.rs
+++ b/crates/core/src/eval/functions/logical/not/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/logical/not/tests/success.rs
+++ b/crates/core/src/eval/functions/logical/not/tests/success.rs
@@ -1,0 +1,17 @@
+use super::super::not_fn;
+use crate::types::Value;
+
+#[test]
+fn not_true_returns_false() {
+    assert_eq!(not_fn(&[Value::Bool(true)]), Value::Bool(false));
+}
+
+#[test]
+fn not_false_returns_true() {
+    assert_eq!(not_fn(&[Value::Bool(false)]), Value::Bool(true));
+}
+
+#[test]
+fn not_nonzero_returns_false() {
+    assert_eq!(not_fn(&[Value::Number(1.0)]), Value::Bool(false));
+}

--- a/crates/core/src/eval/functions/logical/or/mod.rs
+++ b/crates/core/src/eval/functions/logical/or/mod.rs
@@ -1,0 +1,27 @@
+use crate::eval::coercion::to_bool;
+use crate::eval::functions::{check_arity_len, EvalCtx};
+use crate::eval::evaluate_expr;
+use crate::parser::ast::Expr;
+use crate::types::Value;
+
+/// `OR(val1, ...)` — TRUE if ANY argument is truthy.
+///
+/// Short-circuits on the first true value. Returns `#VALUE!` with no args
+/// or if any arg cannot be coerced to bool.
+pub fn or_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if let Some(err) = check_arity_len(args.len(), 1, usize::MAX) {
+        return err;
+    }
+    for arg in args {
+        let val = evaluate_expr(arg, ctx);
+        match to_bool(val) {
+            Ok(true) => return Value::Bool(true),
+            Ok(false) => {}
+            Err(e) => return e,
+        }
+    }
+    Value::Bool(false)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/logical/or/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/or/tests/edge.rs
@@ -1,0 +1,37 @@
+use super::super::or_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{BinaryOp, Expr, Span};
+use crate::types::Value;
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    or_fn(&args, &mut ctx)
+}
+
+/// `OR(TRUE, 1/0)` must short-circuit — the division by zero is never evaluated.
+#[test]
+fn short_circuits_on_first_true() {
+    let div_by_zero = Expr::BinaryOp {
+        op: BinaryOp::Div,
+        left: Box::new(Expr::Number(1.0, span())),
+        right: Box::new(Expr::Number(0.0, span())),
+        span: span(),
+    };
+    let args = vec![Expr::Bool(true, span()), div_by_zero];
+    assert_eq!(run(args), Value::Bool(true));
+}
+
+#[test]
+fn zero_is_falsy() {
+    let args = vec![Expr::Number(0.0, span())];
+    assert_eq!(run(args), Value::Bool(false));
+}
+
+#[test]
+fn single_false() {
+    let args = vec![Expr::Bool(false, span())];
+    assert_eq!(run(args), Value::Bool(false));
+}

--- a/crates/core/src/eval/functions/logical/or/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/or/tests/failure.rs
@@ -1,0 +1,29 @@
+use super::super::or_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
+use crate::types::{ErrorKind, Value};
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    or_fn(&args, &mut ctx)
+}
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(run(vec![]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn text_arg_returns_value_error() {
+    let args = vec![Expr::Text("hello".to_string(), span())];
+    assert_eq!(run(args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn all_zeros_returns_false() {
+    let args = vec![Expr::Number(0.0, span()), Expr::Number(0.0, span())];
+    assert_eq!(run(args), Value::Bool(false));
+}

--- a/crates/core/src/eval/functions/logical/or/tests/mod.rs
+++ b/crates/core/src/eval/functions/logical/or/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/logical/or/tests/success.rs
+++ b/crates/core/src/eval/functions/logical/or/tests/success.rs
@@ -1,0 +1,30 @@
+use super::super::or_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
+use crate::types::Value;
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    or_fn(&args, &mut ctx)
+}
+
+#[test]
+fn one_true_returns_true() {
+    let args = vec![Expr::Bool(false, span()), Expr::Bool(true, span())];
+    assert_eq!(run(args), Value::Bool(true));
+}
+
+#[test]
+fn all_false_returns_false() {
+    let args = vec![Expr::Bool(false, span()), Expr::Bool(false, span())];
+    assert_eq!(run(args), Value::Bool(false));
+}
+
+#[test]
+fn nonzero_number_is_truthy() {
+    let args = vec![Expr::Number(5.0, span())];
+    assert_eq!(run(args), Value::Bool(true));
+}

--- a/crates/core/src/eval/functions/logical/switch/mod.rs
+++ b/crates/core/src/eval/functions/logical/switch/mod.rs
@@ -1,0 +1,41 @@
+use crate::eval::functions::EvalCtx;
+use crate::eval::evaluate_expr;
+use crate::parser::ast::Expr;
+use crate::types::{ErrorKind, Value};
+
+/// `SWITCH(expr, case1, val1, ..., [default])` — matches expr against cases.
+///
+/// - First arg is the expression to match.
+/// - Remaining args are case/value pairs with an optional default as the last arg
+///   when the remaining count is odd.
+/// - Returns `#N/A` if no match and no default.
+/// - Returns `#VALUE!` if fewer than 3 args are provided.
+pub fn switch_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    // Need at least: expr + 1 case + 1 value = 3 args
+    if args.len() < 3 {
+        return Value::Error(ErrorKind::Value);
+    }
+    let expr_val = evaluate_expr(&args[0], ctx);
+    let rest = &args[1..];
+    // odd rest count means last element is the default
+    let has_default = !rest.len().is_multiple_of(2);
+    let pairs_end = if has_default { rest.len() - 1 } else { rest.len() };
+
+    let mut i = 0;
+    while i < pairs_end {
+        let case_val = evaluate_expr(&rest[i], ctx);
+        if case_val == expr_val {
+            return evaluate_expr(&rest[i + 1], ctx);
+        }
+        i += 2;
+    }
+
+    if has_default {
+        evaluate_expr(&rest[rest.len() - 1], ctx)
+    } else {
+        Value::Error(ErrorKind::NA)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/logical/switch/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/switch/tests/edge.rs
@@ -1,7 +1,7 @@
 use super::super::switch_fn;
 use crate::eval::{Context, EvalCtx, Registry};
-use crate::parser::ast::{Expr, Span};
-use crate::types::Value;
+use crate::parser::ast::{BinaryOp, Expr, Span};
+use crate::types::{ErrorKind, Value};
 
 fn span() -> Span { Span::new(0, 1) }
 
@@ -46,3 +46,40 @@ fn single_case_with_default_no_match_uses_default() {
     ];
     assert_eq!(run(args), Value::Text("default".to_string()));
 }
+
+#[test]
+fn matched_result_does_not_evaluate_later_branches() {
+    // SWITCH(1, 1, 42, 2, 1/0) → 42 (second result 1/0 is never evaluated)
+    let args = vec![
+        Expr::Number(1.0, span()),
+        Expr::Number(1.0, span()),
+        Expr::Number(42.0, span()),
+        Expr::Number(2.0, span()),
+        Expr::BinaryOp {
+            op: BinaryOp::Div,
+            left: Box::new(Expr::Number(1.0, span())),
+            right: Box::new(Expr::Number(0.0, span())),
+            span: span(),
+        },
+    ];
+    assert_eq!(run(args), Value::Number(42.0));
+}
+
+#[test]
+fn unmatched_case_does_not_evaluate_skipped_result() {
+    // SWITCH(2, 1, 1/0, 2, 99) → 99 (first result 1/0 is skipped, never evaluated)
+    let args = vec![
+        Expr::Number(2.0, span()),
+        Expr::Number(1.0, span()),
+        Expr::BinaryOp {
+            op: BinaryOp::Div,
+            left: Box::new(Expr::Number(1.0, span())),
+            right: Box::new(Expr::Number(0.0, span())),
+            span: span(),
+        },
+        Expr::Number(2.0, span()),
+        Expr::Number(99.0, span()),
+    ];
+    assert_eq!(run(args), Value::Number(99.0));
+}
+

--- a/crates/core/src/eval/functions/logical/switch/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/switch/tests/edge.rs
@@ -1,0 +1,48 @@
+use super::super::switch_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
+use crate::types::Value;
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    switch_fn(&args, &mut ctx)
+}
+
+#[test]
+fn bool_match() {
+    let args = vec![
+        Expr::Bool(true, span()),
+        Expr::Bool(false, span()),
+        Expr::Text("false".to_string(), span()),
+        Expr::Bool(true, span()),
+        Expr::Text("true".to_string(), span()),
+    ];
+    assert_eq!(run(args), Value::Text("true".to_string()));
+}
+
+#[test]
+fn text_match() {
+    let args = vec![
+        Expr::Text("b".to_string(), span()),
+        Expr::Text("a".to_string(), span()),
+        Expr::Number(1.0, span()),
+        Expr::Text("b".to_string(), span()),
+        Expr::Number(2.0, span()),
+    ];
+    assert_eq!(run(args), Value::Number(2.0));
+}
+
+#[test]
+fn single_case_with_default_no_match_uses_default() {
+    // SWITCH(5, 1, "one", "default") — rest=[1,"one","default"], odd=true => default="default"
+    let args = vec![
+        Expr::Number(5.0, span()),
+        Expr::Number(1.0, span()),
+        Expr::Text("one".to_string(), span()),
+        Expr::Text("default".to_string(), span()),
+    ];
+    assert_eq!(run(args), Value::Text("default".to_string()));
+}

--- a/crates/core/src/eval/functions/logical/switch/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/switch/tests/failure.rs
@@ -1,0 +1,35 @@
+use super::super::switch_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
+use crate::types::{ErrorKind, Value};
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    switch_fn(&args, &mut ctx)
+}
+
+#[test]
+fn no_args_returns_value_error() {
+    assert_eq!(run(vec![]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn too_few_args_returns_value_error() {
+    // Only expr + one more arg — not enough for a case/value pair
+    let args = vec![Expr::Number(1.0, span()), Expr::Number(1.0, span())];
+    assert_eq!(run(args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn no_match_without_default_returns_na() {
+    // SWITCH(99, 1, "one") — even remaining = no default
+    let args = vec![
+        Expr::Number(99.0, span()),
+        Expr::Number(1.0, span()),
+        Expr::Text("one".to_string(), span()),
+    ];
+    assert_eq!(run(args), Value::Error(ErrorKind::NA));
+}

--- a/crates/core/src/eval/functions/logical/switch/tests/mod.rs
+++ b/crates/core/src/eval/functions/logical/switch/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/logical/switch/tests/success.rs
+++ b/crates/core/src/eval/functions/logical/switch/tests/success.rs
@@ -1,0 +1,50 @@
+use super::super::switch_fn;
+use crate::eval::{Context, EvalCtx, Registry};
+use crate::parser::ast::{Expr, Span};
+use crate::types::Value;
+
+fn span() -> Span { Span::new(0, 1) }
+
+fn run(args: Vec<Expr>) -> Value {
+    let reg = Registry::new();
+    let mut ctx = EvalCtx::new(Context::empty(), &reg);
+    switch_fn(&args, &mut ctx)
+}
+
+#[test]
+fn matches_first_case() {
+    let args = vec![
+        Expr::Number(1.0, span()),
+        Expr::Number(1.0, span()),
+        Expr::Text("one".to_string(), span()),
+        Expr::Number(2.0, span()),
+        Expr::Text("two".to_string(), span()),
+    ];
+    assert_eq!(run(args), Value::Text("one".to_string()));
+}
+
+#[test]
+fn matches_second_case() {
+    let args = vec![
+        Expr::Number(2.0, span()),
+        Expr::Number(1.0, span()),
+        Expr::Text("one".to_string(), span()),
+        Expr::Number(2.0, span()),
+        Expr::Text("two".to_string(), span()),
+    ];
+    assert_eq!(run(args), Value::Text("two".to_string()));
+}
+
+#[test]
+fn uses_default_when_no_match() {
+    // SWITCH(3, 1, "one", 2, "two", "other") — odd remaining count = has default
+    let args = vec![
+        Expr::Number(3.0, span()),
+        Expr::Number(1.0, span()),
+        Expr::Text("one".to_string(), span()),
+        Expr::Number(2.0, span()),
+        Expr::Text("two".to_string(), span()),
+        Expr::Text("other".to_string(), span()),
+    ];
+    assert_eq!(run(args), Value::Text("other".to_string()));
+}


### PR DESCRIPTION
Closes #4

## Summary

Implements 12 logical and info functions in `crates/core/src/eval/functions/logical/`:

- **Logical**: `AND`, `OR`, `NOT`, `IFS`, `SWITCH`
- **Conditional**: `IFERROR`, `IFNA`
- **Info / type-check**: `ISNUMBER`, `ISTEXT`, `ISERROR`, `ISBLANK`, `ISNA`

## Key design decisions

- `AND`, `OR`, `IFS`, and `SWITCH` use lazy short-circuit dispatch — arguments are only evaluated until the result is determined.
- Each function lives in its own module under `logical/`, keeping files small and focused.

## Tests

- 200 tests pass (`cargo test`)
- Clippy clean (`cargo clippy -- -D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)