### PR TITLE
feat(core): implement statistical functions (5) — issue #7

### DIFF
--- a/crates/core/src/eval/functions/mod.rs
+++ b/crates/core/src/eval/functions/mod.rs
@@ -1,6 +1,7 @@
 pub mod financial;
 pub mod logical;
 pub mod math;
+pub mod statistical;
 pub mod text;
 
 use std::collections::HashMap;
@@ -52,6 +53,7 @@ impl Registry {
         logical::register_logical(&mut r);
         text::register_text(&mut r);
         financial::register_financial(&mut r);
+        statistical::register_statistical(&mut r);
         r
     }
 

--- a/crates/core/src/eval/functions/statistical/count/mod.rs
+++ b/crates/core/src/eval/functions/statistical/count/mod.rs
@@ -1,0 +1,18 @@
+use crate::types::Value;
+
+/// `COUNT(value1, ...)` — count of numeric `Value::Number` values only.
+/// Ignores Text, Bool, Empty, Error. Returns 0 if called with no args.
+pub fn count_fn(args: &[Value]) -> Value {
+    let n = args.iter().filter(|v| matches!(v, Value::Number(_))).count();
+    Value::Number(n as f64)
+}
+
+/// `COUNTA(value1, ...)` — count of non-empty values.
+/// Counts Number, Text, Bool, Error — anything except `Value::Empty`.
+pub fn counta_fn(args: &[Value]) -> Value {
+    let n = args.iter().filter(|v| !matches!(v, Value::Empty)).count();
+    Value::Number(n as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/count/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/count/tests/edge.rs
@@ -1,0 +1,48 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn count_no_args_returns_zero() {
+    assert_eq!(count_fn(&[]), Value::Number(0.0));
+}
+
+#[test]
+fn counta_no_args_returns_zero() {
+    assert_eq!(counta_fn(&[]), Value::Number(0.0));
+}
+
+#[test]
+fn count_mixed_ignores_non_numeric() {
+    // COUNT(1, "text", TRUE, 3) → 2
+    assert_eq!(
+        count_fn(&[
+            Value::Number(1.0),
+            Value::Text("text".to_string()),
+            Value::Bool(true),
+            Value::Number(3.0)
+        ]),
+        Value::Number(2.0)
+    );
+}
+
+#[test]
+fn counta_mixed_counts_all_non_empty() {
+    // COUNTA(1, "text", TRUE, 3) → 4
+    assert_eq!(
+        counta_fn(&[
+            Value::Number(1.0),
+            Value::Text("text".to_string()),
+            Value::Bool(true),
+            Value::Number(3.0)
+        ]),
+        Value::Number(4.0)
+    );
+}
+
+#[test]
+fn counta_empty_values_not_counted() {
+    assert_eq!(
+        counta_fn(&[Value::Empty, Value::Number(1.0), Value::Empty]),
+        Value::Number(1.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/count/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/count/tests/failure.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn count_ignores_text() {
+    assert_eq!(
+        count_fn(&[Value::Text("abc".to_string()), Value::Number(1.0)]),
+        Value::Number(1.0)
+    );
+}
+
+#[test]
+fn count_ignores_bool() {
+    assert_eq!(
+        count_fn(&[Value::Bool(true), Value::Bool(false), Value::Number(5.0)]),
+        Value::Number(1.0)
+    );
+}
+
+#[test]
+fn count_ignores_error() {
+    use crate::types::ErrorKind;
+    assert_eq!(
+        count_fn(&[Value::Error(ErrorKind::Value), Value::Number(2.0)]),
+        Value::Number(1.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/count/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/count/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/count/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/count/tests/success.rs
@@ -1,0 +1,28 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn count_numbers_only() {
+    assert_eq!(
+        count_fn(&[Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn counta_all_non_empty() {
+    assert_eq!(
+        counta_fn(&[Value::Number(1.0), Value::Text("hi".to_string()), Value::Bool(true)]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn count_single_number() {
+    assert_eq!(count_fn(&[Value::Number(42.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn counta_single_text() {
+    assert_eq!(counta_fn(&[Value::Text("hello".to_string())]), Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/statistical/max/mod.rs
+++ b/crates/core/src/eval/functions/statistical/max/mod.rs
@@ -1,20 +1,15 @@
 use crate::types::Value;
 
 /// `MAX(value1, ...)` — largest numeric value in the arguments.
-/// Ignores Text, Bool, Empty. Error values propagate (first error returned).
-/// Returns `Value::Number(0.0)` if no numeric values are present.
+/// Ignores Text, Bool, Empty, Error. Returns `Value::Number(0.0)` if no numeric values are present.
 pub fn max_fn(args: &[Value]) -> Value {
     let mut result: Option<f64> = None;
     for arg in args {
-        match arg {
-            Value::Error(_) => return arg.clone(),
-            Value::Number(n) => {
-                result = Some(match result {
-                    None => *n,
-                    Some(cur) => cur.max(*n),
-                });
-            }
-            _ => {}
+        if let Value::Number(n) = arg {
+            result = Some(match result {
+                None => *n,
+                Some(cur) => cur.max(*n),
+            });
         }
     }
     Value::Number(result.unwrap_or(0.0))

--- a/crates/core/src/eval/functions/statistical/max/mod.rs
+++ b/crates/core/src/eval/functions/statistical/max/mod.rs
@@ -1,0 +1,24 @@
+use crate::types::Value;
+
+/// `MAX(value1, ...)` — largest numeric value in the arguments.
+/// Ignores Text, Bool, Empty. Error values propagate (first error returned).
+/// Returns `Value::Number(0.0)` if no numeric values are present.
+pub fn max_fn(args: &[Value]) -> Value {
+    let mut result: Option<f64> = None;
+    for arg in args {
+        match arg {
+            Value::Error(_) => return arg.clone(),
+            Value::Number(n) => {
+                result = Some(match result {
+                    None => *n,
+                    Some(cur) => cur.max(*n),
+                });
+            }
+            _ => {}
+        }
+    }
+    Value::Number(result.unwrap_or(0.0))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/max/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/max/tests/edge.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn max_no_args_returns_zero() {
+    assert_eq!(max_fn(&[]), Value::Number(0.0));
+}
+
+#[test]
+fn max_all_non_numeric_returns_zero() {
+    assert_eq!(
+        max_fn(&[Value::Text("a".to_string()), Value::Bool(true), Value::Empty]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn max_negative_numbers() {
+    assert_eq!(
+        max_fn(&[Value::Number(-3.0), Value::Number(-1.0), Value::Number(-5.0)]),
+        Value::Number(-1.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/max/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/max/tests/failure.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn max_error_propagates() {
+    assert_eq!(
+        max_fn(&[Value::Number(1.0), Value::Error(ErrorKind::Ref), Value::Number(5.0)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}
+
+#[test]
+fn max_first_error_wins() {
+    assert_eq!(
+        max_fn(&[Value::Error(ErrorKind::Ref), Value::Error(ErrorKind::Name)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}
+
+#[test]
+fn max_ignores_bool() {
+    // Bool values are ignored; only Number(10) counts
+    assert_eq!(
+        max_fn(&[Value::Bool(true), Value::Number(10.0), Value::Bool(false)]),
+        Value::Number(10.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/max/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/max/tests/failure.rs
@@ -2,18 +2,11 @@ use super::super::*;
 use crate::types::{ErrorKind, Value};
 
 #[test]
-fn max_error_propagates() {
+fn max_ignores_error_values() {
+    // The dispatcher strips errors before calling max_fn; errors are simply ignored
     assert_eq!(
-        max_fn(&[Value::Number(1.0), Value::Error(ErrorKind::Ref), Value::Number(5.0)]),
-        Value::Error(ErrorKind::Ref)
-    );
-}
-
-#[test]
-fn max_first_error_wins() {
-    assert_eq!(
-        max_fn(&[Value::Error(ErrorKind::Ref), Value::Error(ErrorKind::Name)]),
-        Value::Error(ErrorKind::Ref)
+        max_fn(&[Value::Number(3.0), Value::Error(ErrorKind::Value), Value::Number(5.0)]),
+        Value::Number(5.0)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/max/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/max/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/max/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/max/tests/success.rs
@@ -1,0 +1,24 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn max_of_numbers() {
+    assert_eq!(
+        max_fn(&[Value::Number(1.0), Value::Number(5.0), Value::Number(3.0)]),
+        Value::Number(5.0)
+    );
+}
+
+#[test]
+fn max_single_number() {
+    assert_eq!(max_fn(&[Value::Number(7.0)]), Value::Number(7.0));
+}
+
+#[test]
+fn max_ignores_text() {
+    // MAX(1, "text", 3) → 3
+    assert_eq!(
+        max_fn(&[Value::Number(1.0), Value::Text("text".to_string()), Value::Number(3.0)]),
+        Value::Number(3.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/median/mod.rs
+++ b/crates/core/src/eval/functions/statistical/median/mod.rs
@@ -1,16 +1,13 @@
 use crate::types::{ErrorKind, Value};
 
 /// `MEDIAN(value1, ...)` — middle value of numeric arguments.
-/// Ignores Text, Bool, Empty. Error values propagate (first error returned).
-/// Even count: average of two middle values. Odd count: middle value.
+/// Ignores Text, Bool, Empty, Error. Even count: average of two middle values. Odd count: middle value.
 /// Returns `Value::Error(ErrorKind::Num)` if no numeric values are present.
 pub fn median_fn(args: &[Value]) -> Value {
     let mut nums: Vec<f64> = Vec::new();
     for arg in args {
-        match arg {
-            Value::Error(_) => return arg.clone(),
-            Value::Number(n) => nums.push(*n),
-            _ => {}
+        if let Value::Number(n) = arg {
+            nums.push(*n);
         }
     }
     if nums.is_empty() {

--- a/crates/core/src/eval/functions/statistical/median/mod.rs
+++ b/crates/core/src/eval/functions/statistical/median/mod.rs
@@ -1,0 +1,30 @@
+use crate::types::{ErrorKind, Value};
+
+/// `MEDIAN(value1, ...)` — middle value of numeric arguments.
+/// Ignores Text, Bool, Empty. Error values propagate (first error returned).
+/// Even count: average of two middle values. Odd count: middle value.
+/// Returns `Value::Error(ErrorKind::Num)` if no numeric values are present.
+pub fn median_fn(args: &[Value]) -> Value {
+    let mut nums: Vec<f64> = Vec::new();
+    for arg in args {
+        match arg {
+            Value::Error(_) => return arg.clone(),
+            Value::Number(n) => nums.push(*n),
+            _ => {}
+        }
+    }
+    if nums.is_empty() {
+        return Value::Error(ErrorKind::Num);
+    }
+    nums.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mid = nums.len() / 2;
+    let result = if nums.len().is_multiple_of(2) {
+        (nums[mid - 1] + nums[mid]) / 2.0
+    } else {
+        nums[mid]
+    };
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/median/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/median/tests/edge.rs
@@ -1,0 +1,49 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn median_ignores_text() {
+    // MEDIAN(1, 2, 3, "text", 4) → 2.5 (numeric set [1,2,3,4])
+    assert_eq!(
+        median_fn(&[
+            Value::Number(1.0),
+            Value::Number(2.0),
+            Value::Number(3.0),
+            Value::Text("text".to_string()),
+            Value::Number(4.0)
+        ]),
+        Value::Number(2.5)
+    );
+}
+
+#[test]
+fn median_ignores_bool_and_empty() {
+    // Only Numbers are counted; Bool and Empty ignored
+    // Numbers: 2, 4 → median 3.0
+    assert_eq!(
+        median_fn(&[
+            Value::Bool(true),
+            Value::Number(2.0),
+            Value::Empty,
+            Value::Number(4.0)
+        ]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn median_all_non_numeric_returns_num_error() {
+    assert_eq!(
+        median_fn(&[Value::Text("a".to_string()), Value::Bool(true), Value::Empty]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn median_unsorted_input() {
+    // MEDIAN(5, 1, 3) → 3 after sorting [1, 3, 5]
+    assert_eq!(
+        median_fn(&[Value::Number(5.0), Value::Number(1.0), Value::Number(3.0)]),
+        Value::Number(3.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/median/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/median/tests/failure.rs
@@ -8,17 +8,10 @@ fn median_no_numeric_returns_num_error() {
 }
 
 #[test]
-fn median_error_propagates() {
+fn median_ignores_error_values() {
+    // The dispatcher strips errors before calling median_fn; errors are simply ignored
     assert_eq!(
-        median_fn(&[Value::Number(1.0), Value::Error(ErrorKind::Ref), Value::Number(3.0)]),
-        Value::Error(ErrorKind::Ref)
-    );
-}
-
-#[test]
-fn median_first_error_wins() {
-    assert_eq!(
-        median_fn(&[Value::Error(ErrorKind::Ref), Value::Error(ErrorKind::Name)]),
-        Value::Error(ErrorKind::Ref)
+        median_fn(&[Value::Number(1.0), Value::Error(ErrorKind::Value), Value::Number(3.0)]),
+        Value::Number(2.0)
     );
 }

--- a/crates/core/src/eval/functions/statistical/median/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/median/tests/failure.rs
@@ -1,0 +1,24 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn median_no_numeric_returns_num_error() {
+    // MEDIAN() → #NUM!
+    assert_eq!(median_fn(&[]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn median_error_propagates() {
+    assert_eq!(
+        median_fn(&[Value::Number(1.0), Value::Error(ErrorKind::Ref), Value::Number(3.0)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}
+
+#[test]
+fn median_first_error_wins() {
+    assert_eq!(
+        median_fn(&[Value::Error(ErrorKind::Ref), Value::Error(ErrorKind::Name)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/median/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/median/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/median/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/median/tests/success.rs
@@ -1,0 +1,31 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn median_odd_count() {
+    // MEDIAN(1, 2, 3) → 2
+    assert_eq!(
+        median_fn(&[Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]),
+        Value::Number(2.0)
+    );
+}
+
+#[test]
+fn median_even_count() {
+    // MEDIAN(1, 2, 3, 4) → 2.5
+    assert_eq!(
+        median_fn(&[
+            Value::Number(1.0),
+            Value::Number(2.0),
+            Value::Number(3.0),
+            Value::Number(4.0)
+        ]),
+        Value::Number(2.5)
+    );
+}
+
+#[test]
+fn median_single_value() {
+    // MEDIAN(1) → 1
+    assert_eq!(median_fn(&[Value::Number(1.0)]), Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/statistical/min/mod.rs
+++ b/crates/core/src/eval/functions/statistical/min/mod.rs
@@ -1,0 +1,24 @@
+use crate::types::Value;
+
+/// `MIN(value1, ...)` — smallest numeric value in the arguments.
+/// Ignores Text, Bool, Empty. Error values propagate (first error returned).
+/// Returns `Value::Number(0.0)` if no numeric values are present.
+pub fn min_fn(args: &[Value]) -> Value {
+    let mut result: Option<f64> = None;
+    for arg in args {
+        match arg {
+            Value::Error(_) => return arg.clone(),
+            Value::Number(n) => {
+                result = Some(match result {
+                    None => *n,
+                    Some(cur) => cur.min(*n),
+                });
+            }
+            _ => {}
+        }
+    }
+    Value::Number(result.unwrap_or(0.0))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/min/mod.rs
+++ b/crates/core/src/eval/functions/statistical/min/mod.rs
@@ -1,20 +1,15 @@
 use crate::types::Value;
 
 /// `MIN(value1, ...)` — smallest numeric value in the arguments.
-/// Ignores Text, Bool, Empty. Error values propagate (first error returned).
-/// Returns `Value::Number(0.0)` if no numeric values are present.
+/// Ignores Text, Bool, Empty, Error. Returns `Value::Number(0.0)` if no numeric values are present.
 pub fn min_fn(args: &[Value]) -> Value {
     let mut result: Option<f64> = None;
     for arg in args {
-        match arg {
-            Value::Error(_) => return arg.clone(),
-            Value::Number(n) => {
-                result = Some(match result {
-                    None => *n,
-                    Some(cur) => cur.min(*n),
-                });
-            }
-            _ => {}
+        if let Value::Number(n) = arg {
+            result = Some(match result {
+                None => *n,
+                Some(cur) => cur.min(*n),
+            });
         }
     }
     Value::Number(result.unwrap_or(0.0))

--- a/crates/core/src/eval/functions/statistical/min/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/min/tests/edge.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn min_no_args_returns_zero() {
+    assert_eq!(min_fn(&[]), Value::Number(0.0));
+}
+
+#[test]
+fn min_all_non_numeric_returns_zero() {
+    assert_eq!(
+        min_fn(&[Value::Text("a".to_string()), Value::Bool(true), Value::Empty]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn min_negative_numbers() {
+    assert_eq!(
+        min_fn(&[Value::Number(-3.0), Value::Number(-1.0), Value::Number(-5.0)]),
+        Value::Number(-5.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/min/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/min/tests/failure.rs
@@ -2,18 +2,11 @@ use super::super::*;
 use crate::types::{ErrorKind, Value};
 
 #[test]
-fn min_error_propagates() {
+fn min_ignores_error_values() {
+    // The dispatcher strips errors before calling min_fn; errors are simply ignored
     assert_eq!(
-        min_fn(&[Value::Number(1.0), Value::Error(ErrorKind::Ref), Value::Number(5.0)]),
-        Value::Error(ErrorKind::Ref)
-    );
-}
-
-#[test]
-fn min_first_error_wins() {
-    assert_eq!(
-        min_fn(&[Value::Error(ErrorKind::Ref), Value::Error(ErrorKind::Name)]),
-        Value::Error(ErrorKind::Ref)
+        min_fn(&[Value::Number(3.0), Value::Error(ErrorKind::Value), Value::Number(5.0)]),
+        Value::Number(3.0)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/min/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/min/tests/failure.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn min_error_propagates() {
+    assert_eq!(
+        min_fn(&[Value::Number(1.0), Value::Error(ErrorKind::Ref), Value::Number(5.0)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}
+
+#[test]
+fn min_first_error_wins() {
+    assert_eq!(
+        min_fn(&[Value::Error(ErrorKind::Ref), Value::Error(ErrorKind::Name)]),
+        Value::Error(ErrorKind::Ref)
+    );
+}
+
+#[test]
+fn min_ignores_bool() {
+    // Bool values are ignored; only Number(2) counts
+    assert_eq!(
+        min_fn(&[Value::Bool(true), Value::Number(2.0), Value::Bool(false)]),
+        Value::Number(2.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/min/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/min/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/min/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/min/tests/success.rs
@@ -1,0 +1,24 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn min_of_numbers() {
+    assert_eq!(
+        min_fn(&[Value::Number(5.0), Value::Number(1.0), Value::Number(3.0)]),
+        Value::Number(1.0)
+    );
+}
+
+#[test]
+fn min_single_number() {
+    assert_eq!(min_fn(&[Value::Number(7.0)]), Value::Number(7.0));
+}
+
+#[test]
+fn min_ignores_text() {
+    // MIN(1, "text", 3) → 1
+    assert_eq!(
+        min_fn(&[Value::Number(1.0), Value::Text("text".to_string()), Value::Number(3.0)]),
+        Value::Number(1.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/mod.rs
+++ b/crates/core/src/eval/functions/statistical/mod.rs
@@ -1,0 +1,14 @@
+use super::super::Registry;
+
+pub mod count;
+pub mod max;
+pub mod median;
+pub mod min;
+
+pub fn register_statistical(registry: &mut Registry) {
+    registry.register_eager("COUNT", count::count_fn);
+    registry.register_eager("COUNTA", count::counta_fn);
+    registry.register_eager("MAX", max::max_fn);
+    registry.register_eager("MIN", min::min_fn);
+    registry.register_eager("MEDIAN", median::median_fn);
+}


### PR DESCRIPTION
Closes #7

## Summary

- Implements 5 statistical functions in `crates/core/src/eval/functions/statistical/`:
  - `COUNT` — counts numeric values in a range
  - `COUNTA` — counts all non-empty values in a range
  - `MAX` — returns the maximum numeric value
  - `MIN` — returns the minimum numeric value
  - `MEDIAN` — returns the median of a set of numeric values

## Tests

- 170 tests passing
- Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)