### PR TITLE
ci(release): add workflow_dispatch for manual re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     tags: ["ganit-core-v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. ganit-core-v0.1.1)"
+        required: true
 
 permissions:
   contents: write
@@ -85,5 +90,5 @@ jobs:
       - name: Attach binaries to GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
         run: gh release upload "$TAG" artifacts/**/* --clobber


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger with a `tag` input to the Release workflow
- Updates `attach-binaries` job to use the input tag when triggered manually

## Why
`ganit-core-v0.1.1` was created before the Release workflow had the correct trigger (`ganit-core-v*`). The workflow never fired for it. This allows manually triggering the pipeline for any existing tag.

## Usage
Actions → Release → Run workflow → enter `ganit-core-v0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)