### PR TITLE
fix(publish): add description and repository to crate manifests

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -3,6 +3,8 @@ name = "ganit-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+description = "Spreadsheet formula engine — parser and evaluator for Excel-compatible formulas"
+repository.workspace = true
 
 [dependencies]
 nom = "8"

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -3,6 +3,8 @@ name = "ganit-mcp"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+description = "MCP server exposing ganit formula evaluation as a tool for AI assistants"
+repository.workspace = true
 
 [[bin]]
 name = "ganit-mcp"


### PR DESCRIPTION
## Summary
- Adds `description` field to `ganit-core` and `ganit-mcp` (required by crates.io)
- Adds `repository.workspace = true` to both (inherits from workspace `Cargo.toml`)

## Why
`release-plz` was failing with:
> `missing or empty metadata fields: description`

crates.io rejects publishes without a description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)