### PR TITLE
fix(publish): add version to ganit-core path dep in ganit-mcp

### DIFF
--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -11,6 +11,6 @@ name = "ganit-mcp"
 path = "src/main.rs"
 
 [dependencies]
-ganit-core = { path = "../core" }
+ganit-core = { path = "../core", version = "0.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary
- `ganit-core = { path = "../core", version = "0.1" }` in `crates/mcp/Cargo.toml`

## Why
crates.io requires all dependencies to specify a version when publishing. Path-only deps are rejected:
> `dependency 'ganit-core' does not specify a version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)