### PR TITLE
fix(release): set npm package name via post-build patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,11 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build WASM
-        run: wasm-pack build crates/wasm --target bundler --package-name @tryganit/core
+        run: wasm-pack build crates/wasm --target bundler
+
+      - name: Set npm package name
+        run: node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json')); p.name='@tryganit/core'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
+        working-directory: crates/wasm/pkg
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- `--package-name` is not recognized by the wasm-pack version installed by the official installer
- Replace it with a one-liner that patches `pkg/package.json` after the build to set `"name": "@tryganit/core"`

## Test plan
- [ ] Merge and manually trigger Release workflow with tag `ganit-core-v0.1.1`
- [ ] Confirm `publish-npm` job passes
- [ ] Confirm `@tryganit/core` appears on npmjs.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)