### PR TITLE
feat(release): publish @ganit/core to npm + attach binaries on ganit-core tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,48 +2,35 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["ganit-core-v*"]
 
 permissions:
   contents: write
-  id-token: write  # for npm provenance + crates.io trusted publishing
+  id-token: write  # for npm provenance
 
 jobs:
-  publish-crates:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Publish ganit-core
-        run: cargo publish -p ganit-core
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: Publish ganit-mcp
-        run: cargo publish -p ganit-mcp --no-verify
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
   publish-npm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+
       - uses: Swatinem/rust-cache@v2
+
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Install wasm-opt
-        run: cargo install wasm-opt --locked
+
       - name: Build WASM
-        run: wasm-pack build crates/wasm --target bundler
-      - name: Optimize WASM
-        run: wasm-opt -Oz crates/wasm/pkg/ganit_wasm_bg.wasm -o crates/wasm/pkg/ganit_wasm_bg.wasm
+        run: wasm-pack build crates/wasm --target bundler --package-name @ganit/core
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
       - name: Publish to npm
         run: npm publish --provenance --access public
         working-directory: crates/wasm/pkg
@@ -66,28 +53,37 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
       - uses: Swatinem/rust-cache@v2
+
       - name: Build
         run: cargo build -p ganit-mcp --release --target ${{ matrix.target }}
+
+      - name: Rename binary
+        run: mv "target/${{ matrix.target }}/release/ganit-mcp" "${{ matrix.artifact }}"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: target/${{ matrix.target }}/release/ganit-mcp
+          path: ${{ matrix.artifact }}
 
-  github-release:
-    needs: [publish-crates, publish-npm, build-binaries]
+  attach-binaries:
+    needs: build-binaries
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts/
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: artifacts/**/*
+
+      - name: Attach binaries to GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: gh release upload "$TAG" artifacts/**/* --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build WASM
-        run: wasm-pack build crates/wasm --target bundler --package-name @ganit/core
+        run: wasm-pack build crates/wasm --target bundler --package-name @tryganit/core
 
       - uses: actions/setup-node@v4
         with:

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish = false  # published to npm via wasm-pack, not crates.io
+description = "Spreadsheet formula engine for the browser — Excel-compatible formula evaluator compiled to WebAssembly"
+keywords = ["spreadsheet", "formula", "excel", "wasm", "evaluator"]
+repository.workspace = true
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Closes #10

## Changes

### release.yml
- **Trigger**: `v*` → `ganit-core-v*` (matches what release-plz actually creates)
- **Removed**: `publish-crates` job — release-plz already publishes to crates.io
- **Updated**: wasm-pack builds as `@ganit/core` (was unnamed)
- **Removed**: separate `wasm-opt` install step — already handled by `Cargo.toml` metadata
- **Changed**: `github-release` (creates duplicate) → `attach-binaries` (uploads to existing release-plz release)

### crates/wasm/Cargo.toml
- Added `description`, `keywords`, `repository` — surfaced in npm package metadata for discoverability

## What still needs to happen
- Create `ganit` org on npmjs.com
- Add `NPM_TOKEN` secret to repo
- Merge release PR #36 to trigger `ganit-core-v0.1.1` tag → first npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)