### PR TITLE
fix(ci): auto-trigger npm release after release-plz publishes

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,6 +16,24 @@ jobs:
         with:
           fetch-depth: 0
       - uses: MarcoIeni/release-plz-action@v0.5
+        id: release-plz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Trigger npm release for ganit-core
+        if: steps.release-plz.outputs.releases != ''
+        env:
+          RELEASES: ${{ steps.release-plz.outputs.releases }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(echo "$RELEASES" | python3 -c "
+          import json, sys
+          releases = json.load(sys.stdin)
+          r = next((r for r in releases if r['package_name'] == 'ganit-core'), None)
+          if r:
+              print(r['tag'])
+          ")
+          if [ -n "$TAG" ]; then
+            gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --field "tag=$TAG"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags: ["ganit-core-v*"]
   workflow_dispatch:
     inputs:
       tag:
@@ -94,5 +92,5 @@ jobs:
       - name: Attach binaries to GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+          TAG: ${{ github.event.inputs.tag }}
         run: gh release upload "$TAG" artifacts/**/* --clobber


### PR DESCRIPTION
## Summary

- `release-plz` creates tags via `GITHUB_TOKEN`, which GitHub silently blocks from firing `push: tags` triggers in other workflows (to prevent loops) — so `release.yml` never ran automatically for `ganit-core-v0.2.x`
- Fix: after `release-plz` runs, parse its `releases` output and dispatch `release.yml` if a `ganit-core` release was created
- Remove the dead `push: tags: ["ganit-core-v*"]` trigger from `release.yml` since it never fired

## Test Plan

- [ ] Merge a change that bumps `ganit-core` — verify `release-plz.yml` dispatches `release.yml` automatically
- [ ] Verify npm `@tryganit/core` gets published with the new version