### PR TITLE
fix(publish): exclude ganit-wasm from crates.io

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "ganit-wasm"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish = false  # published to npm via wasm-pack, not crates.io
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Summary
- Adds `publish = false` to `crates/wasm/Cargo.toml`

## Why
`release-plz` was trying to publish `ganit-wasm` to crates.io and failing:
> `all dependencies must have a version requirement specified when publishing`

`ganit-wasm` uses a path dependency on `ganit-core` and is published to **npm** via `wasm-pack`, not to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)