### PR TITLE
fix(core): evaluate() takes variables by reference

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,11 +19,11 @@ use eval::{evaluate_expr, Context, EvalCtx, Registry};
 /// Note: constructs a fresh `Registry` on every call. For bulk evaluation
 /// across many formulas, consider reusing a `Registry` via the lower-level
 /// `eval::evaluate_expr` API.
-pub fn evaluate(formula: &str, variables: HashMap<String, Value>) -> Value {
+pub fn evaluate(formula: &str, variables: &HashMap<String, Value>) -> Value {
     match parse(formula) {
         Err(_) => Value::Error(ErrorKind::Value),
         Ok(expr) => {
-            let ctx = Context::new(variables);
+            let ctx = Context::new(variables.clone());
             let registry = Registry::new();
             let mut eval_ctx = EvalCtx::new(ctx, &registry);
             evaluate_expr(&expr, &mut eval_ctx)

--- a/crates/core/tests/helpers.rs
+++ b/crates/core/tests/helpers.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 /// Convenience: evaluate a formula with no variables.
 pub fn eval(formula: &str) -> Value {
-    evaluate(formula, HashMap::new())
+    evaluate(formula, &HashMap::new())
 }
 
 /// Convenience: evaluate a formula with string-keyed variables.
@@ -13,5 +13,5 @@ pub fn eval_with(formula: &str, vars: impl IntoIterator<Item = (&'static str, Va
     for (k, v) in vars {
         map.insert(k.to_string(), v);
     }
-    evaluate(formula, map)
+    evaluate(formula, &map)
 }

--- a/crates/core/tests/property_financial.rs
+++ b/crates/core/tests/property_financial.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 fn run_vars(formula: &str, vars: Vec<(&str, f64)>) -> Value {
     let map = vars.into_iter().map(|(k, v)| (k.to_string(), Value::Number(v))).collect();
-    evaluate(formula, map)
+    evaluate(formula, &map)
 }
 
 fn small_positive() -> impl Strategy<Value = f64> {
@@ -65,6 +65,6 @@ fn npv_zero_rate_sanity() {
         ("v1".to_string(), Value::Number(100.0)),
         ("v2".to_string(), Value::Number(200.0)),
     ].into_iter().collect();
-    let result = evaluate("=NPV(0, v1, v2)", vars);
+    let result = evaluate("=NPV(0, v1, v2)", &vars);
     assert_eq!(result, Value::Number(300.0));
 }

--- a/crates/core/tests/property_logical.rs
+++ b/crates/core/tests/property_logical.rs
@@ -3,12 +3,12 @@ use ganit_core::{evaluate, Value};
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, HashMap::new())
+    evaluate(formula, &HashMap::new())
 }
 
 fn run_vars(formula: &str, vars: Vec<(&str, f64)>) -> Value {
     let map = vars.into_iter().map(|(k, v)| (k.to_string(), Value::Number(v))).collect();
-    evaluate(formula, map)
+    evaluate(formula, &map)
 }
 
 fn small_f64() -> impl Strategy<Value = f64> {

--- a/crates/core/tests/property_math.rs
+++ b/crates/core/tests/property_math.rs
@@ -3,12 +3,12 @@ use ganit_core::{evaluate, Value};
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, HashMap::new())
+    evaluate(formula, &HashMap::new())
 }
 
 fn run_vars(formula: &str, vars: Vec<(&str, f64)>) -> Value {
     let map = vars.into_iter().map(|(k, v)| (k.to_string(), Value::Number(v))).collect();
-    evaluate(formula, map)
+    evaluate(formula, &map)
 }
 
 fn small_f64() -> impl Strategy<Value = f64> {

--- a/crates/core/tests/property_text.rs
+++ b/crates/core/tests/property_text.rs
@@ -7,7 +7,7 @@ fn run_text_vars(formula: &str, vars: Vec<(&str, &str)>) -> Value {
         .into_iter()
         .map(|(k, v)| (k.to_string(), Value::Text(v.to_string())))
         .collect();
-    evaluate(formula, map)
+    evaluate(formula, &map)
 }
 
 fn ascii_string() -> impl Strategy<Value = String> {
@@ -26,9 +26,9 @@ proptest! {
             ("a".to_string(), Value::Text(a.clone())),
             ("b".to_string(), Value::Text(b.clone())),
         ].into_iter().collect();
-        let len_ab = evaluate("=LEN(CONCATENATE(a,b))", vars.clone());
-        let len_a = evaluate("=LEN(a)", vars.clone());
-        let len_b = evaluate("=LEN(b)", vars);
+        let len_ab = evaluate("=LEN(CONCATENATE(a,b))", &vars);
+        let len_a = evaluate("=LEN(a)", &vars);
+        let len_b = evaluate("=LEN(b)", &vars);
         if let (Value::Number(total), Value::Number(la), Value::Number(lb)) = (len_ab, len_a, len_b) {
             prop_assert_eq!(total, la + lb);
         }
@@ -43,13 +43,13 @@ proptest! {
         let vars: HashMap<String, Value> = vec![
             ("s".to_string(), Value::Text(s.clone())),
         ].into_iter().collect();
-        let trimmed = evaluate("=TRIM(s)", vars);
+        let trimmed = evaluate("=TRIM(s)", &vars);
         // Trimming an already-trimmed lowercase ascii string should give same result
         if let Value::Text(t) = trimmed {
             let vars2: HashMap<String, Value> = vec![
                 ("s".to_string(), Value::Text(t.clone())),
             ].into_iter().collect();
-            let trimmed2 = evaluate("=TRIM(s)", vars2);
+            let trimmed2 = evaluate("=TRIM(s)", &vars2);
             prop_assert_eq!(trimmed2, Value::Text(t));
         }
     }
@@ -60,12 +60,12 @@ proptest! {
         let vars: HashMap<String, Value> = vec![
             ("s".to_string(), Value::Text(s.clone())),
         ].into_iter().collect();
-        let upper1 = evaluate("=UPPER(s)", vars);
+        let upper1 = evaluate("=UPPER(s)", &vars);
         if let Value::Text(u) = upper1 {
             let vars2: HashMap<String, Value> = vec![
                 ("s".to_string(), Value::Text(u.clone())),
             ].into_iter().collect();
-            let upper2 = evaluate("=UPPER(s)", vars2);
+            let upper2 = evaluate("=UPPER(s)", &vars2);
             prop_assert_eq!(upper2, Value::Text(u));
         }
     }
@@ -76,12 +76,12 @@ proptest! {
         let vars: HashMap<String, Value> = vec![
             ("s".to_string(), Value::Text(s.clone())),
         ].into_iter().collect();
-        let lower1 = evaluate("=LOWER(s)", vars);
+        let lower1 = evaluate("=LOWER(s)", &vars);
         if let Value::Text(l) = lower1 {
             let vars2: HashMap<String, Value> = vec![
                 ("s".to_string(), Value::Text(l.clone())),
             ].into_iter().collect();
-            let lower2 = evaluate("=LOWER(s)", vars2);
+            let lower2 = evaluate("=LOWER(s)", &vars2);
             prop_assert_eq!(lower2, Value::Text(l));
         }
     }
@@ -94,7 +94,7 @@ proptest! {
             ("s".to_string(), Value::Text(s.clone())),
             ("n".to_string(), Value::Number(len)),
         ].into_iter().collect();
-        let result = evaluate("=LEFT(s, n)", text_var);
+        let result = evaluate("=LEFT(s, n)", &text_var);
         prop_assert_eq!(result, Value::Text(s));
     }
 }

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -127,7 +127,7 @@ fn tool_evaluate(args: &JsonValue) -> JsonValue {
         None => return json!({ "error": "missing formula" }),
     };
     let vars = parse_variables(&args["variables"]);
-    let value = evaluate(formula, vars);
+    let value = evaluate(formula, &vars);
     value_to_json(&value)
 }
 
@@ -177,7 +177,7 @@ fn tool_batch_evaluate(args: &JsonValue) -> JsonValue {
         .iter()
         .map(|f| {
             let formula = f.as_str().unwrap_or("");
-            let value = evaluate(formula, vars.clone());
+            let value = evaluate(formula, &vars);
             value_to_json(&value)
         })
         .collect();

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -52,7 +52,7 @@ pub fn evaluate(formula: &str, variables: JsValue) -> JsValue {
         None => HashMap::new(),
     };
 
-    let result = ganit_core::evaluate(formula, vars);
+    let result = ganit_core::evaluate(formula, &vars);
     let json_result = value_to_json(result);
     serde_wasm_bindgen::to_value(&json_result).unwrap_or(JsValue::NULL)
 }


### PR DESCRIPTION
Closes #34

## Change

```rust
// Before
pub fn evaluate(formula: &str, variables: HashMap<String, Value>) -> Value

// After
pub fn evaluate(formula: &str, variables: &HashMap<String, Value>) -> Value
```

## Why

Callers were forced to move or `.clone()` the map on every call:
```rust
// Before — had to clone to reuse vars
let r1 = evaluate("SUM(A, B)", vars.clone());
let r2 = evaluate("A + B", vars.clone());

// After — borrow, no clone at call site
let r1 = evaluate("SUM(A, B)", &vars);
let r2 = evaluate("A + B", &vars);
```

The clone now happens once inside `evaluate()` to build the normalised `Context`.

## Breaking change

Pre-1.0, so acceptable. Callers add `&` at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)