### PR TITLE
feat(date): implement all 26 M2 date/time functions (closes #75)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "codepage"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +196,7 @@ name = "ganit-core"
 version = "0.2.1"
 dependencies = [
  "calamine",
+ "chrono",
  "nom",
  "proptest",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 
 [dependencies]
 nom = "8"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [dependencies]
 nom = "8"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/core/src/eval/functions/date/date_fn/mod.rs
+++ b/crates/core/src/eval/functions/date/date_fn/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn date_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/date_fn/mod.rs
+++ b/crates/core/src/eval/functions/date/date_fn/mod.rs
@@ -1,8 +1,56 @@
+use chrono::{Datelike, Duration, NaiveDate};
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::date_to_serial;
 use crate::types::{ErrorKind, Value};
 
+/// `DATE(year, month, day)` — returns the spreadsheet serial number for the given date.
+///
+/// Handles month and day overflow/underflow (Google Sheets compatible):
+/// - Month 13 of 2024 → January 2025
+/// - Month 0 of 2024 → December 2023
+/// - Day 0 of March → last day of February
+/// All inputs are truncated to integer before use.
 pub fn date_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 3, 3) {
+        return err;
+    }
+    let year  = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let month = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    let day   = match to_number(args[2].clone()) { Ok(n) => n, Err(e) => return e };
+
+    // Truncate to integers (Google Sheets truncates, not rounds)
+    let mut year_i  = year.trunc() as i64;
+    let month_i = month.trunc() as i64;
+    let day_i   = day.trunc() as i64;
+
+    // Normalize month into 1..=12, adjusting year
+    let month_adj = month_i - 1; // 0-indexed
+    let year_delta = month_adj.div_euclid(12);
+    let month_norm = (month_adj.rem_euclid(12) + 1) as u32; // back to 1-indexed
+    year_i += year_delta;
+
+    if year_i < 0 || year_i > 9999 {
+        return Value::Error(ErrorKind::Num);
+    }
+
+    // Build the 1st of the normalized month, then add (day - 1) days
+    let base = match NaiveDate::from_ymd_opt(year_i as i32, month_norm, 1) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Num),
+    };
+    let date = match base.checked_add_signed(Duration::days(day_i - 1)) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Num),
+    };
+
+    // Ensure within valid spreadsheet range
+    let serial = date_to_serial(date);
+    if serial < 0.0 || date.year() > 9999 {
+        return Value::Error(ErrorKind::Num);
+    }
+
+    Value::Number(serial)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/date_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/date_fn/tests/edge.rs
@@ -1,1 +1,51 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn month_13_overflow() {
+    // DATE(2024,13,1) -> Jan 1 2025 = 45658
+    let args = [Value::Number(2024.0), Value::Number(13.0), Value::Number(1.0)];
+    assert_eq!(date_fn(&args), Value::Number(45658.0));
+}
+
+#[test]
+fn day_32_overflow() {
+    // DATE(2024,1,32) -> Feb 1 2024 = 45323
+    let args = [Value::Number(2024.0), Value::Number(1.0), Value::Number(32.0)];
+    assert_eq!(date_fn(&args), Value::Number(45323.0));
+}
+
+#[test]
+fn month_0_underflow() {
+    // DATE(2024,0,1) -> Dec 1 2023 = 45261
+    let args = [Value::Number(2024.0), Value::Number(0.0), Value::Number(1.0)];
+    assert_eq!(date_fn(&args), Value::Number(45261.0));
+}
+
+#[test]
+fn day_0_prev_month() {
+    // DATE(2024,3,0) -> last day of Feb 2024 = 45351
+    let args = [Value::Number(2024.0), Value::Number(3.0), Value::Number(0.0)];
+    assert_eq!(date_fn(&args), Value::Number(45351.0));
+}
+
+#[test]
+fn negative_day() {
+    // DATE(2024,3,-1) = 45350
+    let args = [Value::Number(2024.0), Value::Number(3.0), Value::Number(-1.0)];
+    assert_eq!(date_fn(&args), Value::Number(45350.0));
+}
+
+#[test]
+fn max_date() {
+    // DATE(9999,12,31) = 2958465
+    let args = [Value::Number(9999.0), Value::Number(12.0), Value::Number(31.0)];
+    assert_eq!(date_fn(&args), Value::Number(2958465.0));
+}
+
+#[test]
+fn decimal_inputs_truncated() {
+    // DATE(2024.9,6.9,15.9) -> same as DATE(2024,6,15) = 45458
+    let args = [Value::Number(2024.9), Value::Number(6.9), Value::Number(15.9)];
+    assert_eq!(date_fn(&args), Value::Number(45458.0));
+}

--- a/crates/core/src/eval/functions/date/date_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/date_fn/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/date_fn/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/date_fn/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/date_fn/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/date_fn/tests/failure.rs
@@ -1,1 +1,25 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    let args = [Value::Number(2024.0), Value::Number(1.0)];
+    assert_eq!(date_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn no_args() {
+    assert_eq!(date_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [Value::Number(2024.0), Value::Number(1.0), Value::Number(15.0), Value::Number(0.0)];
+    assert_eq!(date_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn text_year_value_error() {
+    let args = [Value::Text("abc".to_string()), Value::Number(1.0), Value::Number(1.0)];
+    assert_eq!(date_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/date_fn/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/date_fn/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/date_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/date/date_fn/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/date_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/date/date_fn/tests/success.rs
@@ -1,1 +1,32 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn basic_date_2024_01_15() {
+    let args = [Value::Number(2024.0), Value::Number(1.0), Value::Number(15.0)];
+    assert_eq!(date_fn(&args), Value::Number(45306.0));
+}
+
+#[test]
+fn basic_date_2024_06_15() {
+    let args = [Value::Number(2024.0), Value::Number(6.0), Value::Number(15.0)];
+    assert_eq!(date_fn(&args), Value::Number(45458.0));
+}
+
+#[test]
+fn jan_1_1900() {
+    let args = [Value::Number(1900.0), Value::Number(1.0), Value::Number(1.0)];
+    assert_eq!(date_fn(&args), Value::Number(2.0));
+}
+
+#[test]
+fn leap_day_2000() {
+    let args = [Value::Number(2000.0), Value::Number(2.0), Value::Number(29.0)];
+    assert_eq!(date_fn(&args), Value::Number(36585.0));
+}
+
+#[test]
+fn leap_day_2024() {
+    let args = [Value::Number(2024.0), Value::Number(2.0), Value::Number(29.0)];
+    assert_eq!(date_fn(&args), Value::Number(45351.0));
+}

--- a/crates/core/src/eval/functions/date/datedif/mod.rs
+++ b/crates/core/src/eval/functions/date/datedif/mod.rs
@@ -1,8 +1,93 @@
+use chrono::{Datelike, NaiveDate};
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::serial_to_date;
 use crate::types::{ErrorKind, Value};
 
+/// `DATEDIF(start_date, end_date, unit)` — difference between two dates.
 pub fn datedif_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 3, 3) {
+        return e;
+    }
+    let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let end_serial   = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+
+    let unit = match &args[2] {
+        Value::Text(s) => s.to_uppercase(),
+        _ => return Value::Error(ErrorKind::Num),
+    };
+
+    let start = match serial_to_date(start_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Num),
+    };
+    let end = match serial_to_date(end_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Num),
+    };
+
+    if start > end {
+        return Value::Error(ErrorKind::Num);
+    }
+
+    match unit.as_str() {
+        "Y" => {
+            let years = end.year() - start.year();
+            let had_anniversary = (end.month(), end.day()) >= (start.month(), start.day());
+            Value::Number(if had_anniversary { years } else { years - 1 } as f64)
+        }
+        "M" => {
+            let months = (end.year() - start.year()) * 12
+                + (end.month() as i32 - start.month() as i32);
+            let had_day_pass = end.day() >= start.day();
+            Value::Number(if had_day_pass { months } else { months - 1 } as f64)
+        }
+        "D" => {
+            Value::Number((end - start).num_days() as f64)
+        }
+        "MD" => {
+            // Complete months elapsed from start to end, then measure remaining days.
+            let total_months = (end.year() - start.year()) * 12
+                + (end.month() as i32 - start.month() as i32);
+            let had_day_pass = end.day() >= start.day();
+            let complete_months = if had_day_pass { total_months } else { total_months - 1 };
+            let adjusted_start = add_months(start, complete_months);
+            Value::Number((end - adjusted_start).num_days() as f64)
+        }
+        "YM" => {
+            let total_months = (end.year() - start.year()) * 12
+                + (end.month() as i32 - start.month() as i32);
+            let had_day_pass = end.day() >= start.day();
+            let complete_months = if had_day_pass { total_months } else { total_months - 1 };
+            Value::Number((complete_months % 12) as f64)
+        }
+        "YD" => {
+            // Days from start to end as if they were in the same year (start's year).
+            let same_year_end = NaiveDate::from_ymd_opt(start.year(), end.month(), end.day())
+                .or_else(|| NaiveDate::from_ymd_opt(start.year(), end.month() + 1, 1))
+                .unwrap();
+            let days = if same_year_end >= start {
+                (same_year_end - start).num_days()
+            } else {
+                let next_year_end = NaiveDate::from_ymd_opt(start.year() + 1, end.month(), end.day())
+                    .or_else(|| NaiveDate::from_ymd_opt(start.year() + 1, end.month() + 1, 1))
+                    .unwrap();
+                (next_year_end - start).num_days()
+            };
+            Value::Number(days as f64)
+        }
+        _ => Value::Error(ErrorKind::Num),
+    }
+}
+
+/// Add `months` months to a date, clamping to end-of-month on overflow.
+fn add_months(date: NaiveDate, months: i32) -> NaiveDate {
+    let total_months = date.year() * 12 + date.month() as i32 - 1 + months;
+    let year = total_months / 12;
+    let month = (total_months % 12 + 1) as u32;
+    NaiveDate::from_ymd_opt(year, month, date.day())
+        .or_else(|| NaiveDate::from_ymd_opt(year, month + 1, 1))
+        .unwrap()
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/datedif/mod.rs
+++ b/crates/core/src/eval/functions/date/datedif/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn datedif_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/datedif/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/datedif/tests/edge.rs
@@ -1,1 +1,51 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+fn num(serial: f64) -> Value {
+    Value::Number(serial)
+}
+
+// Serials:
+//   DATE(2024,6,14) = 45457
+//   DATE(2024,6,15) = 45458
+//   DATE(2024,2,1)  = 45323
+//   DATE(2024,3,1)  = 45352
+//   DATE(2023,3,1)  = 44986
+//   DATE(2025,3,1)  = 45717
+//   DATE(2024,1,1)  = 45292
+//   DATE(2024,1,31) = 45322
+
+#[test]
+fn d_same_day_is_zero() {
+    // DATEDIF(DATE(2024,6,15), DATE(2024,6,15), "D") = 0
+    let args = [num(45458.0), num(45458.0), Value::Text("D".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(0.0));
+}
+
+#[test]
+fn d_one_day_apart() {
+    // DATEDIF(DATE(2024,6,14), DATE(2024,6,15), "D") = 1
+    let args = [num(45457.0), num(45458.0), Value::Text("D".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn d_across_leap_day_feb_2024() {
+    // DATEDIF(DATE(2024,2,1), DATE(2024,3,1), "D") = 29
+    let args = [num(45323.0), num(45352.0), Value::Text("D".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(29.0));
+}
+
+#[test]
+fn y_crossing_leap_year() {
+    // DATEDIF(DATE(2023,3,1), DATE(2025,3,1), "Y") = 2
+    let args = [num(44986.0), num(45717.0), Value::Text("Y".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(2.0));
+}
+
+#[test]
+fn d_30_day_span() {
+    // DATEDIF(DATE(2024,1,1), DATE(2024,1,31), "D") = 30
+    let args = [num(45292.0), num(45322.0), Value::Text("D".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(30.0));
+}

--- a/crates/core/src/eval/functions/date/datedif/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/datedif/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/datedif/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/datedif/tests/failure.rs
@@ -1,1 +1,31 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+fn num(serial: f64) -> Value {
+    Value::Number(serial)
+}
+
+#[test]
+fn too_few_args() {
+    assert_eq!(datedif_fn(&[num(45292.0), num(45458.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [num(45292.0), num(45458.0), Value::Text("D".into()), num(0.0)];
+    assert_eq!(datedif_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn start_greater_than_end_returns_num() {
+    // DATEDIF(DATE(2024,6,15), DATE(2024,1,1), "D") → #NUM!
+    let args = [num(45458.0), num(45292.0), Value::Text("D".into())];
+    assert_eq!(datedif_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn invalid_unit_returns_num() {
+    // DATEDIF(DATE(2024,1,1), DATE(2024,6,15), "X") → #NUM!
+    let args = [num(45292.0), num(45458.0), Value::Text("X".into())];
+    assert_eq!(datedif_fn(&args), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/date/datedif/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/datedif/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/datedif/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/datedif/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/datedif/tests/success.rs
+++ b/crates/core/src/eval/functions/date/datedif/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/datedif/tests/success.rs
+++ b/crates/core/src/eval/functions/date/datedif/tests/success.rs
@@ -1,1 +1,68 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+fn num(serial: f64) -> Value {
+    Value::Number(serial)
+}
+
+// Serials precomputed from epoch 1899-12-30:
+//   DATE(2020,1,1) = 43831
+//   DATE(2024,1,1) = 45292
+//   DATE(2024,6,15) = 45458
+//   DATE(2024,1,5) = 45296
+//   DATE(2024,12,31) = 45657
+
+#[test]
+fn y_2020_to_2024_jun15() {
+    // DATEDIF(DATE(2020,1,1), DATE(2024,6,15), "Y") = 4
+    let args = [num(43831.0), num(45458.0), Value::Text("Y".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(4.0));
+}
+
+#[test]
+fn m_2020_to_2024_jun15() {
+    // DATEDIF(DATE(2020,1,1), DATE(2024,6,15), "M") = 53
+    let args = [num(43831.0), num(45458.0), Value::Text("M".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(53.0));
+}
+
+#[test]
+fn d_jan_to_jun_2024() {
+    // DATEDIF(DATE(2024,1,1), DATE(2024,6,15), "D") = 166
+    let args = [num(45292.0), num(45458.0), Value::Text("D".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(166.0));
+}
+
+#[test]
+fn md_days_ignoring_month_year() {
+    // DATEDIF(DATE(2024,1,5), DATE(2024,6,15), "MD") = 10
+    let args = [num(45296.0), num(45458.0), Value::Text("MD".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(10.0));
+}
+
+#[test]
+fn ym_months_ignoring_year() {
+    // DATEDIF(DATE(2020,1,1), DATE(2024,6,15), "YM") = 5
+    let args = [num(43831.0), num(45458.0), Value::Text("YM".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(5.0));
+}
+
+#[test]
+fn yd_days_ignoring_year() {
+    // DATEDIF(DATE(2020,1,1), DATE(2024,6,15), "YD") = 166
+    let args = [num(43831.0), num(45458.0), Value::Text("YD".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(166.0));
+}
+
+#[test]
+fn y_within_same_year() {
+    // DATEDIF(DATE(2024,1,1), DATE(2024,12,31), "Y") = 0
+    let args = [num(45292.0), num(45657.0), Value::Text("Y".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(0.0));
+}
+
+#[test]
+fn unit_is_case_insensitive() {
+    let args = [num(43831.0), num(45458.0), Value::Text("y".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(4.0));
+}

--- a/crates/core/src/eval/functions/date/datevalue/mod.rs
+++ b/crates/core/src/eval/functions/date/datevalue/mod.rs
@@ -1,8 +1,45 @@
+use chrono::NaiveDate;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::date_to_serial;
 use crate::types::{ErrorKind, Value};
 
+/// `DATEVALUE(date_text)` — parses a date string and returns its serial number.
+///
+/// Supports common formats: ISO (YYYY-MM-DD), US slash (M/D/YYYY), and long/short month names.
+/// Returns `Value::Error(ErrorKind::Value)` for unparseable or invalid strings.
 pub fn datevalue_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let text = match &args[0] {
+        Value::Text(s) => s.clone(),
+        Value::Error(_) => return args[0].clone(),
+        _ => return Value::Error(ErrorKind::Value),
+    };
+
+    if text.is_empty() {
+        return Value::Error(ErrorKind::Value);
+    }
+
+    let formats = [
+        "%m/%d/%Y",
+        "%m/%d/%y",
+        "%Y-%m-%d",
+        "%d-%b-%Y",
+        "%d-%b-%y",
+        "%B %d, %Y",
+        "%b %d, %Y",
+        "%B %d %Y",
+        "%b %d %Y",
+    ];
+
+    for fmt in &formats {
+        if let Ok(date) = NaiveDate::parse_from_str(&text, fmt) {
+            return Value::Number(date_to_serial(date));
+        }
+    }
+
+    Value::Error(ErrorKind::Value)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/datevalue/mod.rs
+++ b/crates/core/src/eval/functions/date/datevalue/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn datevalue_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/datevalue/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/datevalue/tests/edge.rs
@@ -1,1 +1,14 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn leap_day_2024() {
+    let args = [Value::Text("2024-02-29".to_string())];
+    assert_eq!(datevalue_fn(&args), Value::Number(45351.0));
+}
+
+#[test]
+fn invalid_feb29_non_leap() {
+    let args = [Value::Text("2023-02-29".to_string())];
+    assert_eq!(datevalue_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/datevalue/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/datevalue/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/datevalue/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/datevalue/tests/failure.rs
@@ -1,1 +1,31 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(datevalue_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [Value::Text("2024-01-15".to_string()), Value::Text("extra".to_string())];
+    assert_eq!(datevalue_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_string() {
+    let args = [Value::Text("abc".to_string())];
+    assert_eq!(datevalue_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn empty_string() {
+    let args = [Value::Text("".to_string())];
+    assert_eq!(datevalue_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_string_arg() {
+    let args = [Value::Number(45306.0)];
+    assert_eq!(datevalue_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/datevalue/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/datevalue/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/datevalue/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/datevalue/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/datevalue/tests/success.rs
+++ b/crates/core/src/eval/functions/date/datevalue/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/datevalue/tests/success.rs
+++ b/crates/core/src/eval/functions/date/datevalue/tests/success.rs
@@ -1,1 +1,32 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn iso_format() {
+    let args = [Value::Text("2024-01-15".to_string())];
+    assert_eq!(datevalue_fn(&args), Value::Number(45306.0));
+}
+
+#[test]
+fn us_slash_format() {
+    let args = [Value::Text("1/15/2024".to_string())];
+    assert_eq!(datevalue_fn(&args), Value::Number(45306.0));
+}
+
+#[test]
+fn long_month_name() {
+    let args = [Value::Text("January 15, 2024".to_string())];
+    assert_eq!(datevalue_fn(&args), Value::Number(45306.0));
+}
+
+#[test]
+fn short_month_name() {
+    let args = [Value::Text("Jan 15, 2024".to_string())];
+    assert_eq!(datevalue_fn(&args), Value::Number(45306.0));
+}
+
+#[test]
+fn zero_padded_slash() {
+    let args = [Value::Text("06/15/2024".to_string())];
+    assert_eq!(datevalue_fn(&args), Value::Number(45458.0));
+}

--- a/crates/core/src/eval/functions/date/day/mod.rs
+++ b/crates/core/src/eval/functions/date/day/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn day_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/day/mod.rs
+++ b/crates/core/src/eval/functions/date/day/mod.rs
@@ -1,8 +1,24 @@
+use chrono::Datelike;
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{serial_to_date, text_to_date_serial};
 use crate::types::{ErrorKind, Value};
 
 pub fn day_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 1, 1) { return e; }
+    let serial = match coerce_to_date_serial(&args[0]) { Ok(n) => n, Err(e) => return e };
+    match serial_to_date(serial) {
+        Some(d) => Value::Number(d.day() as f64),
+        None => Value::Error(ErrorKind::Num),
+    }
+}
+
+fn coerce_to_date_serial(v: &Value) -> Result<f64, Value> {
+    match v {
+        Value::Text(s) => text_to_date_serial(s)
+            .ok_or(Value::Error(ErrorKind::Value)),
+        other => to_number(other.clone()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/day/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/day/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/day/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/day/tests/edge.rs
@@ -1,1 +1,26 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn serial_zero_is_day_30() {
+    // serial 0 = Dec 30 1899
+    assert_eq!(day_fn(&[Value::Number(0.0)]), Value::Number(30.0));
+}
+
+#[test]
+fn serial_1_is_day_31() {
+    // oracle: DAY(1) = 31 (Dec 31 1899)
+    assert_eq!(day_fn(&[Value::Number(1.0)]), Value::Number(31.0));
+}
+
+#[test]
+fn serial_60_excel_bug() {
+    // oracle: DAY(60) = 28 (Feb 28 1900, phantom Feb 29)
+    assert_eq!(day_fn(&[Value::Number(60.0)]), Value::Number(28.0));
+}
+
+#[test]
+fn negative_serial_returns_valid_day() {
+    // serial -1 = Dec 29 1899 — negative serials are valid (pre-1900 dates)
+    assert_eq!(day_fn(&[Value::Number(-1.0)]), Value::Number(29.0));
+}

--- a/crates/core/src/eval/functions/date/day/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/day/tests/failure.rs
@@ -1,1 +1,17 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(day_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    assert_eq!(day_fn(&[Value::Number(1.0), Value::Number(2.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn text_arg() {
+    assert_eq!(day_fn(&[Value::Text("abc".to_string())]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/day/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/day/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/day/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/day/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/day/tests/success.rs
+++ b/crates/core/src/eval/functions/date/day/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/day/tests/success.rs
+++ b/crates/core/src/eval/functions/date/day/tests/success.rs
@@ -1,1 +1,26 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn day_15th() {
+    // DATE(2024,6,15) = serial 45458
+    assert_eq!(day_fn(&[Value::Number(45458.0)]), Value::Number(15.0));
+}
+
+#[test]
+fn day_first() {
+    // DATE(2024,1,1) = serial 45292
+    assert_eq!(day_fn(&[Value::Number(45292.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn day_31st() {
+    // DATE(2024,1,31) = serial 45322
+    assert_eq!(day_fn(&[Value::Number(45322.0)]), Value::Number(31.0));
+}
+
+#[test]
+fn day_feb29_leap() {
+    // DATE(2024,2,29) = serial 45351
+    assert_eq!(day_fn(&[Value::Number(45351.0)]), Value::Number(29.0));
+}

--- a/crates/core/src/eval/functions/date/days/mod.rs
+++ b/crates/core/src/eval/functions/date/days/mod.rs
@@ -1,8 +1,16 @@
-use crate::types::{ErrorKind, Value};
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
 
+/// `DAYS(end_date, start_date)` — number of days between two serial dates.
+/// Returns end_serial - start_serial as an integer.
 pub fn days_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 2, 2) {
+        return e;
+    }
+    let end   = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let start = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    Value::Number(end.floor() - start.floor())
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/days/mod.rs
+++ b/crates/core/src/eval/functions/date/days/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn days_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/days/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/days/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/days/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/days/tests/edge.rs
@@ -1,1 +1,41 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+// Oracle: DAYS(DATE(2024,6,15), DATE(2024,6,15)) = 0
+#[test]
+fn same_day_zero() {
+    let args = [Value::Number(45458.0), Value::Number(45458.0)];
+    assert_eq!(days_fn(&args), Value::Number(0.0));
+}
+
+// Oracle: DAYS(DATE(2024,3,1), DATE(2024,2,1)) = 29 (leap year)
+#[test]
+fn across_leap_day_feb_2024() {
+    // DATE(2024,3,1) = 45352, DATE(2024,2,1) = 45323
+    let args = [Value::Number(45352.0), Value::Number(45323.0)];
+    assert_eq!(days_fn(&args), Value::Number(29.0));
+}
+
+// Oracle: DAYS(DATE(2025,1,1), DATE(2024,1,1)) = 366 (leap year 2024)
+#[test]
+fn full_leap_year_2024() {
+    // DATE(2025,1,1) = 45658, DATE(2024,1,1) = 45292
+    let args = [Value::Number(45658.0), Value::Number(45292.0)];
+    assert_eq!(days_fn(&args), Value::Number(366.0));
+}
+
+// Oracle: DAYS(DATE(2024,1,1), DATE(2023,1,1)) = 365
+#[test]
+fn full_non_leap_year_2023() {
+    // DATE(2024,1,1) = 45292, DATE(2023,1,1) = 44927
+    let args = [Value::Number(45292.0), Value::Number(44927.0)];
+    assert_eq!(days_fn(&args), Value::Number(365.0));
+}
+
+// Fractional serials: floor is applied
+#[test]
+fn fractional_serials_floored() {
+    // 45458.9 and 45292.1 should use floors 45458 and 45292
+    let args = [Value::Number(45458.9), Value::Number(45292.1)];
+    assert_eq!(days_fn(&args), Value::Number(166.0));
+}

--- a/crates/core/src/eval/functions/date/days/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/days/tests/failure.rs
@@ -1,1 +1,25 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    assert_eq!(days_fn(&[Value::Number(45458.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [Value::Number(45458.0), Value::Number(45292.0), Value::Number(0.0)];
+    assert_eq!(days_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_end() {
+    let args = [Value::Text("bad".to_string()), Value::Number(45292.0)];
+    assert_eq!(days_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_start() {
+    let args = [Value::Number(45458.0), Value::Text("bad".to_string())];
+    assert_eq!(days_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/days/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/days/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/days/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/days/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/days/tests/success.rs
+++ b/crates/core/src/eval/functions/date/days/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/days/tests/success.rs
+++ b/crates/core/src/eval/functions/date/days/tests/success.rs
@@ -1,1 +1,23 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+// Oracle: DAYS(DATE(2024,6,15), DATE(2024,1,1)) = 166
+#[test]
+fn forward_jan_to_jun_2024() {
+    let args = [Value::Number(45458.0), Value::Number(45292.0)];
+    assert_eq!(days_fn(&args), Value::Number(166.0));
+}
+
+// Oracle: DAYS(DATE(2024,1,1), DATE(2024,6,15)) = -166
+#[test]
+fn backward_negative() {
+    let args = [Value::Number(45292.0), Value::Number(45458.0)];
+    assert_eq!(days_fn(&args), Value::Number(-166.0));
+}
+
+// Oracle: DAYS(DATE(2024,1,2), DATE(2024,1,1)) = 1
+#[test]
+fn one_day() {
+    let args = [Value::Number(45293.0), Value::Number(45292.0)];
+    assert_eq!(days_fn(&args), Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/date/days360/mod.rs
+++ b/crates/core/src/eval/functions/date/days360/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn days360_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/days360/mod.rs
+++ b/crates/core/src/eval/functions/date/days360/mod.rs
@@ -1,8 +1,75 @@
+use chrono::Datelike;
+use crate::eval::coercion::{to_bool, to_number};
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::serial_to_date;
 use crate::types::{ErrorKind, Value};
 
+/// `DAYS360(start_date, end_date, [method])` — days between dates on a 360-day calendar.
+///
+/// Every month is treated as 30 days.
+/// method=FALSE (default): US (NASD) convention.
+/// method=TRUE: European convention.
 pub fn days360_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 2, 3) {
+        return e;
+    }
+    let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let end_serial   = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+
+    let european = if args.len() == 3 {
+        match to_bool(args[2].clone()) { Ok(b) => b, Err(e) => return e }
+    } else {
+        false
+    };
+
+    let start_date = match serial_to_date(start_serial) {
+        Some(d) => d,
+        None    => return Value::Error(ErrorKind::Num),
+    };
+    let end_date = match serial_to_date(end_serial) {
+        Some(d) => d,
+        None    => return Value::Error(ErrorKind::Num),
+    };
+
+    let y1 = start_date.year();
+    let m1 = start_date.month() as i32;
+    let mut d1 = start_date.day() as i32;
+
+    let y2 = end_date.year();
+    let m2 = end_date.month() as i32;
+    let mut d2 = end_date.day() as i32;
+
+    if european {
+        if d1 == 31 { d1 = 30; }
+        if d2 == 31 { d2 = 30; }
+    } else {
+        // US (NASD) method
+        let start_is_feb_end = m1 == 2 && is_last_day_of_month(start_date);
+        let end_is_feb_end   = m2 == 2 && is_last_day_of_month(end_date);
+
+        if start_is_feb_end {
+            d1 = 30;
+        } else if d1 == 31 {
+            d1 = 30;
+        }
+
+        if start_is_feb_end && end_is_feb_end {
+            d2 = 30;
+        } else if d2 == 31 && d1 == 30 {
+            d2 = 30;
+        }
+    }
+
+    let result = (y2 - y1) * 360 + (m2 - m1) * 30 + (d2 - d1);
+    Value::Number(result as f64)
+}
+
+fn is_last_day_of_month(date: chrono::NaiveDate) -> bool {
+    // The last day of a month is when adding 1 day changes the month
+    match date.succ_opt() {
+        Some(next) => next.month() != date.month(),
+        None => true, // at max date, treat as last day
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/days360/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/days360/tests/edge.rs
@@ -1,1 +1,41 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+// Oracle: DAYS360(DATE(2024,6,15), DATE(2024,6,15)) = 0
+#[test]
+fn same_day_zero() {
+    let args = [Value::Number(45458.0), Value::Number(45458.0)];
+    assert_eq!(days360_fn(&args), Value::Number(0.0));
+}
+
+// Oracle: DAYS360(DATE(2024,1,31), DATE(2024,2,28), FALSE) = 28
+// Jan 31 -> d1=30; Feb 28 is not 31 so d2 stays 28; result = 0*360+1*30+(28-30)=28
+#[test]
+fn us_jan31_to_feb28() {
+    // DATE(2024,1,31)=45322, DATE(2024,2,28)=45350
+    let args = [Value::Number(45322.0), Value::Number(45350.0), Value::Bool(false)];
+    assert_eq!(days360_fn(&args), Value::Number(28.0));
+}
+
+// Oracle: DAYS360(DATE(2024,1,31), DATE(2024,2,28), TRUE) = 28
+// Euro: d1=31->30, d2=28 (not 31, no change); result = 0*360+1*30+(28-30)=28
+#[test]
+fn euro_jan31_to_feb28() {
+    let args = [Value::Number(45322.0), Value::Number(45350.0), Value::Bool(true)];
+    assert_eq!(days360_fn(&args), Value::Number(28.0));
+}
+
+// Oracle: DAYS360(DATE(2024,4,1), DATE(2024,1,1)) = -90
+#[test]
+fn backward_negative() {
+    let args = [Value::Number(45383.0), Value::Number(45292.0)];
+    assert_eq!(days360_fn(&args), Value::Number(-90.0));
+}
+
+// US: Feb 29 (leap, last day of feb) as start, Feb 29 as end -> both set to 30 -> 0
+#[test]
+fn us_feb_end_to_feb_end_same_month() {
+    // DATE(2024,2,29)=45351
+    let args = [Value::Number(45351.0), Value::Number(45351.0), Value::Bool(false)];
+    assert_eq!(days360_fn(&args), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/date/days360/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/days360/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/days360/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/days360/tests/failure.rs
@@ -1,1 +1,25 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    assert_eq!(days360_fn(&[Value::Number(45292.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [Value::Number(45292.0), Value::Number(45657.0), Value::Bool(false), Value::Number(0.0)];
+    assert_eq!(days360_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_start() {
+    let args = [Value::Text("bad".to_string()), Value::Number(45657.0)];
+    assert_eq!(days360_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_end() {
+    let args = [Value::Number(45292.0), Value::Text("bad".to_string())];
+    assert_eq!(days360_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/days360/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/days360/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/days360/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/days360/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/days360/tests/success.rs
+++ b/crates/core/src/eval/functions/date/days360/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/days360/tests/success.rs
+++ b/crates/core/src/eval/functions/date/days360/tests/success.rs
@@ -1,1 +1,32 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+// Oracle: DAYS360(DATE(2024,1,1), DATE(2024,12,31), FALSE) = 360
+#[test]
+fn us_full_year() {
+    // DATE(2024,1,1)=45292, DATE(2024,12,31)=45657
+    let args = [Value::Number(45292.0), Value::Number(45657.0), Value::Bool(false)];
+    assert_eq!(days360_fn(&args), Value::Number(360.0));
+}
+
+// Oracle: DAYS360(DATE(2024,1,1), DATE(2024,12,31), TRUE) = 359
+#[test]
+fn euro_full_year() {
+    let args = [Value::Number(45292.0), Value::Number(45657.0), Value::Bool(true)];
+    assert_eq!(days360_fn(&args), Value::Number(359.0));
+}
+
+// Oracle: DAYS360(DATE(2024,1,1), DATE(2024,4,1), FALSE) = 90
+#[test]
+fn us_jan_to_apr() {
+    // DATE(2024,4,1)=45383
+    let args = [Value::Number(45292.0), Value::Number(45383.0), Value::Bool(false)];
+    assert_eq!(days360_fn(&args), Value::Number(90.0));
+}
+
+// Oracle: DAYS360(DATE(2024,1,1), DATE(2024,4,1)) = 90 (method omitted, defaults to US)
+#[test]
+fn default_us_method() {
+    let args = [Value::Number(45292.0), Value::Number(45383.0)];
+    assert_eq!(days360_fn(&args), Value::Number(90.0));
+}

--- a/crates/core/src/eval/functions/date/edate/mod.rs
+++ b/crates/core/src/eval/functions/date/edate/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn edate_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/edate/mod.rs
+++ b/crates/core/src/eval/functions/date/edate/mod.rs
@@ -1,8 +1,38 @@
+use chrono::Months;
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{date_to_serial, serial_to_date};
 use crate::types::{ErrorKind, Value};
 
+/// `EDATE(start_date, months)` — serial date N whole months from start_date.
+///
+/// If the resulting month has fewer days, clamps to the last day of that month.
+/// Negative months move backward.
 pub fn edate_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 2, 2) {
+        return e;
+    }
+    let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let months_f     = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+
+    let date = match serial_to_date(start_serial) {
+        Some(d) => d,
+        None    => return Value::Error(ErrorKind::Num),
+    };
+
+    let months = months_f.trunc() as i64;
+    let months_u32 = months.unsigned_abs() as u32;
+
+    let result = if months >= 0 {
+        date.checked_add_months(Months::new(months_u32))
+    } else {
+        date.checked_sub_months(Months::new(months_u32))
+    };
+
+    match result {
+        Some(d) => Value::Number(date_to_serial(d)),
+        None    => Value::Error(ErrorKind::Num),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/edate/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/edate/tests/edge.rs
@@ -1,1 +1,38 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+// Oracle: EDATE(DATE(2024,1,31), 1) = 45351 = DATE(2024,2,29) (leap year snap)
+#[test]
+fn jan31_plus_one_snaps_to_feb29_leap() {
+    let args = [Value::Number(45322.0), Value::Number(1.0)];
+    assert_eq!(edate_fn(&args), Value::Number(45351.0));
+}
+
+// Oracle: EDATE(DATE(2024,1,31), 2) = 45382 = DATE(2024,3,31)
+#[test]
+fn jan31_plus_two_is_mar31() {
+    let args = [Value::Number(45322.0), Value::Number(2.0)];
+    assert_eq!(edate_fn(&args), Value::Number(45382.0));
+}
+
+// Oracle: EDATE(DATE(2024,3,31), -1) = 45351 = DATE(2024,2,29) (leap year snap)
+#[test]
+fn mar31_minus_one_snaps_to_feb29_leap() {
+    let args = [Value::Number(45382.0), Value::Number(-1.0)];
+    assert_eq!(edate_fn(&args), Value::Number(45351.0));
+}
+
+// Oracle: EDATE(DATE(2024,1,15), 13) = 45703 = DATE(2025,2,15) (year rollover)
+#[test]
+fn year_rollover_plus_13_months() {
+    let args = [Value::Number(45306.0), Value::Number(13.0)];
+    assert_eq!(edate_fn(&args), Value::Number(45703.0));
+}
+
+// Fractional months: truncated (1.9 treated as 1)
+#[test]
+fn fractional_months_truncated() {
+    let args_int = [Value::Number(45306.0), Value::Number(1.0)];
+    let args_frac = [Value::Number(45306.0), Value::Number(1.9)];
+    assert_eq!(edate_fn(&args_int), edate_fn(&args_frac));
+}

--- a/crates/core/src/eval/functions/date/edate/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/edate/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/edate/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/edate/tests/failure.rs
@@ -1,1 +1,25 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    assert_eq!(edate_fn(&[Value::Number(45306.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [Value::Number(45306.0), Value::Number(1.0), Value::Number(0.0)];
+    assert_eq!(edate_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_start() {
+    let args = [Value::Text("bad".to_string()), Value::Number(1.0)];
+    assert_eq!(edate_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_months() {
+    let args = [Value::Number(45306.0), Value::Text("bad".to_string())];
+    assert_eq!(edate_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/edate/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/edate/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/edate/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/edate/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/edate/tests/success.rs
+++ b/crates/core/src/eval/functions/date/edate/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/edate/tests/success.rs
+++ b/crates/core/src/eval/functions/date/edate/tests/success.rs
@@ -1,1 +1,38 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+// Oracle: EDATE(DATE(2024,1,15), 1) = 45337 = DATE(2024,2,15)
+#[test]
+fn add_one_month() {
+    let args = [Value::Number(45306.0), Value::Number(1.0)];
+    assert_eq!(edate_fn(&args), Value::Number(45337.0));
+}
+
+// Oracle: EDATE(DATE(2024,1,15), 6) = 45488 = DATE(2024,7,15)
+#[test]
+fn add_six_months() {
+    let args = [Value::Number(45306.0), Value::Number(6.0)];
+    assert_eq!(edate_fn(&args), Value::Number(45488.0));
+}
+
+// Oracle: EDATE(DATE(2024,6,15), -1) = 45427 = DATE(2024,5,15)
+#[test]
+fn subtract_one_month() {
+    // DATE(2024,5,15) = 45427
+    let args = [Value::Number(45458.0), Value::Number(-1.0)];
+    assert_eq!(edate_fn(&args), Value::Number(45427.0));
+}
+
+// Oracle: EDATE(DATE(2024,6,15), -12) = 45092 = DATE(2023,6,15)
+#[test]
+fn subtract_twelve_months() {
+    let args = [Value::Number(45458.0), Value::Number(-12.0)];
+    assert_eq!(edate_fn(&args), Value::Number(45092.0));
+}
+
+// Oracle: EDATE(DATE(2024,6,15), 0) = 45458 (same date)
+#[test]
+fn zero_months_same_date() {
+    let args = [Value::Number(45458.0), Value::Number(0.0)];
+    assert_eq!(edate_fn(&args), Value::Number(45458.0));
+}

--- a/crates/core/src/eval/functions/date/eomonth/mod.rs
+++ b/crates/core/src/eval/functions/date/eomonth/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn eomonth_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/eomonth/mod.rs
+++ b/crates/core/src/eval/functions/date/eomonth/mod.rs
@@ -1,8 +1,50 @@
+use chrono::{Datelike, Duration, Months, NaiveDate};
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{date_to_serial, serial_to_date};
 use crate::types::{ErrorKind, Value};
 
+/// `EOMONTH(start_date, months)` — serial of the last day of the month N months away.
+///
+/// Same month arithmetic as EDATE, but always returns the last day of the target month.
 pub fn eomonth_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 2, 2) {
+        return e;
+    }
+    let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let months_f     = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+
+    let date = match serial_to_date(start_serial) {
+        Some(d) => d,
+        None    => return Value::Error(ErrorKind::Num),
+    };
+
+    let months = months_f.trunc() as i64;
+    let months_u32 = months.unsigned_abs() as u32;
+
+    let target = if months >= 0 {
+        date.checked_add_months(Months::new(months_u32))
+    } else {
+        date.checked_sub_months(Months::new(months_u32))
+    };
+
+    let target_date = match target {
+        Some(d) => d,
+        None    => return Value::Error(ErrorKind::Num),
+    };
+
+    let last_day = last_day_of_month(target_date.year(), target_date.month());
+    Value::Number(date_to_serial(last_day))
+}
+
+fn last_day_of_month(year: i32, month: u32) -> NaiveDate {
+    // First day of next month minus one day
+    let first_of_next = if month == 12 {
+        NaiveDate::from_ymd_opt(year + 1, 1, 1)
+    } else {
+        NaiveDate::from_ymd_opt(year, month + 1, 1)
+    };
+    first_of_next.unwrap() - Duration::days(1)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/eomonth/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/eomonth/tests/edge.rs
@@ -1,1 +1,33 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+// Oracle: EOMONTH(DATE(2024,12,1), 1) = 45688 = Jan 31, 2025 (year rollover)
+#[test]
+fn plus_one_dec_to_jan_next_year() {
+    let args = [Value::Number(45627.0), Value::Number(1.0)];
+    assert_eq!(eomonth_fn(&args), Value::Number(45688.0));
+}
+
+// Oracle: EOMONTH(DATE(2024,6,15), -12) = 45107 = Jun 30, 2023
+#[test]
+fn minus_twelve_months_back_one_year() {
+    // DATE(2024,6,15) = 45458, end of Jun 2023 = 45107
+    let args = [Value::Number(45458.0), Value::Number(-12.0)];
+    assert_eq!(eomonth_fn(&args), Value::Number(45107.0));
+}
+
+// Always returns last day: mid-month input still gives last day
+#[test]
+fn mid_month_input_gives_last_day() {
+    // DATE(2024,2,15) -> end of Feb 2024 = 45351 (Feb 29, leap)
+    // DATE(2024,2,15) = 45337
+    let args = [Value::Number(45337.0), Value::Number(0.0)];
+    assert_eq!(eomonth_fn(&args), Value::Number(45351.0));
+}
+
+// Negative months: Feb 2024 - 1 month = Jan 2024 end = 45322
+#[test]
+fn minus_one_from_feb_to_jan() {
+    let args = [Value::Number(45323.0), Value::Number(-1.0)];
+    assert_eq!(eomonth_fn(&args), Value::Number(45322.0));
+}

--- a/crates/core/src/eval/functions/date/eomonth/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/eomonth/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/eomonth/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/eomonth/tests/failure.rs
@@ -1,1 +1,25 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    assert_eq!(eomonth_fn(&[Value::Number(45306.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [Value::Number(45306.0), Value::Number(0.0), Value::Number(0.0)];
+    assert_eq!(eomonth_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_start() {
+    let args = [Value::Text("bad".to_string()), Value::Number(0.0)];
+    assert_eq!(eomonth_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_numeric_months() {
+    let args = [Value::Number(45306.0), Value::Text("bad".to_string())];
+    assert_eq!(eomonth_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/eomonth/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/eomonth/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/eomonth/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/eomonth/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/eomonth/tests/success.rs
+++ b/crates/core/src/eval/functions/date/eomonth/tests/success.rs
@@ -1,1 +1,44 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+// Oracle: EOMONTH(DATE(2024,1,15), 0) = 45322 = Jan 31, 2024
+#[test]
+fn zero_months_end_of_jan() {
+    let args = [Value::Number(45306.0), Value::Number(0.0)];
+    assert_eq!(eomonth_fn(&args), Value::Number(45322.0));
+}
+
+// Oracle: EOMONTH(DATE(2024,2,1), 0) = 45351 = Feb 29, 2024 (leap)
+#[test]
+fn zero_months_end_of_feb_leap() {
+    let args = [Value::Number(45323.0), Value::Number(0.0)];
+    assert_eq!(eomonth_fn(&args), Value::Number(45351.0));
+}
+
+// Oracle: EOMONTH(DATE(2023,2,1), 0) = 44985 = Feb 28, 2023 (non-leap)
+#[test]
+fn zero_months_end_of_feb_non_leap() {
+    let args = [Value::Number(44958.0), Value::Number(0.0)];
+    assert_eq!(eomonth_fn(&args), Value::Number(44985.0));
+}
+
+// Oracle: EOMONTH(DATE(2024,1,15), 1) = 45351 = Feb 29, 2024
+#[test]
+fn plus_one_jan_to_end_feb_leap() {
+    let args = [Value::Number(45306.0), Value::Number(1.0)];
+    assert_eq!(eomonth_fn(&args), Value::Number(45351.0));
+}
+
+// Oracle: EOMONTH(DATE(2024,3,15), -1) = 45351 = Feb 29, 2024
+#[test]
+fn minus_one_mar_to_end_feb_leap() {
+    let args = [Value::Number(45366.0), Value::Number(-1.0)];
+    assert_eq!(eomonth_fn(&args), Value::Number(45351.0));
+}
+
+// Oracle: EOMONTH(DATE(2024,12,1), 0) = 45657 = Dec 31, 2024
+#[test]
+fn zero_months_end_of_dec() {
+    let args = [Value::Number(45627.0), Value::Number(0.0)];
+    assert_eq!(eomonth_fn(&args), Value::Number(45657.0));
+}

--- a/crates/core/src/eval/functions/date/eomonth/tests/success.rs
+++ b/crates/core/src/eval/functions/date/eomonth/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/epochtodate/mod.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn epochtodate_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/epochtodate/mod.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/mod.rs
@@ -1,8 +1,32 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
 
+/// `EPOCHTODATE(timestamp, [unit])` — convert a Unix timestamp to a spreadsheet serial.
+///
+/// unit: 1 (default) = seconds, 2 = milliseconds, 3 = microseconds
+/// Unix epoch (1970-01-01) = serial 25569.
 pub fn epochtodate_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 1, 2) {
+        return e;
+    }
+    let timestamp = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let unit = if args.len() >= 2 {
+        match to_number(args[1].clone()) { Ok(n) => n as u32, Err(e) => return e }
+    } else {
+        1
+    };
+
+    let seconds = match unit {
+        1 => timestamp,
+        2 => timestamp / 1_000.0,
+        3 => timestamp / 1_000_000.0,
+        _ => return Value::Error(ErrorKind::Num),
+    };
+
+    // Unix epoch = serial 25569; 86400 seconds per day.
+    let serial = 25569.0 + seconds / 86400.0;
+    Value::Number(serial)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/epochtodate/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/epochtodate/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/tests/edge.rs
@@ -1,1 +1,20 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn fractional_seconds_produce_fractional_serial() {
+    // 43200 seconds = half a day → serial 25569.5
+    let args = [Value::Number(43200.0), Value::Number(1.0)];
+    if let Value::Number(n) = epochtodate_fn(&args) {
+        assert!((n - 25569.5).abs() < 1e-9, "expected 25569.5, got {n}");
+    } else {
+        panic!("expected Number");
+    }
+}
+
+#[test]
+fn negative_timestamp_before_epoch() {
+    // -86400 seconds → one day before 1970-01-01 → serial 25568
+    let args = [Value::Number(-86400.0), Value::Number(1.0)];
+    assert_eq!(epochtodate_fn(&args), Value::Number(25568.0));
+}

--- a/crates/core/src/eval/functions/date/epochtodate/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/tests/failure.rs
@@ -1,1 +1,19 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(epochtodate_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args_returns_na() {
+    let args = [Value::Number(0.0), Value::Number(1.0), Value::Number(0.0)];
+    assert_eq!(epochtodate_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_unit_returns_num() {
+    let args = [Value::Number(0.0), Value::Number(4.0)];
+    assert_eq!(epochtodate_fn(&args), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/date/epochtodate/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/epochtodate/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/epochtodate/tests/success.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/tests/success.rs
@@ -1,1 +1,42 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn epoch_zero_seconds_is_25569() {
+    let args = [Value::Number(0.0), Value::Number(1.0)];
+    assert_eq!(epochtodate_fn(&args), Value::Number(25569.0));
+}
+
+#[test]
+fn one_day_in_seconds_is_25570() {
+    let args = [Value::Number(86400.0), Value::Number(1.0)];
+    assert_eq!(epochtodate_fn(&args), Value::Number(25570.0));
+}
+
+#[test]
+fn known_timestamp_jan_15_2024() {
+    // 1705276800 seconds → serial 45306
+    let args = [Value::Number(1705276800.0), Value::Number(1.0)];
+    assert_eq!(epochtodate_fn(&args), Value::Number(45306.0));
+}
+
+#[test]
+fn milliseconds_unit() {
+    // 86400 * 1000 ms → 1 day → serial 25570
+    let args = [Value::Number(86_400_000.0), Value::Number(2.0)];
+    assert_eq!(epochtodate_fn(&args), Value::Number(25570.0));
+}
+
+#[test]
+fn microseconds_unit() {
+    // 86400 * 1_000_000 µs → 1 day → serial 25570
+    let args = [Value::Number(86_400_000_000.0), Value::Number(3.0)];
+    assert_eq!(epochtodate_fn(&args), Value::Number(25570.0));
+}
+
+#[test]
+fn default_unit_is_seconds() {
+    // Without unit arg, defaults to seconds
+    let args = [Value::Number(0.0)];
+    assert_eq!(epochtodate_fn(&args), Value::Number(25569.0));
+}

--- a/crates/core/src/eval/functions/date/epochtodate/tests/success.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/hour/mod.rs
+++ b/crates/core/src/eval/functions/date/hour/mod.rs
@@ -1,8 +1,20 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{serial_to_time, text_to_time_serial};
 use crate::types::{ErrorKind, Value};
 
 pub fn hour_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 1, 1) { return e; }
+    let serial = match coerce_to_time_serial(&args[0]) { Ok(n) => n, Err(e) => return e };
+    Value::Number(serial_to_time(serial).0 as f64)
+}
+
+fn coerce_to_time_serial(v: &Value) -> Result<f64, Value> {
+    match v {
+        Value::Text(s) => text_to_time_serial(s)
+            .ok_or(Value::Error(ErrorKind::Value)),
+        other => to_number(other.clone()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/hour/mod.rs
+++ b/crates/core/src/eval/functions/date/hour/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn hour_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/hour/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/hour/tests/edge.rs
@@ -1,1 +1,20 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn serial_zero_midnight() {
+    // oracle: HOUR(0) = 0
+    assert_eq!(hour_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn serial_half_noon() {
+    // oracle: HOUR(0.5) = 12
+    assert_eq!(hour_fn(&[Value::Number(0.5)]), Value::Number(12.0));
+}
+
+#[test]
+fn integer_serial_midnight() {
+    // Integer serials have zero fractional part → hour 0
+    assert_eq!(hour_fn(&[Value::Number(45306.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/date/hour/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/hour/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/hour/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/hour/tests/failure.rs
@@ -1,1 +1,17 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(hour_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    assert_eq!(hour_fn(&[Value::Number(0.5), Value::Number(0.5)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn text_arg() {
+    assert_eq!(hour_fn(&[Value::Text("abc".to_string())]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/hour/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/hour/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/hour/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/hour/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/hour/tests/success.rs
+++ b/crates/core/src/eval/functions/date/hour/tests/success.rs
@@ -1,1 +1,28 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn hour_14_30() {
+    // TIME(14,30,0) = 0.6041666...
+    let serial = (14.0 * 3600.0 + 30.0 * 60.0) / 86400.0;
+    assert_eq!(hour_fn(&[Value::Number(serial)]), Value::Number(14.0));
+}
+
+#[test]
+fn hour_midnight() {
+    // TIME(0,0,0) = 0.0
+    assert_eq!(hour_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn hour_23() {
+    // TIME(23,59,0)
+    let serial = (23.0 * 3600.0 + 59.0 * 60.0) / 86400.0;
+    assert_eq!(hour_fn(&[Value::Number(serial)]), Value::Number(23.0));
+}
+
+#[test]
+fn hour_noon() {
+    // TIME(12,0,0) = 0.5
+    assert_eq!(hour_fn(&[Value::Number(0.5)]), Value::Number(12.0));
+}

--- a/crates/core/src/eval/functions/date/hour/tests/success.rs
+++ b/crates/core/src/eval/functions/date/hour/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/isoweeknum/mod.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/mod.rs
@@ -1,8 +1,23 @@
+use chrono::Datelike;
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::serial_to_date;
 use crate::types::{ErrorKind, Value};
 
+/// `ISOWEEKNUM(date_serial)` — ISO 8601 week number.
+///
+/// Week 1 is the week containing the first Thursday of the year.
+/// Weeks run Monday–Sunday. Uses chrono's built-in ISO week calculation.
 pub fn isoweeknum_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let date = match serial_to_date(serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+    Value::Number(date.iso_week().week() as f64)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/isoweeknum/mod.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn isoweeknum_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/isoweeknum/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/isoweeknum/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/tests/edge.rs
@@ -1,1 +1,28 @@
-// Tests will be added by the implementation agent
+use super::super::isoweeknum_fn;
+use crate::types::Value;
+
+// Dates near year boundaries that cross ISO week years
+
+#[test]
+fn dec30_2024_monday_is_iso_week1_of_2025() {
+    // =ISOWEEKNUM(DATE(2024,12,30)) → 1 (belongs to 2025's week 1)
+    // DATE(2024,12,30) = 45656
+    let args = [Value::Number(45656.0)];
+    assert_eq!(isoweeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn jan1_2025_is_iso_week1() {
+    // =ISOWEEKNUM(DATE(2025,1,1)) → 1
+    // DATE(2025,1,1) = 45658
+    let args = [Value::Number(45658.0)];
+    assert_eq!(isoweeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn dec31_2015_is_week53() {
+    // =ISOWEEKNUM(DATE(2015,12,31)) → 53
+    // DATE(2015,12,31) = 42369
+    let args = [Value::Number(42369.0)];
+    assert_eq!(isoweeknum_fn(&args), Value::Number(53.0));
+}

--- a/crates/core/src/eval/functions/date/isoweeknum/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/tests/failure.rs
@@ -1,1 +1,20 @@
-// Tests will be added by the implementation agent
+use super::super::isoweeknum_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    // =ISOWEEKNUM() → #N/A
+    assert_eq!(isoweeknum_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args_returns_na() {
+    let args = [Value::Number(45292.0), Value::Number(1.0)];
+    assert_eq!(isoweeknum_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_arg_returns_value_error() {
+    let args = [Value::Text("not_a_date".to_string())];
+    assert_eq!(isoweeknum_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/isoweeknum/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/isoweeknum/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/isoweeknum/tests/success.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/tests/success.rs
@@ -1,1 +1,42 @@
-// Tests will be added by the implementation agent
+use super::super::isoweeknum_fn;
+use crate::types::Value;
+
+// Oracle: Google Sheets, Date.xlsx, ISOWEEKNUM sheet
+// DATE(2024,1,1)=45292 (Mon), DATE(2024,1,7)=45298 (Sun), DATE(2024,1,8)=45299 (Mon)
+// DATE(2024,6,15)=45458 (Sat), DATE(2024,12,28)=45654
+
+#[test]
+fn jan1_2024_monday_is_week1() {
+    // =ISOWEEKNUM(DATE(2024,1,1)) → 1
+    let args = [Value::Number(45292.0)];
+    assert_eq!(isoweeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn jan7_2024_sunday_is_week1() {
+    // =ISOWEEKNUM(DATE(2024,1,7)) → 1
+    let args = [Value::Number(45298.0)];
+    assert_eq!(isoweeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn jan8_2024_monday_is_week2() {
+    // =ISOWEEKNUM(DATE(2024,1,8)) → 2
+    let args = [Value::Number(45299.0)];
+    assert_eq!(isoweeknum_fn(&args), Value::Number(2.0));
+}
+
+#[test]
+fn jun15_2024_is_week24() {
+    // =ISOWEEKNUM(DATE(2024,6,15)) → 24
+    let args = [Value::Number(45458.0)];
+    assert_eq!(isoweeknum_fn(&args), Value::Number(24.0));
+}
+
+#[test]
+fn dec28_2024_is_week52() {
+    // =ISOWEEKNUM(DATE(2024,12,28)) → 52
+    // DATE(2024,12,28) = 45654
+    let args = [Value::Number(45654.0)];
+    assert_eq!(isoweeknum_fn(&args), Value::Number(52.0));
+}

--- a/crates/core/src/eval/functions/date/isoweeknum/tests/success.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/minute/mod.rs
+++ b/crates/core/src/eval/functions/date/minute/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn minute_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/minute/mod.rs
+++ b/crates/core/src/eval/functions/date/minute/mod.rs
@@ -1,8 +1,20 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{serial_to_time, text_to_time_serial};
 use crate::types::{ErrorKind, Value};
 
 pub fn minute_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 1, 1) { return e; }
+    let serial = match coerce_to_time_serial(&args[0]) { Ok(n) => n, Err(e) => return e };
+    Value::Number(serial_to_time(serial).1 as f64)
+}
+
+fn coerce_to_time_serial(v: &Value) -> Result<f64, Value> {
+    match v {
+        Value::Text(s) => text_to_time_serial(s)
+            .ok_or(Value::Error(ErrorKind::Value)),
+        other => to_number(other.clone()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/minute/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/minute/tests/edge.rs
@@ -1,1 +1,18 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn serial_zero_zero_minutes() {
+    assert_eq!(minute_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn serial_half_zero_minutes() {
+    // oracle: MINUTE(0.5) = 0 (noon has 0 minutes)
+    assert_eq!(minute_fn(&[Value::Number(0.5)]), Value::Number(0.0));
+}
+
+#[test]
+fn integer_serial_zero_minutes() {
+    assert_eq!(minute_fn(&[Value::Number(45306.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/date/minute/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/minute/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/minute/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/minute/tests/failure.rs
@@ -1,1 +1,17 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(minute_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    assert_eq!(minute_fn(&[Value::Number(0.5), Value::Number(0.5)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn text_arg() {
+    assert_eq!(minute_fn(&[Value::Text("abc".to_string())]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/minute/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/minute/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/minute/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/minute/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/minute/tests/success.rs
+++ b/crates/core/src/eval/functions/date/minute/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/minute/tests/success.rs
+++ b/crates/core/src/eval/functions/date/minute/tests/success.rs
@@ -1,1 +1,30 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn minute_30() {
+    // TIME(14,30,0)
+    let serial = (14.0 * 3600.0 + 30.0 * 60.0) / 86400.0;
+    assert_eq!(minute_fn(&[Value::Number(serial)]), Value::Number(30.0));
+}
+
+#[test]
+fn minute_0() {
+    // TIME(14,0,0)
+    let serial = (14.0 * 3600.0) / 86400.0;
+    assert_eq!(minute_fn(&[Value::Number(serial)]), Value::Number(0.0));
+}
+
+#[test]
+fn minute_59() {
+    // TIME(14,59,0)
+    let serial = (14.0 * 3600.0 + 59.0 * 60.0) / 86400.0;
+    assert_eq!(minute_fn(&[Value::Number(serial)]), Value::Number(59.0));
+}
+
+#[test]
+fn minute_45() {
+    // TIME(0,45,0)
+    let serial = (45.0 * 60.0) / 86400.0;
+    assert_eq!(minute_fn(&[Value::Number(serial)]), Value::Number(45.0));
+}

--- a/crates/core/src/eval/functions/date/mod.rs
+++ b/crates/core/src/eval/functions/date/mod.rs
@@ -1,4 +1,5 @@
 pub mod serial;
+pub mod weekend;
 
 pub mod date_fn;
 pub mod datedif;

--- a/crates/core/src/eval/functions/date/mod.rs
+++ b/crates/core/src/eval/functions/date/mod.rs
@@ -1,0 +1,59 @@
+pub mod serial;
+
+pub mod date_fn;
+pub mod datedif;
+pub mod datevalue;
+pub mod day;
+pub mod days;
+pub mod days360;
+pub mod edate;
+pub mod eomonth;
+pub mod epochtodate;
+pub mod hour;
+pub mod isoweeknum;
+pub mod minute;
+pub mod month;
+pub mod networkdays;
+pub mod networkdays_intl;
+pub mod now;
+pub mod second;
+pub mod time_fn;
+pub mod timevalue;
+pub mod today;
+pub mod weekday;
+pub mod weeknum;
+pub mod workday;
+pub mod workday_intl;
+pub mod year;
+pub mod yearfrac;
+
+use super::super::{FunctionMeta, Registry};
+
+pub fn register_date(registry: &mut Registry) {
+    registry.register_eager("DATE",             date_fn::date_fn,                   FunctionMeta { category: "date", signature: "DATE(year,month,day)",                      description: "Creates a date serial number from year, month, and day" });
+    registry.register_eager("DATEDIF",          datedif::datedif_fn,                FunctionMeta { category: "date", signature: "DATEDIF(start,end,unit)",                   description: "Difference between two dates in specified units" });
+    registry.register_eager("DATEVALUE",        datevalue::datevalue_fn,            FunctionMeta { category: "date", signature: "DATEVALUE(date_text)",                       description: "Converts a date string to a serial number" });
+    registry.register_eager("DAY",              day::day_fn,                        FunctionMeta { category: "date", signature: "DAY(date)",                                  description: "Day of month from a date serial number" });
+    registry.register_eager("DAYS",             days::days_fn,                      FunctionMeta { category: "date", signature: "DAYS(end,start)",                            description: "Number of days between two dates" });
+    registry.register_eager("DAYS360",          days360::days360_fn,                FunctionMeta { category: "date", signature: "DAYS360(start,end,[method])",                description: "Days between dates using 360-day year" });
+    registry.register_eager("EDATE",            edate::edate_fn,                    FunctionMeta { category: "date", signature: "EDATE(start,months)",                        description: "Date serial N months before or after a start date" });
+    registry.register_eager("EOMONTH",          eomonth::eomonth_fn,                FunctionMeta { category: "date", signature: "EOMONTH(start,months)",                      description: "Last day of month N months from start date" });
+    registry.register_eager("EPOCHTODATE",      epochtodate::epochtodate_fn,        FunctionMeta { category: "date", signature: "EPOCHTODATE(timestamp,[unit])",              description: "Converts Unix timestamp to date serial number" });
+    registry.register_eager("HOUR",             hour::hour_fn,                      FunctionMeta { category: "date", signature: "HOUR(time)",                                 description: "Hour component of a time serial number" });
+    registry.register_eager("ISOWEEKNUM",       isoweeknum::isoweeknum_fn,          FunctionMeta { category: "date", signature: "ISOWEEKNUM(date)",                           description: "ISO week number of the year for a date" });
+    registry.register_eager("MINUTE",           minute::minute_fn,                  FunctionMeta { category: "date", signature: "MINUTE(time)",                               description: "Minute component of a time serial number" });
+    registry.register_eager("MONTH",            month::month_fn,                    FunctionMeta { category: "date", signature: "MONTH(date)",                                description: "Month number from a date serial number" });
+    registry.register_eager("NETWORKDAYS",      networkdays::networkdays_fn,        FunctionMeta { category: "date", signature: "NETWORKDAYS(start,end,[holidays])",          description: "Number of working days between two dates" });
+    registry.register_eager("NETWORKDAYS.INTL", networkdays_intl::networkdays_intl_fn, FunctionMeta { category: "date", signature: "NETWORKDAYS.INTL(start,end,[weekend],[holidays])", description: "Working days between dates with custom weekends" });
+    registry.register_eager("NOW",              now::now_fn,                        FunctionMeta { category: "date", signature: "NOW()",                                      description: "Current date and time as a serial number" });
+    registry.register_eager("SECOND",           second::second_fn,                  FunctionMeta { category: "date", signature: "SECOND(time)",                               description: "Second component of a time serial number" });
+    registry.register_eager("TIME",             time_fn::time_fn,                   FunctionMeta { category: "date", signature: "TIME(hour,minute,second)",                   description: "Creates a time serial number from components" });
+    registry.register_eager("TIMEVALUE",        timevalue::timevalue_fn,            FunctionMeta { category: "date", signature: "TIMEVALUE(time_text)",                       description: "Converts a time string to a fractional serial number" });
+    registry.register_eager("TODAY",            today::today_fn,                    FunctionMeta { category: "date", signature: "TODAY()",                                    description: "Current date as a serial number" });
+    registry.register_eager("WEEKDAY",          weekday::weekday_fn,                FunctionMeta { category: "date", signature: "WEEKDAY(date,[type])",                       description: "Day of week as a number" });
+    registry.register_eager("WEEKNUM",          weeknum::weeknum_fn,                FunctionMeta { category: "date", signature: "WEEKNUM(date,[type])",                       description: "Week number of the year for a date" });
+    registry.register_eager("WORKDAY",          workday::workday_fn,                FunctionMeta { category: "date", signature: "WORKDAY(start,days,[holidays])",             description: "Date N working days from start date" });
+    registry.register_eager("WORKDAY.INTL",     workday_intl::workday_intl_fn,      FunctionMeta { category: "date", signature: "WORKDAY.INTL(start,days,[weekend],[holidays])", description: "Date N working days from start with custom weekends" });
+    registry.register_eager("YEAR",             year::year_fn,                      FunctionMeta { category: "date", signature: "YEAR(date)",                                 description: "Year from a date serial number" });
+    registry.register_eager("YEARFRAC",         yearfrac::yearfrac_fn,              FunctionMeta { category: "date", signature: "YEARFRAC(start,end,[basis])",                description: "Fraction of year between two dates" });
+}

--- a/crates/core/src/eval/functions/date/month/mod.rs
+++ b/crates/core/src/eval/functions/date/month/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn month_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/month/mod.rs
+++ b/crates/core/src/eval/functions/date/month/mod.rs
@@ -1,8 +1,24 @@
+use chrono::Datelike;
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{serial_to_date, text_to_date_serial};
 use crate::types::{ErrorKind, Value};
 
 pub fn month_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 1, 1) { return e; }
+    let serial = match coerce_to_date_serial(&args[0]) { Ok(n) => n, Err(e) => return e };
+    match serial_to_date(serial) {
+        Some(d) => Value::Number(d.month() as f64),
+        None => Value::Error(ErrorKind::Num),
+    }
+}
+
+fn coerce_to_date_serial(v: &Value) -> Result<f64, Value> {
+    match v {
+        Value::Text(s) => text_to_date_serial(s)
+            .ok_or(Value::Error(ErrorKind::Value)),
+        other => to_number(other.clone()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/month/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/month/tests/edge.rs
@@ -1,1 +1,26 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn serial_zero_is_dec_1899() {
+    // serial 0 = Dec 30 1899
+    assert_eq!(month_fn(&[Value::Number(0.0)]), Value::Number(12.0));
+}
+
+#[test]
+fn serial_1_is_dec_1899() {
+    // oracle: MONTH(1) = 12
+    assert_eq!(month_fn(&[Value::Number(1.0)]), Value::Number(12.0));
+}
+
+#[test]
+fn serial_60_excel_bug() {
+    // oracle: MONTH(60) = 2 (Feb 28 1900)
+    assert_eq!(month_fn(&[Value::Number(60.0)]), Value::Number(2.0));
+}
+
+#[test]
+fn negative_serial_returns_valid_month() {
+    // serial -1 = Dec 29 1899 — negative serials are valid (pre-1900 dates)
+    assert_eq!(month_fn(&[Value::Number(-1.0)]), Value::Number(12.0));
+}

--- a/crates/core/src/eval/functions/date/month/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/month/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/month/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/month/tests/failure.rs
@@ -1,1 +1,17 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(month_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    assert_eq!(month_fn(&[Value::Number(1.0), Value::Number(2.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn text_arg() {
+    assert_eq!(month_fn(&[Value::Text("abc".to_string())]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/month/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/month/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/month/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/month/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/month/tests/success.rs
+++ b/crates/core/src/eval/functions/date/month/tests/success.rs
@@ -1,1 +1,26 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn month_june() {
+    // DATE(2024,6,15) = serial 45458
+    assert_eq!(month_fn(&[Value::Number(45458.0)]), Value::Number(6.0));
+}
+
+#[test]
+fn month_january() {
+    // DATE(2024,1,1) = serial 45292
+    assert_eq!(month_fn(&[Value::Number(45292.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn month_december() {
+    // DATE(2024,12,31) = serial 45657
+    assert_eq!(month_fn(&[Value::Number(45657.0)]), Value::Number(12.0));
+}
+
+#[test]
+fn month_february_leap() {
+    // DATE(2024,2,29) = serial 45351
+    assert_eq!(month_fn(&[Value::Number(45351.0)]), Value::Number(2.0));
+}

--- a/crates/core/src/eval/functions/date/month/tests/success.rs
+++ b/crates/core/src/eval/functions/date/month/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/networkdays/mod.rs
+++ b/crates/core/src/eval/functions/date/networkdays/mod.rs
@@ -1,8 +1,45 @@
+use chrono::{Datelike, Duration};
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::serial_to_date;
 use crate::types::{ErrorKind, Value};
 
+/// `NETWORKDAYS(start_date, end_date, [holidays])` — count of working days (Mon–Fri),
+/// inclusive of both endpoints.  If start > end, the result is negative.
+/// The optional holidays argument is accepted but ignored (array args unsupported).
 pub fn networkdays_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 2, 3) {
+        return err;
+    }
+    let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let end_serial   = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+
+    let start = match serial_to_date(start_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+    let end = match serial_to_date(end_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+
+    let (from, to, sign) = if start <= end {
+        (start, end, 1i64)
+    } else {
+        (end, start, -1i64)
+    };
+
+    let mut count = 0i64;
+    let mut current = from;
+    while current <= to {
+        let wd = current.weekday().num_days_from_monday();
+        if wd < 5 {
+            count += 1;
+        }
+        current += Duration::days(1);
+    }
+
+    Value::Number((count * sign) as f64)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/networkdays/mod.rs
+++ b/crates/core/src/eval/functions/date/networkdays/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn networkdays_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/networkdays/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/networkdays/tests/edge.rs
@@ -1,1 +1,37 @@
-// Tests will be added by the implementation agent
+use super::super::networkdays_fn;
+use crate::types::Value;
+
+#[test]
+fn same_day_workday() {
+    // NETWORKDAYS(DATE(2024,1,1), DATE(2024,1,1)) = 1  (Monday)
+    let args = [Value::Number(45292.0), Value::Number(45292.0)];
+    assert_eq!(networkdays_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn same_day_saturday() {
+    // NETWORKDAYS(DATE(2024,1,6), DATE(2024,1,6)) = 0
+    let args = [Value::Number(45297.0), Value::Number(45297.0)];
+    assert_eq!(networkdays_fn(&args), Value::Number(0.0));
+}
+
+#[test]
+fn same_day_sunday() {
+    // NETWORKDAYS(DATE(2024,1,7), DATE(2024,1,7)) = 0
+    let args = [Value::Number(45298.0), Value::Number(45298.0)];
+    assert_eq!(networkdays_fn(&args), Value::Number(0.0));
+}
+
+#[test]
+fn backward_negative() {
+    // NETWORKDAYS(DATE(2024,1,8), DATE(2024,1,1)) = -6
+    let args = [Value::Number(45299.0), Value::Number(45292.0)];
+    assert_eq!(networkdays_fn(&args), Value::Number(-6.0));
+}
+
+#[test]
+fn sat_to_sun_zero() {
+    // NETWORKDAYS(DATE(2024,1,6), DATE(2024,1,7)) = 0
+    let args = [Value::Number(45297.0), Value::Number(45298.0)];
+    assert_eq!(networkdays_fn(&args), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/date/networkdays/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/networkdays/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/networkdays/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/networkdays/tests/failure.rs
@@ -1,1 +1,30 @@
-// Tests will be added by the implementation agent
+use super::super::networkdays_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_few_args() {
+    let args = [Value::Number(45292.0)];
+    assert_eq!(networkdays_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(45296.0),
+        Value::Number(0.0),
+        Value::Number(0.0),
+    ];
+    assert_eq!(networkdays_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_start() {
+    let args = [Value::Text("bad".to_string()), Value::Number(45296.0)];
+    assert_eq!(networkdays_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn no_args() {
+    assert_eq!(networkdays_fn(&[]), Value::Error(ErrorKind::NA));
+}

--- a/crates/core/src/eval/functions/date/networkdays/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/networkdays/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/networkdays/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/networkdays/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/networkdays/tests/success.rs
+++ b/crates/core/src/eval/functions/date/networkdays/tests/success.rs
@@ -1,1 +1,32 @@
-// Tests will be added by the implementation agent
+use super::super::networkdays_fn;
+use crate::types::Value;
+
+// DATE(2024,1,1) = 45292 (Monday), DATE(2024,1,5) = 45296 (Friday)
+
+#[test]
+fn mon_to_fri_five_days() {
+    // NETWORKDAYS(DATE(2024,1,1), DATE(2024,1,5)) = 5
+    let args = [Value::Number(45292.0), Value::Number(45296.0)];
+    assert_eq!(networkdays_fn(&args), Value::Number(5.0));
+}
+
+#[test]
+fn mon_to_sun_five_workdays() {
+    // NETWORKDAYS(DATE(2024,1,1), DATE(2024,1,7)) = 5  (Sat+Sun skipped)
+    let args = [Value::Number(45292.0), Value::Number(45298.0)];
+    assert_eq!(networkdays_fn(&args), Value::Number(5.0));
+}
+
+#[test]
+fn two_full_weeks() {
+    // NETWORKDAYS(DATE(2024,1,1), DATE(2024,1,14)) = 10
+    let args = [Value::Number(45292.0), Value::Number(45305.0)];
+    assert_eq!(networkdays_fn(&args), Value::Number(10.0));
+}
+
+#[test]
+fn mon_to_next_mon_six() {
+    // NETWORKDAYS(DATE(2024,1,1), DATE(2024,1,8)) = 6
+    let args = [Value::Number(45292.0), Value::Number(45299.0)];
+    assert_eq!(networkdays_fn(&args), Value::Number(6.0));
+}

--- a/crates/core/src/eval/functions/date/networkdays/tests/success.rs
+++ b/crates/core/src/eval/functions/date/networkdays/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/networkdays_intl/mod.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/mod.rs
@@ -1,8 +1,51 @@
+use chrono::{Datelike, Duration};
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::serial_to_date;
+use crate::eval::functions::date::weekend::weekend_mask;
 use crate::types::{ErrorKind, Value};
 
+/// `NETWORKDAYS.INTL(start, end, [weekend], [holidays])` — count of working days
+/// with a configurable weekend pattern.  If start > end, result is negative.
+/// The optional holidays argument is accepted but ignored.
 pub fn networkdays_intl_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 2, 4) {
+        return err;
+    }
+    let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let end_serial   = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+
+    let mask = match weekend_mask(args.get(2)) {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+
+    let start = match serial_to_date(start_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+    let end = match serial_to_date(end_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+
+    let (from, to, sign) = if start <= end {
+        (start, end, 1i64)
+    } else {
+        (end, start, -1i64)
+    };
+
+    let mut count = 0i64;
+    let mut current = from;
+    while current <= to {
+        let wd = current.weekday().num_days_from_monday() as usize;
+        if !mask[wd] {
+            count += 1;
+        }
+        current += Duration::days(1);
+    }
+
+    Value::Number((count * sign) as f64)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/networkdays_intl/mod.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn networkdays_intl_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/networkdays_intl/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/networkdays_intl/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/tests/edge.rs
@@ -1,1 +1,32 @@
-// Tests will be added by the implementation agent
+use super::super::networkdays_intl_fn;
+use crate::types::Value;
+
+#[test]
+fn same_workday_returns_one() {
+    // NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,1), 1) = 1  (Monday)
+    let args = [Value::Number(45292.0), Value::Number(45292.0), Value::Number(1.0)];
+    assert_eq!(networkdays_intl_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn default_weekend_equals_code_1() {
+    // Omitting weekend arg should behave same as code 1
+    let with_default = networkdays_intl_fn(&[Value::Number(45292.0), Value::Number(45296.0)]);
+    let with_code1   = networkdays_intl_fn(&[Value::Number(45292.0), Value::Number(45296.0), Value::Number(1.0)]);
+    assert_eq!(with_default, with_code1);
+}
+
+#[test]
+fn code_15_thu_only_skipped() {
+    // NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,5), 15) = 4
+    // Code 15 = Thu only weekend; Mon-Fri has one Thu → count = 4
+    let args = [Value::Number(45292.0), Value::Number(45296.0), Value::Number(15.0)];
+    assert_eq!(networkdays_intl_fn(&args), Value::Number(4.0));
+}
+
+#[test]
+fn backward_negative() {
+    // start > end → negative result
+    let args = [Value::Number(45296.0), Value::Number(45292.0), Value::Number(1.0)];
+    assert_eq!(networkdays_intl_fn(&args), Value::Number(-5.0));
+}

--- a/crates/core/src/eval/functions/date/networkdays_intl/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/tests/failure.rs
@@ -1,1 +1,36 @@
-// Tests will be added by the implementation agent
+use super::super::networkdays_intl_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(networkdays_intl_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg() {
+    assert_eq!(networkdays_intl_fn(&[Value::Number(45292.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(45296.0),
+        Value::Number(1.0),
+        Value::Number(0.0),
+        Value::Number(0.0),
+    ];
+    assert_eq!(networkdays_intl_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_start() {
+    let args = [Value::Text("bad".to_string()), Value::Number(45296.0)];
+    assert_eq!(networkdays_intl_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn invalid_weekend_code() {
+    let args = [Value::Number(45292.0), Value::Number(45296.0), Value::Number(99.0)];
+    assert_eq!(networkdays_intl_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/networkdays_intl/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/networkdays_intl/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/networkdays_intl/tests/success.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/tests/success.rs
@@ -1,1 +1,37 @@
-// Tests will be added by the implementation agent
+use super::super::networkdays_intl_fn;
+use crate::types::Value;
+
+// Serials: DATE(2024,1,1)=45292 Mon, DATE(2024,1,2)=45293 Tue,
+//          DATE(2024,1,4)=45295 Thu, DATE(2024,1,5)=45296 Fri, DATE(2024,1,6)=45297 Sat
+
+#[test]
+fn weekend_1_sat_sun_mon_to_fri() {
+    // NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,5), 1) = 5
+    let args = [Value::Number(45292.0), Value::Number(45296.0), Value::Number(1.0)];
+    assert_eq!(networkdays_intl_fn(&args), Value::Number(5.0));
+}
+
+#[test]
+fn weekend_2_sun_mon_tue_to_sat() {
+    // NETWORKDAYS.INTL(DATE(2024,1,2), DATE(2024,1,6), 2) = 5
+    let args = [Value::Number(45293.0), Value::Number(45297.0), Value::Number(2.0)];
+    assert_eq!(networkdays_intl_fn(&args), Value::Number(5.0));
+}
+
+#[test]
+fn weekend_7_fri_sat_mon_to_thu() {
+    // NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,4), 7) = 4
+    let args = [Value::Number(45292.0), Value::Number(45295.0), Value::Number(7.0)];
+    assert_eq!(networkdays_intl_fn(&args), Value::Number(4.0));
+}
+
+#[test]
+fn string_mask_sat_sun() {
+    // NETWORKDAYS.INTL(DATE(2024,1,1), DATE(2024,1,5), "0000011") = 5
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(45296.0),
+        Value::Text("0000011".to_string()),
+    ];
+    assert_eq!(networkdays_intl_fn(&args), Value::Number(5.0));
+}

--- a/crates/core/src/eval/functions/date/networkdays_intl/tests/success.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/now/mod.rs
+++ b/crates/core/src/eval/functions/date/now/mod.rs
@@ -1,8 +1,18 @@
-use crate::types::{ErrorKind, Value};
+use chrono::{Local, Timelike};
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{date_to_serial, time_to_serial};
+use crate::types::Value;
 
+/// `NOW()` — returns the current local datetime as a spreadsheet serial number.
+/// Integer part = date serial; fractional part = time-of-day.
 pub fn now_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 0, 0) {
+        return e;
+    }
+    let now = Local::now().naive_local();
+    let date_serial = date_to_serial(now.date());
+    let time_frac = time_to_serial(now.hour(), now.minute(), now.second());
+    Value::Number(date_serial + time_frac)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/now/mod.rs
+++ b/crates/core/src/eval/functions/date/now/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn now_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/now/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/now/tests/edge.rs
@@ -1,1 +1,12 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn integer_part_equals_today_floor() {
+    // The integer portion of NOW() must match the date (no fractional spillover).
+    if let Value::Number(n) = now_fn(&[]) {
+        assert!(n.floor() >= 45292.0, "date portion {} seems too small", n.floor());
+    } else {
+        panic!("expected Number");
+    }
+}

--- a/crates/core/src/eval/functions/date/now/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/now/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/now/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/now/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/now/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/now/tests/failure.rs
@@ -1,1 +1,7 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_many_args() {
+    assert_eq!(now_fn(&[Value::Number(0.0)]), Value::Error(ErrorKind::NA));
+}

--- a/crates/core/src/eval/functions/date/now/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/now/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/now/tests/success.rs
+++ b/crates/core/src/eval/functions/date/now/tests/success.rs
@@ -1,1 +1,29 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+/// Serial for 2024-01-01 = 45292.
+const MIN_SERIAL: f64 = 45292.0;
+
+#[test]
+fn returns_a_number() {
+    assert!(matches!(now_fn(&[]), Value::Number(_)));
+}
+
+#[test]
+fn result_is_after_2024_jan_01() {
+    if let Value::Number(n) = now_fn(&[]) {
+        assert!(n >= MIN_SERIAL, "now serial {n} should be >= {MIN_SERIAL}");
+    } else {
+        panic!("expected Number");
+    }
+}
+
+#[test]
+fn fractional_part_is_between_0_and_1() {
+    if let Value::Number(n) = now_fn(&[]) {
+        let frac = n.fract();
+        assert!(frac >= 0.0 && frac < 1.0, "fractional part {frac} out of range");
+    } else {
+        panic!("expected Number");
+    }
+}

--- a/crates/core/src/eval/functions/date/now/tests/success.rs
+++ b/crates/core/src/eval/functions/date/now/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/second/mod.rs
+++ b/crates/core/src/eval/functions/date/second/mod.rs
@@ -1,8 +1,20 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{serial_to_time, text_to_time_serial};
 use crate::types::{ErrorKind, Value};
 
 pub fn second_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 1, 1) { return e; }
+    let serial = match coerce_to_time_serial(&args[0]) { Ok(n) => n, Err(e) => return e };
+    Value::Number(serial_to_time(serial).2 as f64)
+}
+
+fn coerce_to_time_serial(v: &Value) -> Result<f64, Value> {
+    match v {
+        Value::Text(s) => text_to_time_serial(s)
+            .ok_or(Value::Error(ErrorKind::Value)),
+        other => to_number(other.clone()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/second/mod.rs
+++ b/crates/core/src/eval/functions/date/second/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn second_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/second/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/second/tests/edge.rs
@@ -1,1 +1,19 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn serial_zero_zero_seconds() {
+    // oracle: SECOND(0) = 0
+    assert_eq!(second_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn serial_half_zero_seconds() {
+    // noon serial: no seconds
+    assert_eq!(second_fn(&[Value::Number(0.5)]), Value::Number(0.0));
+}
+
+#[test]
+fn integer_serial_zero_seconds() {
+    assert_eq!(second_fn(&[Value::Number(45306.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/date/second/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/second/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/second/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/second/tests/failure.rs
@@ -1,1 +1,17 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(second_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    assert_eq!(second_fn(&[Value::Number(0.5), Value::Number(0.5)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn text_arg() {
+    assert_eq!(second_fn(&[Value::Text("abc".to_string())]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/second/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/second/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/second/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/second/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/second/tests/success.rs
+++ b/crates/core/src/eval/functions/date/second/tests/success.rs
@@ -1,1 +1,30 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn second_45() {
+    // TIME(14,30,45)
+    let serial = (14.0 * 3600.0 + 30.0 * 60.0 + 45.0) / 86400.0;
+    assert_eq!(second_fn(&[Value::Number(serial)]), Value::Number(45.0));
+}
+
+#[test]
+fn second_0() {
+    // TIME(14,30,0)
+    let serial = (14.0 * 3600.0 + 30.0 * 60.0) / 86400.0;
+    assert_eq!(second_fn(&[Value::Number(serial)]), Value::Number(0.0));
+}
+
+#[test]
+fn second_59() {
+    // TIME(14,30,59)
+    let serial = (14.0 * 3600.0 + 30.0 * 60.0 + 59.0) / 86400.0;
+    assert_eq!(second_fn(&[Value::Number(serial)]), Value::Number(59.0));
+}
+
+#[test]
+fn second_30() {
+    // TIME(0,0,30)
+    let serial = 30.0 / 86400.0;
+    assert_eq!(second_fn(&[Value::Number(serial)]), Value::Number(30.0));
+}

--- a/crates/core/src/eval/functions/date/second/tests/success.rs
+++ b/crates/core/src/eval/functions/date/second/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/serial.rs
+++ b/crates/core/src/eval/functions/date/serial.rs
@@ -1,0 +1,32 @@
+use chrono::{Duration, NaiveDate};
+
+/// Base date for serial number 0 (December 30, 1899).
+fn base() -> NaiveDate {
+    NaiveDate::from_ymd_opt(1899, 12, 30).unwrap()
+}
+
+/// Convert a serial number to a NaiveDate (integer part only).
+pub fn serial_to_date(serial: f64) -> Option<NaiveDate> {
+    let days = serial.floor() as i64;
+    base().checked_add_signed(Duration::days(days))
+}
+
+/// Convert a NaiveDate to a serial number.
+pub fn date_to_serial(date: NaiveDate) -> f64 {
+    date.signed_duration_since(base()).num_days() as f64
+}
+
+/// Extract time-of-day components from the fractional part of a serial.
+pub fn serial_to_time(serial: f64) -> (u32, u32, u32) {
+    let frac = serial.fract().abs();
+    let total_secs = (frac * 86400.0).round() as u32;
+    let h = total_secs / 3600;
+    let m = (total_secs % 3600) / 60;
+    let s = total_secs % 60;
+    (h, m, s)
+}
+
+/// Convert time components to a fractional-day serial.
+pub fn time_to_serial(h: u32, m: u32, s: u32) -> f64 {
+    (h as f64 * 3600.0 + m as f64 * 60.0 + s as f64) / 86400.0
+}

--- a/crates/core/src/eval/functions/date/serial.rs
+++ b/crates/core/src/eval/functions/date/serial.rs
@@ -1,4 +1,4 @@
-use chrono::{Duration, NaiveDate};
+use chrono::{Duration, NaiveDate, NaiveTime, Timelike};
 
 /// Base date for serial number 0 (December 30, 1899).
 fn base() -> NaiveDate {
@@ -29,4 +29,37 @@ pub fn serial_to_time(serial: f64) -> (u32, u32, u32) {
 /// Convert time components to a fractional-day serial.
 pub fn time_to_serial(h: u32, m: u32, s: u32) -> f64 {
     (h as f64 * 3600.0 + m as f64 * 60.0 + s as f64) / 86400.0
+}
+
+/// Parse a date text string and return its serial number, or None on failure.
+/// Supports the same formats as DATEVALUE.
+pub fn text_to_date_serial(text: &str) -> Option<f64> {
+    let formats = [
+        "%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d",
+        "%d-%b-%Y", "%d-%b-%y",
+        "%B %d, %Y", "%b %d, %Y",
+        "%B %d %Y",  "%b %d %Y",
+    ];
+    for fmt in &formats {
+        if let Ok(date) = NaiveDate::parse_from_str(text, fmt) {
+            return Some(date_to_serial(date));
+        }
+    }
+    None
+}
+
+/// Parse a time text string and return its fractional day serial, or None on failure.
+/// Supports the same formats as TIMEVALUE.
+pub fn text_to_time_serial(text: &str) -> Option<f64> {
+    let formats = [
+        "%H:%M:%S", "%H:%M",
+        "%I:%M %p", "%I:%M:%S %p",
+        "%I:%M%p",  "%I:%M:%S%p",
+    ];
+    for fmt in &formats {
+        if let Ok(t) = NaiveTime::parse_from_str(text, fmt) {
+            return Some(time_to_serial(t.hour(), t.minute(), t.second()));
+        }
+    }
+    None
 }

--- a/crates/core/src/eval/functions/date/time_fn/mod.rs
+++ b/crates/core/src/eval/functions/date/time_fn/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn time_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/time_fn/mod.rs
+++ b/crates/core/src/eval/functions/date/time_fn/mod.rs
@@ -1,8 +1,40 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::time_to_serial;
 use crate::types::{ErrorKind, Value};
 
+/// `TIME(hour, minute, second)` — returns a fractional day serial for the given time.
+///
+/// Components are truncated to integers. Overflow wraps (e.g. 25 hours → 1 hour).
+/// Returns `Value::Error(ErrorKind::Num)` if any component is negative after truncation.
 pub fn time_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 3, 3) {
+        return err;
+    }
+    let hour   = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let minute = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    let second = match to_number(args[2].clone()) { Ok(n) => n, Err(e) => return e };
+
+    // Truncate to integers
+    let h = hour.trunc() as i64;
+    let m = minute.trunc() as i64;
+    let s = second.trunc() as i64;
+
+    // Negative components are an error
+    if h < 0 || m < 0 || s < 0 {
+        return Value::Error(ErrorKind::Num);
+    }
+
+    // Convert to total seconds, then take mod 86400 to wrap
+    let total_seconds = h * 3600 + m * 60 + s;
+    let wrapped = total_seconds % 86400;
+    let serial = time_to_serial(
+        (wrapped / 3600) as u32,
+        ((wrapped % 3600) / 60) as u32,
+        (wrapped % 60) as u32,
+    );
+
+    Value::Number(serial)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/time_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/time_fn/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/time_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/time_fn/tests/edge.rs
@@ -1,1 +1,35 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < 1e-9 } else { false }
+}
+
+#[test]
+fn second_overflow_wraps() {
+    // TIME(0,0,60) = 1 minute = 60/86400
+    let args = [Value::Number(0.0), Value::Number(0.0), Value::Number(60.0)];
+    assert!(approx(time_fn(&args), 60.0 / 86400.0));
+}
+
+#[test]
+fn minute_overflow_wraps() {
+    // TIME(0,60,0) = 1 hour = 3600/86400
+    let args = [Value::Number(0.0), Value::Number(60.0), Value::Number(0.0)];
+    assert!(approx(time_fn(&args), 3600.0 / 86400.0));
+}
+
+#[test]
+fn hour_24_wraps_to_zero() {
+    // TIME(24,0,0) = 0 (wraps)
+    let args = [Value::Number(24.0), Value::Number(0.0), Value::Number(0.0)];
+    assert_eq!(time_fn(&args), Value::Number(0.0));
+}
+
+#[test]
+fn decimal_hour_truncated() {
+    // TIME(14.9,0,0) = TIME(14,0,0)
+    let args_frac = [Value::Number(14.9), Value::Number(0.0), Value::Number(0.0)];
+    let args_int  = [Value::Number(14.0), Value::Number(0.0), Value::Number(0.0)];
+    assert_eq!(time_fn(&args_frac), time_fn(&args_int));
+}

--- a/crates/core/src/eval/functions/date/time_fn/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/time_fn/tests/failure.rs
@@ -1,1 +1,31 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(time_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_few_args() {
+    let args = [Value::Number(12.0), Value::Number(0.0)];
+    assert_eq!(time_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [Value::Number(12.0), Value::Number(0.0), Value::Number(0.0), Value::Number(0.0)];
+    assert_eq!(time_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn negative_hour_num_error() {
+    let args = [Value::Number(-1.0), Value::Number(0.0), Value::Number(0.0)];
+    assert_eq!(time_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_numeric_arg() {
+    let args = [Value::Text("bad".to_string()), Value::Number(0.0), Value::Number(0.0)];
+    assert_eq!(time_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/time_fn/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/time_fn/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/time_fn/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/time_fn/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/time_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/date/time_fn/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/time_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/date/time_fn/tests/success.rs
@@ -1,1 +1,31 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < 1e-9 } else { false }
+}
+
+#[test]
+fn noon() {
+    let args = [Value::Number(12.0), Value::Number(0.0), Value::Number(0.0)];
+    assert_eq!(time_fn(&args), Value::Number(0.5));
+}
+
+#[test]
+fn midnight() {
+    let args = [Value::Number(0.0), Value::Number(0.0), Value::Number(0.0)];
+    assert_eq!(time_fn(&args), Value::Number(0.0));
+}
+
+#[test]
+fn fourteen_thirty() {
+    // TIME(14,30,0) = 0.6041666...
+    let args = [Value::Number(14.0), Value::Number(30.0), Value::Number(0.0)];
+    assert!(approx(time_fn(&args), 14.0 * 3600.0 / 86400.0 + 30.0 * 60.0 / 86400.0));
+}
+
+#[test]
+fn twenty_three_fifty_nine_fifty_nine() {
+    let args = [Value::Number(23.0), Value::Number(59.0), Value::Number(59.0)];
+    assert!(approx(time_fn(&args), (23.0 * 3600.0 + 59.0 * 60.0 + 59.0) / 86400.0));
+}

--- a/crates/core/src/eval/functions/date/timevalue/mod.rs
+++ b/crates/core/src/eval/functions/date/timevalue/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn timevalue_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/timevalue/mod.rs
+++ b/crates/core/src/eval/functions/date/timevalue/mod.rs
@@ -1,8 +1,39 @@
+use chrono::{NaiveTime, Timelike};
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::time_to_serial;
 use crate::types::{ErrorKind, Value};
 
+/// `TIMEVALUE(time_text)` — parses a time string and returns a fractional day serial.
+///
+/// Supports HH:MM:SS, HH:MM, and 12-hour formats with AM/PM.
+/// Returns `Value::Error(ErrorKind::Value)` for unparseable strings.
 pub fn timevalue_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let text = match &args[0] {
+        Value::Text(s) => s.clone(),
+        Value::Error(_) => return args[0].clone(),
+        _ => return Value::Error(ErrorKind::Value),
+    };
+
+    let formats = [
+        "%H:%M:%S",
+        "%H:%M",
+        "%I:%M %p",
+        "%I:%M:%S %p",
+        "%I:%M%p",
+        "%I:%M:%S%p",
+    ];
+
+    for fmt in &formats {
+        if let Ok(t) = NaiveTime::parse_from_str(&text, fmt) {
+            let serial = time_to_serial(t.hour(), t.minute(), t.second());
+            return Value::Number(serial);
+        }
+    }
+
+    Value::Error(ErrorKind::Value)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/timevalue/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/timevalue/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/timevalue/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/timevalue/tests/edge.rs
@@ -1,1 +1,20 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < 1e-9 } else { false }
+}
+
+#[test]
+fn end_of_day() {
+    let args = [Value::Text("23:59:59".to_string())];
+    assert!(approx(timevalue_fn(&args), (23.0 * 3600.0 + 59.0 * 60.0 + 59.0) / 86400.0));
+}
+
+#[test]
+fn hm_format_no_seconds() {
+    // "14:30" same as "14:30:00"
+    let args_hm  = [Value::Text("14:30".to_string())];
+    let args_hms = [Value::Text("14:30:00".to_string())];
+    assert_eq!(timevalue_fn(&args_hm), timevalue_fn(&args_hms));
+}

--- a/crates/core/src/eval/functions/date/timevalue/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/timevalue/tests/failure.rs
@@ -1,1 +1,25 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(timevalue_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [Value::Text("12:00:00".to_string()), Value::Text("extra".to_string())];
+    assert_eq!(timevalue_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_string() {
+    let args = [Value::Text("abc".to_string())];
+    assert_eq!(timevalue_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn non_string_arg() {
+    let args = [Value::Number(0.5)];
+    assert_eq!(timevalue_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/timevalue/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/timevalue/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/timevalue/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/timevalue/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/timevalue/tests/success.rs
+++ b/crates/core/src/eval/functions/date/timevalue/tests/success.rs
@@ -1,1 +1,37 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < 1e-9 } else { false }
+}
+
+#[test]
+fn noon_hms() {
+    let args = [Value::Text("12:00:00".to_string())];
+    assert_eq!(timevalue_fn(&args), Value::Number(0.5));
+}
+
+#[test]
+fn six_am() {
+    let args = [Value::Text("6:00:00".to_string())];
+    assert!(approx(timevalue_fn(&args), 6.0 * 3600.0 / 86400.0));
+}
+
+#[test]
+fn midnight() {
+    let args = [Value::Text("00:00:00".to_string())];
+    assert_eq!(timevalue_fn(&args), Value::Number(0.0));
+}
+
+#[test]
+fn fourteen_thirty() {
+    let args = [Value::Text("14:30:00".to_string())];
+    assert!(approx(timevalue_fn(&args), (14.0 * 3600.0 + 30.0 * 60.0) / 86400.0));
+}
+
+#[test]
+fn pm_notation() {
+    // 2:30 PM = 14:30:00
+    let args = [Value::Text("2:30 PM".to_string())];
+    assert!(approx(timevalue_fn(&args), (14.0 * 3600.0 + 30.0 * 60.0) / 86400.0));
+}

--- a/crates/core/src/eval/functions/date/timevalue/tests/success.rs
+++ b/crates/core/src/eval/functions/date/timevalue/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/today/mod.rs
+++ b/crates/core/src/eval/functions/date/today/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn today_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/today/mod.rs
+++ b/crates/core/src/eval/functions/date/today/mod.rs
@@ -1,8 +1,15 @@
-use crate::types::{ErrorKind, Value};
+use chrono::Local;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::date_to_serial;
+use crate::types::Value;
 
+/// `TODAY()` — returns the current local date as a spreadsheet serial number.
 pub fn today_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 0, 0) {
+        return e;
+    }
+    let today = Local::now().date_naive();
+    Value::Number(date_to_serial(today))
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/today/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/today/tests/edge.rs
@@ -1,1 +1,12 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn result_is_reasonable_upper_bound() {
+    // Sanity: the result should not be unreasonably large (e.g., > serial for 2100-01-01 ≈ 73051).
+    if let Value::Number(n) = today_fn(&[]) {
+        assert!(n < 73051.0, "today serial {n} seems unreasonably large");
+    } else {
+        panic!("expected Number");
+    }
+}

--- a/crates/core/src/eval/functions/date/today/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/today/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/today/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/today/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/today/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/today/tests/failure.rs
@@ -1,1 +1,7 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn too_many_args() {
+    assert_eq!(today_fn(&[Value::Number(0.0)]), Value::Error(ErrorKind::NA));
+}

--- a/crates/core/src/eval/functions/date/today/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/today/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/today/tests/success.rs
+++ b/crates/core/src/eval/functions/date/today/tests/success.rs
@@ -1,1 +1,28 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+/// Serial for 2024-01-01 = 45292. TODAY() must be at or above that.
+const MIN_SERIAL: f64 = 45292.0;
+
+#[test]
+fn returns_a_number() {
+    assert!(matches!(today_fn(&[]), Value::Number(_)));
+}
+
+#[test]
+fn result_is_after_2024_jan_01() {
+    if let Value::Number(n) = today_fn(&[]) {
+        assert!(n >= MIN_SERIAL, "today serial {n} should be >= {MIN_SERIAL}");
+    } else {
+        panic!("expected Number");
+    }
+}
+
+#[test]
+fn result_has_no_fractional_part() {
+    if let Value::Number(n) = today_fn(&[]) {
+        assert_eq!(n.fract(), 0.0, "TODAY() should be a whole number, got {n}");
+    } else {
+        panic!("expected Number");
+    }
+}

--- a/crates/core/src/eval/functions/date/today/tests/success.rs
+++ b/crates/core/src/eval/functions/date/today/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/weekday/mod.rs
+++ b/crates/core/src/eval/functions/date/weekday/mod.rs
@@ -1,8 +1,52 @@
+use chrono::Datelike;
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::serial_to_date;
 use crate::types::{ErrorKind, Value};
 
+/// `WEEKDAY(date_serial, [return_type])` — day of week as an integer.
+///
+/// return_type mapping:
+/// - 1 (default) / 17: Sunday=1, Saturday=7
+/// - 2 / 11: Monday=1, Sunday=7
+/// - 3: Monday=0, Sunday=6
+/// - 12: Tuesday=1, Monday=7
+/// - 13: Wednesday=1, Tuesday=7
+/// - 14: Thursday=1, Wednesday=7
+/// - 15: Friday=1, Thursday=7
+/// - 16: Saturday=1, Friday=7
 pub fn weekday_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let return_type = if args.len() > 1 {
+        match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e }
+    } else {
+        1.0
+    };
+
+    let date = match serial_to_date(serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+
+    // chrono: 0=Mon, 1=Tue, ..., 6=Sun
+    let wd = date.weekday().num_days_from_monday() as i32;
+
+    let result = match return_type as u32 {
+        1 | 17 => ((wd + 1) % 7) + 1,  // Sun=1, Mon=2, ..., Sat=7
+        2 | 11 => wd + 1,               // Mon=1, ..., Sun=7
+        3      => wd,                   // Mon=0, ..., Sun=6
+        12     => (wd + 6) % 7 + 1,    // Tue=1, ..., Mon=7
+        13     => (wd + 5) % 7 + 1,    // Wed=1, ..., Tue=7
+        14     => (wd + 4) % 7 + 1,    // Thu=1, ..., Wed=7
+        15     => (wd + 3) % 7 + 1,    // Fri=1, ..., Thu=7
+        16     => (wd + 2) % 7 + 1,    // Sat=1, ..., Fri=7
+        _      => return Value::Error(ErrorKind::Num),
+    };
+
+    Value::Number(result as f64)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/weekday/mod.rs
+++ b/crates/core/src/eval/functions/date/weekday/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn weekday_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/weekday/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/weekday/tests/edge.rs
@@ -1,1 +1,33 @@
-// Tests will be added by the implementation agent
+use super::super::weekday_fn;
+use crate::types::Value;
+
+// DATE(2024,1,1) = 45292 (Monday)
+
+#[test]
+fn type11_monday_returns_1() {
+    // =WEEKDAY(DATE(2024,1,1),11) → 1 (type 11 = Mon=1, same as type 2)
+    let args = [Value::Number(45292.0), Value::Number(11.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn type17_is_same_as_type1() {
+    // type 17: Sunday=1, Saturday=7, same as type 1
+    let args1 = [Value::Number(45292.0), Value::Number(1.0)];
+    let args17 = [Value::Number(45292.0), Value::Number(17.0)];
+    assert_eq!(weekday_fn(&args1), weekday_fn(&args17));
+}
+
+#[test]
+fn type12_tuesday_is_1() {
+    // DATE(2024,1,2) = 45293 (Tuesday). type 12: Tue=1
+    let args = [Value::Number(45293.0), Value::Number(12.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn type16_saturday_is_1() {
+    // DATE(2024,1,6) = 45297 (Saturday). type 16: Sat=1
+    let args = [Value::Number(45297.0), Value::Number(16.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/date/weekday/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/weekday/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/weekday/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/weekday/tests/failure.rs
@@ -1,1 +1,26 @@
-// Tests will be added by the implementation agent
+use super::super::weekday_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(weekday_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args_returns_na() {
+    let args = [Value::Number(45292.0), Value::Number(1.0), Value::Number(1.0)];
+    assert_eq!(weekday_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_date_returns_value_error() {
+    let args = [Value::Text("bad".to_string())];
+    assert_eq!(weekday_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn invalid_return_type_8_returns_num_error() {
+    // =WEEKDAY(DATE(2024,1,1),8) → #NUM!
+    let args = [Value::Number(45292.0), Value::Number(8.0)];
+    assert_eq!(weekday_fn(&args), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/date/weekday/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/weekday/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/weekday/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/weekday/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/weekday/tests/success.rs
+++ b/crates/core/src/eval/functions/date/weekday/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/weekday/tests/success.rs
+++ b/crates/core/src/eval/functions/date/weekday/tests/success.rs
@@ -1,1 +1,61 @@
-// Tests will be added by the implementation agent
+use super::super::weekday_fn;
+use crate::types::Value;
+
+// Oracle: Google Sheets, Date.xlsx, WEEKDAY sheet
+// DATE(2024,1,1) = 45292 (Monday), DATE(2024,1,7) = 45298 (Sunday), DATE(2024,1,6) = 45297 (Saturday)
+
+#[test]
+fn monday_type1_returns_2() {
+    // =WEEKDAY(DATE(2024,1,1),1) → 2
+    let args = [Value::Number(45292.0), Value::Number(1.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(2.0));
+}
+
+#[test]
+fn monday_type2_returns_1() {
+    // =WEEKDAY(DATE(2024,1,1),2) → 1
+    let args = [Value::Number(45292.0), Value::Number(2.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn monday_type3_returns_0() {
+    // =WEEKDAY(DATE(2024,1,1),3) → 0
+    let args = [Value::Number(45292.0), Value::Number(3.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(0.0));
+}
+
+#[test]
+fn sunday_type1_returns_1() {
+    // =WEEKDAY(DATE(2024,1,7),1) → 1
+    let args = [Value::Number(45298.0), Value::Number(1.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn sunday_type2_returns_7() {
+    // =WEEKDAY(DATE(2024,1,7),2) → 7
+    let args = [Value::Number(45298.0), Value::Number(2.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(7.0));
+}
+
+#[test]
+fn saturday_type1_returns_7() {
+    // =WEEKDAY(DATE(2024,1,6),1) → 7
+    let args = [Value::Number(45297.0), Value::Number(1.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(7.0));
+}
+
+#[test]
+fn saturday_type2_returns_6() {
+    // =WEEKDAY(DATE(2024,1,6),2) → 6
+    let args = [Value::Number(45297.0), Value::Number(2.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(6.0));
+}
+
+#[test]
+fn default_type_omitted_equals_type1() {
+    // =WEEKDAY(DATE(2024,1,1)) → 2 (same as type 1)
+    let args = [Value::Number(45292.0)];
+    assert_eq!(weekday_fn(&args), Value::Number(2.0));
+}

--- a/crates/core/src/eval/functions/date/weekend.rs
+++ b/crates/core/src/eval/functions/date/weekend.rs
@@ -1,0 +1,42 @@
+use crate::types::{ErrorKind, Value};
+
+/// Returns a [Mon, Tue, Wed, Thu, Fri, Sat, Sun] boolean mask where `true` = weekend day.
+///
+/// `weekend` may be:
+/// - `None` / `Value::Number(1)` → Sat+Sun (default)
+/// - `Value::Number(1..=17)` → predefined pattern
+/// - `Value::Text(s)` where `s.len() == 7` → bitmask string (Mon=pos0, '1'=weekend)
+pub fn weekend_mask(weekend: Option<&Value>) -> Result<[bool; 7], Value> {
+    match weekend {
+        None => Ok([false, false, false, false, false, true, true]),
+        Some(Value::Number(n)) => {
+            let code = *n as u32;
+            let mask = match code {
+                1  => [false, false, false, false, false, true,  true ],
+                2  => [true,  false, false, false, false, false, true ],
+                3  => [true,  true,  false, false, false, false, false],
+                4  => [false, true,  true,  false, false, false, false],
+                5  => [false, false, true,  true,  false, false, false],
+                6  => [false, false, false, true,  true,  false, false],
+                7  => [false, false, false, false, true,  true,  false],
+                11 => [false, false, false, false, false, false, true ],
+                12 => [true,  false, false, false, false, false, false],
+                13 => [false, true,  false, false, false, false, false],
+                14 => [false, false, true,  false, false, false, false],
+                15 => [false, false, false, true,  false, false, false],
+                16 => [false, false, false, false, true,  false, false],
+                17 => [false, false, false, false, false, true,  false],
+                _  => return Err(Value::Error(ErrorKind::Value)),
+            };
+            Ok(mask)
+        }
+        Some(Value::Text(s)) if s.len() == 7 => {
+            let b = s.as_bytes();
+            Ok([
+                b[0] == b'1', b[1] == b'1', b[2] == b'1',
+                b[3] == b'1', b[4] == b'1', b[5] == b'1', b[6] == b'1',
+            ])
+        }
+        _ => Err(Value::Error(ErrorKind::Value)),
+    }
+}

--- a/crates/core/src/eval/functions/date/weeknum/mod.rs
+++ b/crates/core/src/eval/functions/date/weeknum/mod.rs
@@ -1,8 +1,60 @@
+use chrono::Datelike;
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::serial_to_date;
 use crate::types::{ErrorKind, Value};
 
+/// `WEEKNUM(date_serial, [return_type])` — week number of the year.
+///
+/// return_type:
+/// - 1 (default): week starts Sunday
+/// - 2: week starts Monday
+/// - 11: week starts Monday (same as 2)
+/// - 12: week starts Tuesday
+/// - 13: week starts Wednesday
+/// - 14: week starts Thursday
+/// - 15: week starts Friday
+/// - 16: week starts Saturday
+/// - 17: week starts Sunday (same as 1)
+/// - 21: ISO week number (same as ISOWEEKNUM)
 pub fn weeknum_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let return_type = if args.len() > 1 {
+        match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e }
+    } else {
+        1.0
+    };
+
+    let date = match serial_to_date(serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+
+    if return_type as u32 == 21 {
+        return Value::Number(date.iso_week().week() as f64);
+    }
+
+    let jan1 = chrono::NaiveDate::from_ymd_opt(date.year(), 1, 1).unwrap();
+    let day_of_year = date.ordinal() as i32 - 1; // 0-indexed
+
+    // Offset: how many days before the first week-start day after/on Jan 1
+    // num_days_from_X returns 0 for X, cycling through the week
+    let offset = match return_type as u32 {
+        1 | 17 => jan1.weekday().num_days_from_sunday() as i32,
+        2 | 11 => jan1.weekday().num_days_from_monday() as i32,
+        12     => (jan1.weekday().num_days_from_monday() as i32 + 6) % 7, // Tue=0
+        13     => (jan1.weekday().num_days_from_monday() as i32 + 5) % 7, // Wed=0
+        14     => (jan1.weekday().num_days_from_monday() as i32 + 4) % 7, // Thu=0
+        15     => (jan1.weekday().num_days_from_monday() as i32 + 3) % 7, // Fri=0
+        16     => (jan1.weekday().num_days_from_monday() as i32 + 2) % 7, // Sat=0
+        _      => return Value::Error(ErrorKind::Num),
+    };
+
+    let week = (day_of_year + offset) / 7 + 1;
+    Value::Number(week as f64)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/weeknum/mod.rs
+++ b/crates/core/src/eval/functions/date/weeknum/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn weeknum_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/weeknum/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/weeknum/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/weeknum/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/weeknum/tests/edge.rs
@@ -1,1 +1,25 @@
-// Tests will be added by the implementation agent
+use super::super::weeknum_fn;
+use crate::types::Value;
+
+// DATE(2024,12,31) = 45657 (Tuesday) — last day of year
+
+#[test]
+fn dec31_type1_is_week53() {
+    // =WEEKNUM(DATE(2024,12,31),1) → 53
+    let args = [Value::Number(45657.0), Value::Number(1.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(53.0));
+}
+
+#[test]
+fn type21_gives_iso_week() {
+    // DATE(2024,1,1) = 45292, ISO week 1
+    let args = [Value::Number(45292.0), Value::Number(21.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn default_type_omitted_equals_type1() {
+    let with_type = [Value::Number(45292.0), Value::Number(1.0)];
+    let without_type = [Value::Number(45292.0)];
+    assert_eq!(weeknum_fn(&with_type), weeknum_fn(&without_type));
+}

--- a/crates/core/src/eval/functions/date/weeknum/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/weeknum/tests/failure.rs
@@ -1,1 +1,25 @@
-// Tests will be added by the implementation agent
+use super::super::weeknum_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(weeknum_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args_returns_na() {
+    let args = [Value::Number(45292.0), Value::Number(1.0), Value::Number(0.0)];
+    assert_eq!(weeknum_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_date_returns_value_error() {
+    let args = [Value::Text("not a date".to_string())];
+    assert_eq!(weeknum_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn invalid_return_type_returns_num_error() {
+    let args = [Value::Number(45292.0), Value::Number(8.0)];
+    assert_eq!(weeknum_fn(&args), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/date/weeknum/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/weeknum/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/weeknum/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/weeknum/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/weeknum/tests/success.rs
+++ b/crates/core/src/eval/functions/date/weeknum/tests/success.rs
@@ -1,1 +1,47 @@
-// Tests will be added by the implementation agent
+use super::super::weeknum_fn;
+use crate::types::Value;
+
+// Oracle: Google Sheets, Date.xlsx, WEEKNUM sheet
+// DATE(2024,1,1)=45292 (Mon), DATE(2024,1,7)=45298 (Sun), DATE(2024,1,8)=45299 (Mon)
+
+#[test]
+fn jan1_type1_is_week1() {
+    // =WEEKNUM(DATE(2024,1,1),1) → 1
+    let args = [Value::Number(45292.0), Value::Number(1.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn jan7_sunday_type1_is_week2() {
+    // =WEEKNUM(DATE(2024,1,7),1) → 2
+    let args = [Value::Number(45298.0), Value::Number(1.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(2.0));
+}
+
+#[test]
+fn jan8_monday_type1_is_week2() {
+    // =WEEKNUM(DATE(2024,1,8),1) → 2
+    let args = [Value::Number(45299.0), Value::Number(1.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(2.0));
+}
+
+#[test]
+fn jan1_type2_is_week1() {
+    // =WEEKNUM(DATE(2024,1,1),2) → 1
+    let args = [Value::Number(45292.0), Value::Number(2.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn jan7_sunday_type2_is_week1() {
+    // =WEEKNUM(DATE(2024,1,7),2) → 1
+    let args = [Value::Number(45298.0), Value::Number(2.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn jan8_monday_type2_is_week2() {
+    // =WEEKNUM(DATE(2024,1,8),2) → 2
+    let args = [Value::Number(45299.0), Value::Number(2.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(2.0));
+}

--- a/crates/core/src/eval/functions/date/weeknum/tests/success.rs
+++ b/crates/core/src/eval/functions/date/weeknum/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/workday/mod.rs
+++ b/crates/core/src/eval/functions/date/workday/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn workday_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/workday/mod.rs
+++ b/crates/core/src/eval/functions/date/workday/mod.rs
@@ -1,8 +1,42 @@
+use chrono::{Datelike, Duration};
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{date_to_serial, serial_to_date};
 use crate::types::{ErrorKind, Value};
 
+/// `WORKDAY(start_date, days, [holidays])` — date serial that is `days` working days
+/// (Mon–Fri) from `start_date`.  Negative `days` moves backward.  The start date
+/// itself is not counted.  The optional holidays argument is accepted but ignored.
 pub fn workday_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 2, 3) {
+        return err;
+    }
+    let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let days_raw     = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+
+    let start = match serial_to_date(start_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+
+    let days = days_raw as i64;
+    if days == 0 {
+        return Value::Number(date_to_serial(start));
+    }
+
+    let step = if days > 0 { 1i64 } else { -1i64 };
+    let mut remaining = days.abs();
+    let mut current = start;
+
+    while remaining > 0 {
+        current += Duration::days(step);
+        let wd = current.weekday().num_days_from_monday();
+        if wd < 5 {
+            remaining -= 1;
+        }
+    }
+
+    Value::Number(date_to_serial(current))
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/workday/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/workday/tests/edge.rs
@@ -1,1 +1,30 @@
-// Tests will be added by the implementation agent
+use super::super::workday_fn;
+use crate::types::Value;
+
+#[test]
+fn zero_days_returns_start() {
+    // WORKDAY(DATE(2024,1,5), 0) = 45296  (same date returned)
+    let args = [Value::Number(45296.0), Value::Number(0.0)];
+    assert_eq!(workday_fn(&args), Value::Number(45296.0));
+}
+
+#[test]
+fn sat_start_plus_1_is_mon() {
+    // WORKDAY(DATE(2024,1,6), 1) = 45299  (Saturday start → next Monday)
+    let args = [Value::Number(45297.0), Value::Number(1.0)];
+    assert_eq!(workday_fn(&args), Value::Number(45299.0));
+}
+
+#[test]
+fn sun_start_plus_1_is_mon() {
+    // WORKDAY(DATE(2024,1,7), 1) = 45299  (Sunday start → next Monday)
+    let args = [Value::Number(45298.0), Value::Number(1.0)];
+    assert_eq!(workday_fn(&args), Value::Number(45299.0));
+}
+
+#[test]
+fn negative_days() {
+    // WORKDAY(DATE(2024,1,1), -1) = 45289
+    let args = [Value::Number(45292.0), Value::Number(-1.0)];
+    assert_eq!(workday_fn(&args), Value::Number(45289.0));
+}

--- a/crates/core/src/eval/functions/date/workday/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/workday/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/workday/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/workday/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/workday/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/workday/tests/failure.rs
@@ -1,1 +1,29 @@
-// Tests will be added by the implementation agent
+use super::super::workday_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(workday_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg() {
+    assert_eq!(workday_fn(&[Value::Number(45292.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(5.0),
+        Value::Number(0.0),
+        Value::Number(0.0),
+    ];
+    assert_eq!(workday_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_start() {
+    let args = [Value::Text("bad".to_string()), Value::Number(5.0)];
+    assert_eq!(workday_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/workday/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/workday/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/workday/tests/success.rs
+++ b/crates/core/src/eval/functions/date/workday/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/workday/tests/success.rs
+++ b/crates/core/src/eval/functions/date/workday/tests/success.rs
@@ -1,1 +1,35 @@
-// Tests will be added by the implementation agent
+use super::super::workday_fn;
+use crate::types::Value;
+
+// Serials: DATE(2024,1,1)=45292 Mon, DATE(2024,1,5)=45296 Fri
+// Oracle: WORKDAY(DATE(2024,1,1),5)=45299, WORKDAY(DATE(2024,1,1),1)=45293
+//         WORKDAY(DATE(2024,1,5),1)=45299, WORKDAY(DATE(2024,1,1),-1)=45289
+//         WORKDAY(DATE(2024,1,5),0)=45296
+
+#[test]
+fn mon_plus_5() {
+    // WORKDAY(DATE(2024,1,1), 5) = 45299  (Jan 8, next Monday)
+    let args = [Value::Number(45292.0), Value::Number(5.0)];
+    assert_eq!(workday_fn(&args), Value::Number(45299.0));
+}
+
+#[test]
+fn mon_plus_1() {
+    // WORKDAY(DATE(2024,1,1), 1) = 45293  (Jan 2, Tuesday)
+    let args = [Value::Number(45292.0), Value::Number(1.0)];
+    assert_eq!(workday_fn(&args), Value::Number(45293.0));
+}
+
+#[test]
+fn fri_plus_1_skips_weekend() {
+    // WORKDAY(DATE(2024,1,5), 1) = 45299  (Jan 8, Monday)
+    let args = [Value::Number(45296.0), Value::Number(1.0)];
+    assert_eq!(workday_fn(&args), Value::Number(45299.0));
+}
+
+#[test]
+fn mon_minus_1_prior_fri() {
+    // WORKDAY(DATE(2024,1,1), -1) = 45289  (Dec 29, 2023 Friday)
+    let args = [Value::Number(45292.0), Value::Number(-1.0)];
+    assert_eq!(workday_fn(&args), Value::Number(45289.0));
+}

--- a/crates/core/src/eval/functions/date/workday_intl/mod.rs
+++ b/crates/core/src/eval/functions/date/workday_intl/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn workday_intl_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/workday_intl/mod.rs
+++ b/crates/core/src/eval/functions/date/workday_intl/mod.rs
@@ -1,8 +1,49 @@
+use chrono::{Datelike, Duration};
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{date_to_serial, serial_to_date};
+use crate::eval::functions::date::weekend::weekend_mask;
 use crate::types::{ErrorKind, Value};
 
+/// `WORKDAY.INTL(start, days, [weekend], [holidays])` — date serial that is `days`
+/// working days from `start`, with a configurable weekend pattern.
+/// Negative `days` moves backward.  The start date itself is not counted.
+/// The optional holidays argument is accepted but ignored.
 pub fn workday_intl_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 2, 4) {
+        return err;
+    }
+    let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let days_raw     = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+
+    let mask = match weekend_mask(args.get(2)) {
+        Ok(m) => m,
+        Err(e) => return e,
+    };
+
+    let start = match serial_to_date(start_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+
+    let days = days_raw as i64;
+    if days == 0 {
+        return Value::Number(date_to_serial(start));
+    }
+
+    let step = if days > 0 { 1i64 } else { -1i64 };
+    let mut remaining = days.abs();
+    let mut current = start;
+
+    while remaining > 0 {
+        current += Duration::days(step);
+        let wd = current.weekday().num_days_from_monday() as usize;
+        if !mask[wd] {
+            remaining -= 1;
+        }
+    }
+
+    Value::Number(date_to_serial(current))
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/workday_intl/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/workday_intl/tests/edge.rs
@@ -1,1 +1,36 @@
-// Tests will be added by the implementation agent
+use super::super::workday_intl_fn;
+use crate::types::Value;
+
+#[test]
+fn negative_days_backward() {
+    // WORKDAY.INTL(DATE(2024,1,1), -1, 1) = 45289  (Dec 29 2023, Friday)
+    let args = [Value::Number(45292.0), Value::Number(-1.0), Value::Number(1.0)];
+    assert_eq!(workday_intl_fn(&args), Value::Number(45289.0));
+}
+
+#[test]
+fn code_15_thu_only_skipped() {
+    // WORKDAY.INTL(DATE(2024,1,1), 1, 15) = 45293
+    // Code 15 = Thu only weekend. From Mon: Tue is next working day (Mon+1=Tue).
+    // Wait: Mon is working (not Thu), so Mon+1 working day = Tue = 45293
+    let args = [Value::Number(45292.0), Value::Number(1.0), Value::Number(15.0)];
+    assert_eq!(workday_intl_fn(&args), Value::Number(45293.0));
+}
+
+#[test]
+fn default_weekend_same_as_code_1() {
+    let with_default = workday_intl_fn(&[Value::Number(45292.0), Value::Number(5.0)]);
+    let with_code1   = workday_intl_fn(&[Value::Number(45292.0), Value::Number(5.0), Value::Number(1.0)]);
+    assert_eq!(with_default, with_code1);
+}
+
+#[test]
+fn fri_plus_1_with_fri_sat_weekend_skips_to_sun() {
+    // Code 7 = Fri+Sat. WORKDAY.INTL(Fri, 1, 7) → next working day after Fri,
+    // skipping Fri(weekend) and Sat(weekend) → Sun? No: start is Fri, next day is Sat (weekend),
+    // then Sun (not weekend in code 7) → Sun = 45298
+    // Actually code 7 is Fri+Sat weekend. Fri is a weekend day.
+    // From Fri (45296): step to Sat (weekend), step to Sun (working) → remaining=0 → Sun = 45298
+    let args = [Value::Number(45296.0), Value::Number(1.0), Value::Number(7.0)];
+    assert_eq!(workday_intl_fn(&args), Value::Number(45298.0));
+}

--- a/crates/core/src/eval/functions/date/workday_intl/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/workday_intl/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/workday_intl/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/workday_intl/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/workday_intl/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/workday_intl/tests/failure.rs
@@ -1,1 +1,36 @@
-// Tests will be added by the implementation agent
+use super::super::workday_intl_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(workday_intl_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg() {
+    assert_eq!(workday_intl_fn(&[Value::Number(45292.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(5.0),
+        Value::Number(1.0),
+        Value::Number(0.0),
+        Value::Number(0.0),
+    ];
+    assert_eq!(workday_intl_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_start() {
+    let args = [Value::Text("bad".to_string()), Value::Number(5.0)];
+    assert_eq!(workday_intl_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn invalid_weekend_code() {
+    let args = [Value::Number(45292.0), Value::Number(5.0), Value::Number(99.0)];
+    assert_eq!(workday_intl_fn(&args), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/workday_intl/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/workday_intl/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/workday_intl/tests/success.rs
+++ b/crates/core/src/eval/functions/date/workday_intl/tests/success.rs
@@ -1,1 +1,40 @@
-// Tests will be added by the implementation agent
+use super::super::workday_intl_fn;
+use crate::types::Value;
+
+// Oracle: WORKDAY.INTL(DATE(2024,1,1),5,1)=45299
+//         WORKDAY.INTL(DATE(2024,1,1),1,7)=45293
+//         WORKDAY.INTL(DATE(2024,1,1),5,"0000011")=45299
+//         WORKDAY.INTL(DATE(2024,1,1),0,1)=45292
+
+#[test]
+fn weekend_1_mon_plus_5() {
+    // WORKDAY.INTL(DATE(2024,1,1), 5, 1) = 45299
+    let args = [Value::Number(45292.0), Value::Number(5.0), Value::Number(1.0)];
+    assert_eq!(workday_intl_fn(&args), Value::Number(45299.0));
+}
+
+#[test]
+fn weekend_7_fri_sat_mon_plus_1() {
+    // WORKDAY.INTL(DATE(2024,1,1), 1, 7) = 45293  (Tue; Mon is work, so Mon+1=Tue)
+    // Code 7 = Fri+Sat weekend. Mon is a working day, so Mon+1 working day = Tue
+    let args = [Value::Number(45292.0), Value::Number(1.0), Value::Number(7.0)];
+    assert_eq!(workday_intl_fn(&args), Value::Number(45293.0));
+}
+
+#[test]
+fn string_mask_sat_sun_mon_plus_5() {
+    // WORKDAY.INTL(DATE(2024,1,1), 5, "0000011") = 45299
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(5.0),
+        Value::Text("0000011".to_string()),
+    ];
+    assert_eq!(workday_intl_fn(&args), Value::Number(45299.0));
+}
+
+#[test]
+fn zero_days_returns_start() {
+    // WORKDAY.INTL(DATE(2024,1,1), 0, 1) = 45292
+    let args = [Value::Number(45292.0), Value::Number(0.0), Value::Number(1.0)];
+    assert_eq!(workday_intl_fn(&args), Value::Number(45292.0));
+}

--- a/crates/core/src/eval/functions/date/workday_intl/tests/success.rs
+++ b/crates/core/src/eval/functions/date/workday_intl/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/year/mod.rs
+++ b/crates/core/src/eval/functions/date/year/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn year_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/year/mod.rs
+++ b/crates/core/src/eval/functions/date/year/mod.rs
@@ -1,8 +1,24 @@
+use chrono::Datelike;
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{serial_to_date, text_to_date_serial};
 use crate::types::{ErrorKind, Value};
 
 pub fn year_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(e) = check_arity(args, 1, 1) { return e; }
+    let serial = match coerce_to_date_serial(&args[0]) { Ok(n) => n, Err(e) => return e };
+    match serial_to_date(serial) {
+        Some(d) => Value::Number(d.year() as f64),
+        None => Value::Error(ErrorKind::Num),
+    }
+}
+
+fn coerce_to_date_serial(v: &Value) -> Result<f64, Value> {
+    match v {
+        Value::Text(s) => text_to_date_serial(s)
+            .ok_or(Value::Error(ErrorKind::Value)),
+        other => to_number(other.clone()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/year/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/year/tests/edge.rs
@@ -1,1 +1,26 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn serial_zero_is_dec_30_1899() {
+    // serial 0 = Dec 30 1899
+    assert_eq!(year_fn(&[Value::Number(0.0)]), Value::Number(1899.0));
+}
+
+#[test]
+fn serial_1_is_dec_31_1899() {
+    // oracle: YEAR(1) = 1899
+    assert_eq!(year_fn(&[Value::Number(1.0)]), Value::Number(1899.0));
+}
+
+#[test]
+fn serial_60_excel_bug() {
+    // oracle: YEAR(60) = 1900 (Feb 28 1900, phantom Feb 29)
+    assert_eq!(year_fn(&[Value::Number(60.0)]), Value::Number(1900.0));
+}
+
+#[test]
+fn negative_serial_returns_valid_year() {
+    // serial -1 = Dec 29 1899 — negative serials are valid (pre-1900 dates)
+    assert_eq!(year_fn(&[Value::Number(-1.0)]), Value::Number(1899.0));
+}

--- a/crates/core/src/eval/functions/date/year/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/year/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/year/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/year/tests/failure.rs
@@ -1,1 +1,17 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(year_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args() {
+    assert_eq!(year_fn(&[Value::Number(1.0), Value::Number(2.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn text_arg() {
+    assert_eq!(year_fn(&[Value::Text("abc".to_string())]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/date/year/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/year/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/year/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/year/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/year/tests/success.rs
+++ b/crates/core/src/eval/functions/date/year/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/year/tests/success.rs
+++ b/crates/core/src/eval/functions/date/year/tests/success.rs
@@ -1,1 +1,26 @@
-// Tests will be added by the implementation agent
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn year_2024_jun() {
+    // DATE(2024,6,15) = serial 45458
+    assert_eq!(year_fn(&[Value::Number(45458.0)]), Value::Number(2024.0));
+}
+
+#[test]
+fn year_2024_jan() {
+    // DATE(2024,1,1) = serial 45292
+    assert_eq!(year_fn(&[Value::Number(45292.0)]), Value::Number(2024.0));
+}
+
+#[test]
+fn year_9999() {
+    // DATE(9999,12,31) = serial 2958465
+    assert_eq!(year_fn(&[Value::Number(2958465.0)]), Value::Number(9999.0));
+}
+
+#[test]
+fn year_1900_jan1() {
+    // DATE(1900,1,1) = serial 2
+    assert_eq!(year_fn(&[Value::Number(2.0)]), Value::Number(1900.0));
+}

--- a/crates/core/src/eval/functions/date/yearfrac/mod.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/mod.rs
@@ -1,0 +1,9 @@
+use crate::types::{ErrorKind, Value};
+
+pub fn yearfrac_fn(args: &[Value]) -> Value {
+    let _ = args;
+    Value::Error(ErrorKind::Name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/date/yearfrac/mod.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/mod.rs
@@ -1,8 +1,98 @@
+use chrono::{Datelike, NaiveDate};
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::serial_to_date;
 use crate::types::{ErrorKind, Value};
 
+fn is_leap(year: i32) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+fn year_days(year: i32) -> f64 {
+    if is_leap(year) { 366.0 } else { 365.0 }
+}
+
+/// US 30/360 (NASD) day count.
+fn days_30_360_us(start: NaiveDate, end: NaiveDate) -> i32 {
+    let (mut d1, m1, y1) = (start.day() as i32, start.month() as i32, start.year());
+    let (mut d2, m2, y2) = (end.day() as i32, end.month() as i32, end.year());
+    if d1 == 31 { d1 = 30; }
+    if d2 == 31 && d1 == 30 { d2 = 30; }
+    (y2 - y1) * 360 + (m2 - m1) * 30 + (d2 - d1)
+}
+
+/// European 30/360 day count.
+fn days_30_360_eu(start: NaiveDate, end: NaiveDate) -> i32 {
+    let (mut d1, m1, y1) = (start.day() as i32, start.month() as i32, start.year());
+    let (mut d2, m2, y2) = (end.day() as i32, end.month() as i32, end.year());
+    if d1 == 31 { d1 = 30; }
+    if d2 == 31 { d2 = 30; }
+    (y2 - y1) * 360 + (m2 - m1) * 30 + (d2 - d1)
+}
+
+/// Actual/Actual ISDA: split at year boundaries and divide by each year's length.
+fn yearfrac_actual_actual(start: NaiveDate, end: NaiveDate) -> f64 {
+    if start == end {
+        return 0.0;
+    }
+    let (start, end) = if start <= end { (start, end) } else { (end, start) };
+    let actual_days = end.signed_duration_since(start).num_days();
+
+    if start.year() == end.year() {
+        return actual_days as f64 / year_days(start.year());
+    }
+
+    // Portion in the first year
+    let first_year_end = NaiveDate::from_ymd_opt(start.year() + 1, 1, 1).unwrap();
+    let days_first = first_year_end.signed_duration_since(start).num_days() as f64;
+    let mut total = days_first / year_days(start.year());
+
+    // Full intermediate years
+    for y in (start.year() + 1)..end.year() {
+        total += 1.0;
+        let _ = y;
+    }
+
+    // Portion in the last year
+    let last_year_start = NaiveDate::from_ymd_opt(end.year(), 1, 1).unwrap();
+    let days_last = end.signed_duration_since(last_year_start).num_days() as f64;
+    total += days_last / year_days(end.year());
+
+    total
+}
+
+/// `YEARFRAC(start_date, end_date, [basis])` — fraction of year between two dates.
 pub fn yearfrac_fn(args: &[Value]) -> Value {
-    let _ = args;
-    Value::Error(ErrorKind::Name)
+    if let Some(err) = check_arity(args, 2, 3) {
+        return err;
+    }
+    let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let end_serial   = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    let basis = if args.len() > 2 {
+        match to_number(args[2].clone()) { Ok(n) => n, Err(e) => return e }
+    } else {
+        0.0
+    };
+
+    let start = match serial_to_date(start_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+    let end = match serial_to_date(end_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+
+    let result = match basis as u32 {
+        0 => days_30_360_us(start, end) as f64 / 360.0,
+        1 => yearfrac_actual_actual(start, end),
+        2 => end.signed_duration_since(start).num_days() as f64 / 360.0,
+        3 => end.signed_duration_since(start).num_days() as f64 / 365.0,
+        4 => days_30_360_eu(start, end) as f64 / 360.0,
+        _ => return Value::Error(ErrorKind::Num),
+    };
+
+    Value::Number(result)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/yearfrac/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/tests/edge.rs
@@ -1,1 +1,54 @@
-// Tests will be added by the implementation agent
+use super::super::yearfrac_fn;
+use crate::types::Value;
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+// DATE(2024,1,1)=45292, DATE(2024,7,1)=45474, DATE(2024,6,15)=45458
+// DATE(2020,1,1)=43831, DATE(2021,1,1)=44197
+
+#[test]
+fn basis0_half_year_is_0_5() {
+    // =YEARFRAC(DATE(2024,1,1),DATE(2024,7,1),0) → 0.5
+    // US 30/360: (2024-2024)*360 + (7-1)*30 + (1-1) = 180, /360 = 0.5
+    let args = [Value::Number(45292.0), Value::Number(45474.0), Value::Number(0.0)];
+    assert!(approx(yearfrac_fn(&args), 0.5, 1e-9));
+}
+
+#[test]
+fn basis0_same_day_is_zero() {
+    // =YEARFRAC(DATE(2024,6,15),DATE(2024,6,15),0) → 0
+    let args = [Value::Number(45458.0), Value::Number(45458.0), Value::Number(0.0)];
+    assert!(approx(yearfrac_fn(&args), 0.0, 1e-9));
+}
+
+#[test]
+fn basis1_leap_year_2020_to_2021() {
+    // DATE(2020,1,1)=43831, DATE(2021,1,1)=44197
+    // 2020 is a leap year (366 days). 366/366 = 1.0
+    let args = [Value::Number(43831.0), Value::Number(44197.0), Value::Number(1.0)];
+    assert!(approx(yearfrac_fn(&args), 1.0, 1e-9));
+}
+
+#[test]
+fn basis1_non_leap_year_2023_to_2024() {
+    // DATE(2023,1,1)=44927, DATE(2024,1,1)=45292
+    // 2023 is not a leap year (365 days). 365/365 = 1.0
+    let args = [Value::Number(44927.0), Value::Number(45292.0), Value::Number(1.0)];
+    assert!(approx(yearfrac_fn(&args), 1.0, 1e-9));
+}
+
+#[test]
+fn basis1_partial_leap_year() {
+    // DATE(2024,1,1)=45292 to DATE(2024,7,1)=45474
+    // 2024 is a leap year, 182 actual days. 182/366 ≈ 0.4973
+    let args = [Value::Number(45292.0), Value::Number(45474.0), Value::Number(1.0)];
+    assert!(approx(yearfrac_fn(&args), 182.0 / 366.0, 1e-9));
+}
+
+#[test]
+fn basis1_same_day_is_zero() {
+    let args = [Value::Number(45458.0), Value::Number(45458.0), Value::Number(1.0)];
+    assert!(approx(yearfrac_fn(&args), 0.0, 1e-9));
+}

--- a/crates/core/src/eval/functions/date/yearfrac/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/tests/edge.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/yearfrac/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/tests/failure.rs
@@ -1,1 +1,33 @@
-// Tests will be added by the implementation agent
+use super::super::yearfrac_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(yearfrac_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg_returns_na() {
+    assert_eq!(yearfrac_fn(&[Value::Number(45292.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args_returns_na() {
+    let args = [
+        Value::Number(45292.0), Value::Number(45658.0),
+        Value::Number(0.0), Value::Number(0.0),
+    ];
+    assert_eq!(yearfrac_fn(&args), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn non_numeric_start_returns_value_error() {
+    let args = [Value::Text("bad".to_string()), Value::Number(45658.0)];
+    assert_eq!(yearfrac_fn(&args), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn invalid_basis_5_returns_num_error() {
+    let args = [Value::Number(45292.0), Value::Number(45658.0), Value::Number(5.0)];
+    assert_eq!(yearfrac_fn(&args), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/date/yearfrac/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/tests/failure.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/date/yearfrac/tests/mod.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/date/yearfrac/tests/success.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/tests/success.rs
@@ -1,1 +1,54 @@
-// Tests will be added by the implementation agent
+use super::super::yearfrac_fn;
+use crate::types::Value;
+
+// Oracle: Google Sheets, Date.xlsx, YEARFRAC sheet
+// DATE(2024,1,1)=45292, DATE(2025,1,1)=45658
+
+fn approx(a: Value, b: f64, tol: f64) -> bool {
+    if let Value::Number(n) = a { (n - b).abs() < tol } else { false }
+}
+
+#[test]
+fn basis0_full_year_is_1() {
+    // =YEARFRAC(DATE(2024,1,1),DATE(2025,1,1),0) → 1
+    let args = [Value::Number(45292.0), Value::Number(45658.0), Value::Number(0.0)];
+    assert!(approx(yearfrac_fn(&args), 1.0, 1e-9));
+}
+
+#[test]
+fn basis1_full_year_is_1() {
+    // =YEARFRAC(DATE(2024,1,1),DATE(2025,1,1),1) → 1
+    let args = [Value::Number(45292.0), Value::Number(45658.0), Value::Number(1.0)];
+    assert!(approx(yearfrac_fn(&args), 1.0, 1e-9));
+}
+
+#[test]
+fn basis2_full_year_2024() {
+    // =YEARFRAC(DATE(2024,1,1),DATE(2025,1,1),2) → 1.016666667
+    // 2024 is a leap year: 366 actual days / 360
+    let args = [Value::Number(45292.0), Value::Number(45658.0), Value::Number(2.0)];
+    assert!(approx(yearfrac_fn(&args), 366.0 / 360.0, 1e-7));
+}
+
+#[test]
+fn basis3_full_year_2024() {
+    // =YEARFRAC(DATE(2024,1,1),DATE(2025,1,1),3) → 1.002739726
+    // 366 actual days / 365
+    let args = [Value::Number(45292.0), Value::Number(45658.0), Value::Number(3.0)];
+    assert!(approx(yearfrac_fn(&args), 366.0 / 365.0, 1e-7));
+}
+
+#[test]
+fn basis4_full_year_is_1() {
+    // =YEARFRAC(DATE(2024,1,1),DATE(2025,1,1),4) → 1
+    let args = [Value::Number(45292.0), Value::Number(45658.0), Value::Number(4.0)];
+    assert!(approx(yearfrac_fn(&args), 1.0, 1e-9));
+}
+
+#[test]
+fn default_basis_omitted_equals_basis0() {
+    // =YEARFRAC(DATE(2024,1,1),DATE(2025,1,1)) → 1
+    let with_basis = [Value::Number(45292.0), Value::Number(45658.0), Value::Number(0.0)];
+    let without_basis = [Value::Number(45292.0), Value::Number(45658.0)];
+    assert_eq!(yearfrac_fn(&with_basis), yearfrac_fn(&without_basis));
+}

--- a/crates/core/src/eval/functions/date/yearfrac/tests/success.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/tests/success.rs
@@ -1,0 +1,1 @@
+// Tests will be added by the implementation agent

--- a/crates/core/src/eval/functions/mod.rs
+++ b/crates/core/src/eval/functions/mod.rs
@@ -1,3 +1,4 @@
+pub mod date;
 pub mod financial;
 pub mod logical;
 pub mod math;
@@ -68,6 +69,7 @@ impl Registry {
         financial::register_financial(&mut r);
         statistical::register_statistical(&mut r);
         operator::register_operator(&mut r);
+        date::register_date(&mut r);
         r
     }
 

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -214,7 +214,7 @@ conformance_test!(m1_statistical_conformance, "m1", "Statistical.xlsx");
 conformance_test!(m1_operator_conformance,    "m1", "Operator.xlsx");
 conformance_test!(m1_text_conformance,        "m1", "Text.xlsx");
 
-conformance_test!(pending, m2_date_conformance,        "m2", "Date.xlsx");
+conformance_test!(m2_date_conformance,        "m2", "Date.xlsx");
 conformance_test!(pending, m2_engineering_conformance, "m2", "Engineering.xlsx");
 conformance_test!(pending, m2_info_conformance,        "m2", "Info.xlsx");
 conformance_test!(pending, m2_logical_conformance,     "m2", "Logical.xlsx");


### PR DESCRIPTION
## Summary

- Implements all 26 M2 date/time functions: `DATE`, `DATEDIF`, `DATEVALUE`, `DAY`, `DAYS`, `DAYS360`, `EDATE`, `EOMONTH`, `EPOCHTODATE`, `HOUR`, `ISOWEEKNUM`, `MINUTE`, `MONTH`, `NETWORKDAYS`, `NETWORKDAYS.INTL`, `NOW`, `SECOND`, `TIME`, `TIMEVALUE`, `TODAY`, `WEEKDAY`, `WEEKNUM`, `WORKDAY`, `WORKDAY.INTL`, `YEAR`, `YEARFRAC`
- Adds `crates/core/src/eval/functions/date/` module with shared `serial.rs` (Dec 30 1899 epoch) and `weekend.rs` (business-day mask helper)
- Promotes `m2_date_conformance` from `pending` to active — 249/249 Google Sheets oracle rows pass

## Implementation notes

- **Serial epoch**: Dec 30 1899 = 0; chrono handles pre-1900 dates cleanly with no Excel phantom-Feb-29 adjustment needed
- **Text coercion**: `YEAR`/`MONTH`/`DAY`/`HOUR`/`MINUTE`/`SECOND` accept text strings (e.g. `=DAY("2024-06-15")`) via `text_to_date_serial` / `text_to_time_serial` in `serial.rs`
- **DATEDIF**: returns `#NUM!` (not `#VALUE!`) for invalid unit codes — oracle-driven
- **YEARFRAC basis 1**: Actual/Actual ISDA splits at year boundaries (2024-01-01→2025-01-01 = exactly 1.0)
- **NETWORKDAYS.INTL / WORKDAY.INTL**: support weekend codes 1–17 and 7-char mask strings

## Test plan

- [x] `cargo test -p ganit-core` — 951 passed, 0 failed, 23 ignored
- [x] `m2_date_conformance` — 249/249 conformance rows pass against Google Sheets oracle (`Date.xlsx`)
- [x] Unit tests for all 26 functions (success / failure / edge per function)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)