### PR TITLE
docs: add getting started guide for npm consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,102 @@
-# ganit
+# @tryganit/core
+
+WebAssembly-powered spreadsheet formula engine for JavaScript/TypeScript.
+
+## Install
+
+```sh
+npm install @tryganit/core
+```
+
+## Usage
+
+### Node.js (CJS)
+
+Works out of the box — no bundler configuration needed.
+
+```js
+const { evaluate, validate, list_functions } = require('@tryganit/core');
+
+const result = evaluate('SUM(A1, B1)', { A1: 100, B1: 200 });
+// => { type: 'number', value: 300 }
+```
+
+### Vite
+
+Install the wasm plugin first:
+
+```sh
+npm install -D vite-plugin-wasm
+```
+
+Add it to `vite.config.js`:
+
+```js
+import wasm from 'vite-plugin-wasm';
+
+export default {
+  plugins: [wasm()],
+};
+```
+
+Then import and use normally:
+
+```js
+import { evaluate } from '@tryganit/core';
+
+const result = evaluate('IF(A1 > 0, "yes", "no")', { A1: 1 });
+// => { type: 'text', value: 'yes' }
+```
+
+### webpack 5
+
+webpack 5 supports WebAssembly natively. Enable the experiment in `webpack.config.js`:
+
+```js
+module.exports = {
+  experiments: {
+    asyncWebAssembly: true,
+  },
+};
+```
+
+## API
+
+### `evaluate(formula, variables)`
+
+Evaluates a formula with the given variable bindings.
+
+```js
+evaluate('SUM(A1, B1)', { A1: 100, B1: 200 })
+// => { type: 'number', value: 300 }
+
+evaluate('CONCAT("Hello, ", name)', { name: 'world' })
+// => { type: 'text', value: 'Hello, world' }
+```
+
+**Return value shape:**
+
+| `type`    | Shape                            |
+|-----------|----------------------------------|
+| `number`  | `{ type: 'number', value: 6 }`   |
+| `text`    | `{ type: 'text', value: 'yes' }` |
+| `boolean` | `{ type: 'boolean', value: true }`|
+| `error`   | `{ type: 'error', error: '#NAME?' }` |
+| `empty`   | `{ type: 'empty', value: null }` |
+
+### `validate(formula)`
+
+Checks whether a formula is syntactically valid without evaluating it.
+
+```js
+validate('SUM(A1, B1)')  // => { valid: true }
+validate('SUM(A1,')      // => { valid: false, error: '...' }
+```
+
+### `list_functions()`
+
+Returns metadata for all built-in functions.
+
+```js
+const fns = list_functions();
+```


### PR DESCRIPTION
## Summary

- Replaces the placeholder `# ganit` README with a proper getting started guide for `@tryganit/core` npm consumers
- Covers Node.js (CJS), Vite (with `vite-plugin-wasm`), and webpack 5 setup
- Documents all three exported functions: `evaluate()`, `validate()`, `list_functions()`
- Includes return value shapes and a variables-binding example

Closes #41

## Test plan

- [ ] Verify Node.js CJS snippet runs correctly with the published package
- [ ] Verify Vite setup with `vite-plugin-wasm` works as documented
- [ ] Verify webpack 5 `asyncWebAssembly` experiment enables the import
- [ ] Review docs for accuracy against the current public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)