### PR TITLE
fix(wasm): disable wasm-opt to fix SIGSEGV in release build

### DIFF
--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -20,4 +20,4 @@ tsify-next = { version = "0.5", features = ["js"] }
 serde = { version = "1", features = ["derive"] }
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
+wasm-opt = false  # wasm-opt segfaults on this binary; re-enable when wasm-pack ships a fix


### PR DESCRIPTION
## Summary
- `wasm-opt` crashes with SIGSEGV on the tsify-generated WASM binary during the Release workflow
- Disabling `wasm-opt` unblocks publishing; WASM still works, just slightly larger (~265KB unoptimised vs ~200KB optimised)

## After merge
- Merge this PR
- Trigger Release workflow manually: `Actions → Release → Run workflow → ganit-core-v0.1.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)