### PR TITLE
feat(mcp): implement MCP server with 5 tools — issue #9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,12 +13,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bit-set"
@@ -57,52 +42,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cc"
-version = "1.2.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chrono"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "serde",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -127,12 +70,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,94 +80,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "slab",
-]
 
 [[package]]
 name = "ganit-core"
@@ -245,8 +94,8 @@ name = "ganit-mcp"
 version = "0.1.0"
 dependencies = [
  "ganit-core",
- "rmcp",
- "tokio",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -304,30 +153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,16 +177,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "js-sys"
-version = "0.3.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,15 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,17 +205,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "mio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys",
-]
 
 [[package]]
 name = "nom"
@@ -434,41 +229,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "ppv-lite86"
@@ -583,51 +343,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "rmcp"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a0110d28bd076f39e14bfd5b0340216dd18effeb5d02b43215944cc3e5c751"
-dependencies = [
- "base64",
- "chrono",
- "futures",
- "paste",
- "pin-project-lite",
- "rmcp-macros",
- "schemars",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "rmcp-macros"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e2b2fd7497540489fa2db285edd43b7ed14c49157157438664278da6e42a7a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "rustix"
@@ -659,36 +378,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -727,17 +416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,44 +426,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys",
 ]
 
 [[package]]
@@ -810,98 +450,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio"
-version = "1.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -930,12 +478,6 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1035,63 +577,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -9,6 +9,6 @@ name = "ganit-mcp"
 path = "src/main.rs"
 
 [dependencies]
-rmcp = { version = "0.1", features = ["server", "transport-io", "macros"] }
 ganit-core = { path = "../core" }
-tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -12,15 +12,38 @@ fn main() {
     let mut out = stdout.lock();
 
     for line in stdin.lock().lines() {
-        let line = line.expect("stdin read error");
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break, // EOF or broken pipe — exit cleanly
+        };
         if line.is_empty() {
             continue;
         }
 
         let request: JsonValue = match serde_json::from_str(&line) {
             Ok(v) => v,
-            Err(_) => continue,
+            Err(_) => {
+                let err = json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "error": { "code": -32700, "message": "Parse error" }
+                });
+                writeln!(out, "{}", serde_json::to_string(&err).unwrap()).unwrap();
+                out.flush().unwrap();
+                continue;
+            }
         };
+
+        if !request.is_object() {
+            let err = json!({
+                "jsonrpc": "2.0",
+                "id": null,
+                "error": { "code": -32700, "message": "Parse error" }
+            });
+            writeln!(out, "{}", serde_json::to_string(&err).unwrap()).unwrap();
+            out.flush().unwrap();
+            continue;
+        }
 
         // Notifications have no "id"; respond only to requests.
         if request.get("id").is_none() {
@@ -61,12 +84,17 @@ fn handle_request(req: &JsonValue) -> JsonValue {
             let name = params["name"].as_str().unwrap_or("");
             let args = &params["arguments"];
             let result = dispatch_tool(name, args);
+            let is_error = result.get("error").is_some();
+            let mut tool_result = json!({
+                "content": [{ "type": "text", "text": serde_json::to_string(&result).expect("result serialisation is infallible") }]
+            });
+            if is_error {
+                tool_result["isError"] = json!(true);
+            }
             json!({
                 "jsonrpc": "2.0",
                 "id": id,
-                "result": {
-                    "content": [{ "type": "text", "text": serde_json::to_string(&result).unwrap() }]
-                }
+                "result": tool_result
             })
         }
 
@@ -87,7 +115,7 @@ fn dispatch_tool(name: &str, args: &JsonValue) -> JsonValue {
         "explain" => tool_explain(args),
         "batch_evaluate" => tool_batch_evaluate(args),
         "list_functions" => tool_list_functions(),
-        _ => json!({ "error": "Unknown tool" }),
+        _ => json!({ "error": format!("Unknown tool: {}", name) }),
     }
 }
 

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -1,4 +1,354 @@
-#[tokio::main]
-async fn main() {
-    // ganit MCP server entry point
+// ganit MCP server — hand-rolled JSON-RPC over stdio (MCP protocol 2024-11-05)
+
+use std::collections::HashMap;
+use std::io::{self, BufRead, Write};
+
+use ganit_core::{evaluate, parse, validate, Expr, Value};
+use serde_json::{json, Value as JsonValue};
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+
+    for line in stdin.lock().lines() {
+        let line = line.expect("stdin read error");
+        if line.is_empty() {
+            continue;
+        }
+
+        let request: JsonValue = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        // Notifications have no "id"; respond only to requests.
+        if request.get("id").is_none() {
+            continue;
+        }
+
+        let response = handle_request(&request);
+        let mut response_str = serde_json::to_string(&response).expect("serialisation error");
+        response_str.push('\n');
+        out.write_all(response_str.as_bytes()).expect("stdout write error");
+        out.flush().expect("stdout flush error");
+    }
 }
+
+fn handle_request(req: &JsonValue) -> JsonValue {
+    let id = &req["id"];
+    let method = req["method"].as_str().unwrap_or("");
+    let params = &req["params"];
+
+    match method {
+        "initialize" => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "ganit-mcp", "version": "0.1.0" }
+            }
+        }),
+
+        "tools/list" => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": { "tools": tools_list() }
+        }),
+
+        "tools/call" => {
+            let name = params["name"].as_str().unwrap_or("");
+            let args = &params["arguments"];
+            let result = dispatch_tool(name, args);
+            json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
+                    "content": [{ "type": "text", "text": serde_json::to_string(&result).unwrap() }]
+                }
+            })
+        }
+
+        _ => json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": { "code": -32601, "message": "Method not found" }
+        }),
+    }
+}
+
+// ─── Tool dispatch ────────────────────────────────────────────────────────────
+
+fn dispatch_tool(name: &str, args: &JsonValue) -> JsonValue {
+    match name {
+        "evaluate" => tool_evaluate(args),
+        "validate" => tool_validate(args),
+        "explain" => tool_explain(args),
+        "batch_evaluate" => tool_batch_evaluate(args),
+        "list_functions" => tool_list_functions(),
+        _ => json!({ "error": "Unknown tool" }),
+    }
+}
+
+// ─── Individual tools ─────────────────────────────────────────────────────────
+
+fn tool_evaluate(args: &JsonValue) -> JsonValue {
+    let formula = match args["formula"].as_str() {
+        Some(f) => f,
+        None => return json!({ "error": "missing formula" }),
+    };
+    let vars = parse_variables(&args["variables"]);
+    let value = evaluate(formula, vars);
+    value_to_json(&value)
+}
+
+fn tool_validate(args: &JsonValue) -> JsonValue {
+    let formula = match args["formula"].as_str() {
+        Some(f) => f,
+        None => return json!({ "error": "missing formula" }),
+    };
+    match validate(formula) {
+        Ok(_) => json!({ "valid": true }),
+        Err(e) => json!({ "valid": false, "error": e.to_string() }),
+    }
+}
+
+fn tool_explain(args: &JsonValue) -> JsonValue {
+    let formula = match args["formula"].as_str() {
+        Some(f) => f,
+        None => return json!({ "error": "missing formula" }),
+    };
+    match parse(formula) {
+        Ok(expr) => {
+            let mut functions = Vec::new();
+            collect_functions(&expr, &mut functions);
+            functions.sort_unstable();
+            functions.dedup();
+            let description = if functions.is_empty() {
+                "Formula with no function calls".to_string()
+            } else {
+                format!("Formula using: {}", functions.join(", "))
+            };
+            json!({ "description": description, "functions_used": functions })
+        }
+        Err(e) => json!({
+            "description": format!("Invalid formula: {}", e),
+            "functions_used": []
+        }),
+    }
+}
+
+fn tool_batch_evaluate(args: &JsonValue) -> JsonValue {
+    let formulas = match args["formulas"].as_array() {
+        Some(a) => a,
+        None => return json!({ "error": "missing formulas array" }),
+    };
+    let vars = parse_variables(&args["variables"]);
+    let results: Vec<JsonValue> = formulas
+        .iter()
+        .map(|f| {
+            let formula = f.as_str().unwrap_or("");
+            let value = evaluate(formula, vars.clone());
+            value_to_json(&value)
+        })
+        .collect();
+    json!(results)
+}
+
+fn tool_list_functions() -> JsonValue {
+    let entries: Vec<JsonValue> = FUNCTIONS
+        .iter()
+        .map(|(name, category, syntax, description)| {
+            json!({
+                "name": name,
+                "category": category,
+                "syntax": syntax,
+                "description": description
+            })
+        })
+        .collect();
+    json!({ "functions": entries })
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+fn parse_variables(vars_json: &JsonValue) -> HashMap<String, Value> {
+    let mut map = HashMap::new();
+    if let Some(obj) = vars_json.as_object() {
+        for (k, v) in obj {
+            let val = match v {
+                JsonValue::Number(n) => {
+                    if let Some(f) = n.as_f64() {
+                        Value::Number(f)
+                    } else {
+                        continue;
+                    }
+                }
+                JsonValue::String(s) => Value::Text(s.clone()),
+                JsonValue::Bool(b) => Value::Bool(*b),
+                _ => continue,
+            };
+            map.insert(k.clone(), val);
+        }
+    }
+    map
+}
+
+fn value_to_json(v: &Value) -> JsonValue {
+    match v {
+        Value::Number(n) => json!({ "value": n, "type": "number" }),
+        Value::Text(s) => json!({ "value": s, "type": "text" }),
+        Value::Bool(b) => json!({ "value": b, "type": "bool" }),
+        Value::Empty => json!({ "value": null, "type": "empty" }),
+        Value::Error(e) => json!({ "value": e.to_string(), "type": "error" }),
+        Value::Array(arr) => {
+            let items: Vec<JsonValue> = arr.iter().map(value_to_json).collect();
+            json!({ "value": items, "type": "array" })
+        }
+    }
+}
+
+fn collect_functions(expr: &Expr, out: &mut Vec<String>) {
+    match expr {
+        Expr::FunctionCall { name, args, .. } => {
+            out.push(name.clone());
+            for arg in args {
+                collect_functions(arg, out);
+            }
+        }
+        Expr::UnaryOp { operand, .. } => collect_functions(operand, out),
+        Expr::BinaryOp { left, right, .. } => {
+            collect_functions(left, out);
+            collect_functions(right, out);
+        }
+        _ => {}
+    }
+}
+
+// ─── tools/list metadata ─────────────────────────────────────────────────────
+
+fn tools_list() -> JsonValue {
+    json!([
+        {
+            "name": "evaluate",
+            "description": "Evaluate a spreadsheet formula with optional variable bindings.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "formula": { "type": "string", "description": "Formula string, e.g. \"SUM(A,B)\"" },
+                    "variables": { "type": "object", "description": "Variable bindings (name → number/string/bool)" }
+                },
+                "required": ["formula"]
+            }
+        },
+        {
+            "name": "validate",
+            "description": "Check whether a formula parses without errors.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "formula": { "type": "string" }
+                },
+                "required": ["formula"]
+            }
+        },
+        {
+            "name": "explain",
+            "description": "Describe a formula and list the functions it uses.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "formula": { "type": "string" }
+                },
+                "required": ["formula"]
+            }
+        },
+        {
+            "name": "batch_evaluate",
+            "description": "Evaluate multiple formulas sharing the same variable bindings.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "formulas": { "type": "array", "items": { "type": "string" } },
+                    "variables": { "type": "object" }
+                },
+                "required": ["formulas"]
+            }
+        },
+        {
+            "name": "list_functions",
+            "description": "Return the catalogue of supported spreadsheet functions.",
+            "inputSchema": { "type": "object", "properties": {} }
+        }
+    ])
+}
+
+// ─── Function catalogue (58 functions) ───────────────────────────────────────
+
+static FUNCTIONS: &[(&str, &str, &str, &str)] = &[
+    // math (18)
+    ("ABS",        "math",        "ABS(number)",                          "Absolute value of a number"),
+    ("CEILING",    "math",        "CEILING(number, significance)",         "Round up to nearest multiple of significance"),
+    ("FLOOR",      "math",        "FLOOR(number, significance)",           "Round down to nearest multiple of significance"),
+    ("INT",        "math",        "INT(number)",                           "Round down to nearest integer"),
+    ("LN",         "math",        "LN(number)",                            "Natural logarithm"),
+    ("LOG",        "math",        "LOG(number, base)",                     "Logarithm to specified base"),
+    ("LOG10",      "math",        "LOG10(number)",                         "Base-10 logarithm"),
+    ("MOD",        "math",        "MOD(number, divisor)",                  "Remainder after division"),
+    ("POWER",      "math",        "POWER(number, power)",                  "Number raised to a power"),
+    ("PRODUCT",    "math",        "PRODUCT(value1,...)",                   "Product of arguments"),
+    ("ROUND",      "math",        "ROUND(number, digits)",                 "Round to specified decimal places"),
+    ("ROUNDDOWN",  "math",        "ROUNDDOWN(number, digits)",             "Round toward zero"),
+    ("ROUNDUP",    "math",        "ROUNDUP(number, digits)",               "Round away from zero"),
+    ("SIGN",       "math",        "SIGN(number)",                          "Sign of a number: -1, 0, or 1"),
+    ("SQRT",       "math",        "SQRT(number)",                          "Square root"),
+    ("SUM",        "math",        "SUM(value1,...)",                       "Sum of arguments"),
+    ("SUMIF",      "math",        "SUMIF(range, criteria, sum_range)",     "Sum cells matching a condition"),
+    ("TRUNC",      "math",        "TRUNC(number, digits)",                 "Truncate to integer or decimal places"),
+    // logical (11)
+    ("AND",        "logical",     "AND(value1,...)",                       "True if all arguments are true"),
+    ("FALSE",      "logical",     "FALSE()",                               "Logical false value"),
+    ("IF",         "logical",     "IF(condition, true_val, false_val)",    "Conditional value"),
+    ("IFERROR",    "logical",     "IFERROR(value, value_if_error)",        "Return alternate value on error"),
+    ("IFNA",       "logical",     "IFNA(value, value_if_na)",              "Return alternate value on #N/A"),
+    ("IFS",        "logical",     "IFS(cond1, val1,...)",                  "First value whose condition is true"),
+    ("NOT",        "logical",     "NOT(value)",                            "Logical negation"),
+    ("OR",         "logical",     "OR(value1,...)",                        "True if any argument is true"),
+    ("SWITCH",     "logical",     "SWITCH(expr, val1, result1,...)",       "Match expression against values"),
+    ("TRUE",       "logical",     "TRUE()",                                "Logical true value"),
+    ("XOR",        "logical",     "XOR(value1,...)",                       "True if an odd number of arguments are true"),
+    // text (21)
+    ("CHAR",       "text",        "CHAR(number)",                          "Character from ASCII/Unicode code"),
+    ("CLEAN",      "text",        "CLEAN(text)",                           "Remove non-printable characters"),
+    ("CODE",       "text",        "CODE(text)",                            "Numeric code of first character"),
+    ("CONCAT",     "text",        "CONCAT(value1,...)",                    "Concatenate values"),
+    ("CONCATENATE","text",        "CONCATENATE(value1,...)",               "Concatenate values (legacy)"),
+    ("EXACT",      "text",        "EXACT(text1, text2)",                   "Case-sensitive string comparison"),
+    ("FIND",       "text",        "FIND(find_text, within_text, start)",   "Case-sensitive position search"),
+    ("LEFT",       "text",        "LEFT(text, num_chars)",                 "Left portion of a string"),
+    ("LEN",        "text",        "LEN(text)",                             "Number of characters in text"),
+    ("LOWER",      "text",        "LOWER(text)",                           "Convert to lowercase"),
+    ("MID",        "text",        "MID(text, start, num_chars)",           "Substring from middle of text"),
+    ("PROPER",     "text",        "PROPER(text)",                          "Capitalise first letter of each word"),
+    ("REPLACE",    "text",        "REPLACE(text, start, num_chars, new_text)", "Replace portion of text"),
+    ("REPT",       "text",        "REPT(text, number_times)",              "Repeat text N times"),
+    ("RIGHT",      "text",        "RIGHT(text, num_chars)",                "Right portion of a string"),
+    ("SEARCH",     "text",        "SEARCH(find_text, within_text, start)", "Case-insensitive position search"),
+    ("SUBSTITUTE", "text",        "SUBSTITUTE(text, old, new, instance)",  "Replace occurrences of a substring"),
+    ("TEXT",       "text",        "TEXT(value, format)",                   "Format number as text"),
+    ("TRIM",       "text",        "TRIM(text)",                            "Remove extra whitespace"),
+    ("UPPER",      "text",        "UPPER(text)",                           "Convert to uppercase"),
+    ("VALUE",      "text",        "VALUE(text)",                           "Convert text to number"),
+    // statistical (7)
+    ("AVERAGE",    "statistical", "AVERAGE(value1,...)",                   "Arithmetic mean of arguments"),
+    ("AVERAGEIF",  "statistical", "AVERAGEIF(range, criteria, avg_range)", "Average of cells matching a condition"),
+    ("COUNT",      "statistical", "COUNT(value1,...)",                     "Count numeric values"),
+    ("COUNTA",     "statistical", "COUNTA(value1,...)",                    "Count non-empty values"),
+    ("COUNTBLANK", "statistical", "COUNTBLANK(range)",                     "Count empty cells"),
+    ("COUNTIF",    "statistical", "COUNTIF(range, criteria)",              "Count cells matching a condition"),
+    ("MAX",        "statistical", "MAX(value1,...)",                       "Maximum value"),
+    ("MIN",        "statistical", "MIN(value1,...)",                       "Minimum value"),
+    // financial (1)
+    ("PMT",        "financial",   "PMT(rate, nper, pv)",                   "Periodic payment for a loan"),
+];


### PR DESCRIPTION
Closes #9. Hand-rolled JSON-RPC stdio server implementing `evaluate`, `validate`, `explain`, `batch_evaluate`, `list_functions`. Handles MCP `initialize`, `tools/list`, `tools/call`. Build + clippy clean.