### PR TITLE
docs: add badges and per-crate READMEs for crates.io and npm

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Spreadsheet formula engine — parser and evaluator for Excel-compatible formulas"
 repository.workspace = true
+readme = "README.md"
 
 [dependencies]
 nom = "8"

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,0 +1,116 @@
+# ganit-core
+
+[![crates.io](https://img.shields.io/crates/v/ganit-core)](https://crates.io/crates/ganit-core)
+[![docs.rs](https://img.shields.io/docsrs/ganit-core)](https://docs.rs/ganit-core)
+[![license](https://img.shields.io/crates/l/ganit-core)](LICENSE)
+
+Spreadsheet formula engine — parser and evaluator for Excel-compatible formulas.
+
+Also available as a WebAssembly npm package: [`@tryganit/core`](https://www.npmjs.com/package/@tryganit/core)
+
+## Install
+
+```toml
+[dependencies]
+ganit-core = "0.1"
+```
+
+Or via cargo:
+
+```sh
+cargo add ganit-core
+```
+
+## Usage
+
+### Evaluate a formula
+
+```rust
+use std::collections::HashMap;
+use ganit_core::{evaluate, Value};
+
+let mut vars = HashMap::new();
+vars.insert("A1".to_string(), Value::Number(100.0));
+vars.insert("B1".to_string(), Value::Number(200.0));
+
+let result = evaluate("SUM(A1, B1)", &vars);
+assert_eq!(result, Value::Number(300.0));
+```
+
+### Pattern match on the result
+
+```rust
+use std::collections::HashMap;
+use ganit_core::{evaluate, Value};
+
+let mut vars = HashMap::new();
+vars.insert("score".to_string(), Value::Number(85.0));
+
+match evaluate("IF(score >= 60, \"pass\", \"fail\")", &vars) {
+    Value::Text(s)   => println!("{s}"),           // "pass"
+    Value::Number(n) => println!("{n}"),
+    Value::Bool(b)   => println!("{b}"),
+    Value::Error(e)  => eprintln!("formula error: {e}"),
+    Value::Empty     => println!("(empty)"),
+    Value::Array(_)  => println!("(array)"),
+}
+```
+
+### Validate without evaluating
+
+```rust
+use ganit_core::validate;
+
+match validate("SUM(A1, B1)") {
+    Ok(_)  => println!("valid"),
+    Err(e) => eprintln!("parse error at position {}: {}", e.position, e.message),
+}
+```
+
+### Parse to an AST
+
+```rust
+use ganit_core::parse;
+
+let expr = parse("1 + 2 * 3").expect("valid formula");
+// expr is an Expr tree you can walk yourself
+```
+
+## Types
+
+### `Value`
+
+| Variant | Description |
+|---------|-------------|
+| `Number(f64)` | Finite numeric value (never NaN or infinity) |
+| `Text(String)` | String value |
+| `Bool(bool)` | Boolean value |
+| `Error(ErrorKind)` | Formula error (e.g. `#DIV/0!`) |
+| `Empty` | Missing/blank cell reference |
+| `Array(Vec<Value>)` | Array of values |
+
+### `ErrorKind`
+
+| Variant | Excel error |
+|---------|-------------|
+| `DivByZero` | `#DIV/0!` |
+| `Value` | `#VALUE!` |
+| `Ref` | `#REF!` |
+| `Name` | `#NAME?` |
+| `Num` | `#NUM!` |
+| `NA` | `#N/A` |
+| `Null` | `#NULL!` |
+
+## Available functions
+
+| Category    | Functions |
+|-------------|-----------|
+| math        | SUM, AVERAGE, PRODUCT, ROUND, ROUNDUP, ROUNDDOWN, INT, ABS, SIGN, MOD, POWER, SQRT, LOG, LOG10, LN, EXP, CEILING, FLOOR, RAND, RANDBETWEEN, PI, SIN, COS, TAN, QUOTIENT |
+| logical     | IF, AND, OR, NOT, IFERROR, IFNA, IFS, SWITCH, ISNUMBER, ISTEXT, ISERROR, ISBLANK, ISNA |
+| text        | LEFT, MID, RIGHT, LEN, LOWER, UPPER, TRIM, CONCATENATE, FIND, SUBSTITUTE, REPLACE, TEXT, VALUE, REPT |
+| financial   | PMT, NPV, IRR, PV, FV, RATE, NPER |
+| statistical | COUNT, COUNTA, MAX, MIN, MEDIAN |
+
+## License
+
+MIT

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -81,13 +81,13 @@ evaluate('CONCAT("Hello, ", name)', { name: 'world' })
 
 **Return value shape:**
 
-| `type`    | Shape                            |
-|-----------|----------------------------------|
-| `number`  | `{ type: 'number', value: 6 }`   |
-| `text`    | `{ type: 'text', value: 'yes' }` |
-| `boolean` | `{ type: 'boolean', value: true }`|
+| `type`    | Shape                                |
+|-----------|--------------------------------------|
+| `number`  | `{ type: 'number', value: 6 }`       |
+| `text`    | `{ type: 'text', value: 'yes' }`     |
+| `boolean` | `{ type: 'boolean', value: true }`   |
 | `error`   | `{ type: 'error', error: '#NAME?' }` |
-| `empty`   | `{ type: 'empty', value: null }` |
+| `empty`   | `{ type: 'empty', value: null }`     |
 
 ### `validate(formula)`
 
@@ -100,8 +100,24 @@ validate('SUM(A1,')      // => { valid: false, error: '...' }
 
 ### `list_functions()`
 
-Returns metadata for all built-in functions.
+Returns metadata for all built-in functions as an array of `{ name, category, syntax, description }`.
 
 ```js
 const fns = list_functions();
+// [
+//   { name: 'SUM',     category: 'math',     syntax: 'SUM(value1, ...)',   description: 'Sum of all arguments' },
+//   { name: 'AVERAGE', category: 'math',     syntax: 'AVERAGE(value1, ...)', description: 'Arithmetic mean of all arguments' },
+//   { name: 'IF',      category: 'logical',  syntax: 'IF(condition, value_if_true, value_if_false)', description: 'Conditional evaluation' },
+//   ...
+// ]
 ```
+
+**Available functions by category:**
+
+| Category   | Functions |
+|------------|-----------|
+| math       | SUM, AVERAGE, PRODUCT, ROUND, ROUNDUP, ROUNDDOWN, INT, ABS, SIGN, MOD, POWER, SQRT, LOG, LOG10, LN, EXP, CEILING, FLOOR, RAND, RANDBETWEEN, PI, SIN, COS, TAN, QUOTIENT |
+| logical    | IF, AND, OR, NOT, IFERROR, IFNA, IFS, SWITCH, ISNUMBER, ISTEXT, ISERROR, ISBLANK, ISNA |
+| text       | LEFT, MID, RIGHT, LEN, LOWER, UPPER, TRIM, CONCATENATE, FIND, SUBSTITUTE, REPLACE, TEXT, VALUE, REPT |
+| financial  | PMT, NPV, IRR, PV, FV, RATE, NPER |
+| statistical | COUNT, COUNTA, MAX, MIN, MEDIAN |

--- a/crates/wasm/package.json
+++ b/crates/wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ganit/engine",
+  "name": "@tryganit/core",
   "publishConfig": {
     "provenance": true,
     "access": "public"


### PR DESCRIPTION
## Summary

- Adds npm / crates.io / docs.rs / license badges to the root `README.md`
- Creates `crates/core/README.md` with Rust API docs (install, usage examples, type tables) so crates.io shows a README instead of the blank page
- Creates `crates/wasm/README.md` with the JS/WASM docs so npm shows a README instead of the blank page
- Adds `readme = \"README.md\"` to `crates/core/Cargo.toml` so crates.io picks it up on next publish
- Fixes `crates/wasm/package.json` name: `@ganit/engine` → `@tryganit/core` (the package was published under `@tryganit/core` but the manifest still had the old name)

## Test plan

- [ ] Verify badges render correctly on the GitHub repo page
- [ ] After next `cargo publish`, check https://crates.io/crates/ganit-core shows the Rust README
- [ ] After next `wasm-pack publish`, check https://www.npmjs.com/package/@tryganit/core shows the JS README

🤖 Generated with [Claude Code](https://claude.com/claude-code)