### PR TITLE
feat(parser): add {} array literal syntax

### DIFF
--- a/crates/core/src/eval/mod.rs
+++ b/crates/core/src/eval/mod.rs
@@ -50,6 +50,16 @@ pub fn evaluate_expr(expr: &Expr, ctx: &mut EvalCtx<'_>) -> Value {
             eval_binary(op, lv, rv)
         }
 
+        // ── Array literals ──────────────────────────────────────────────────
+        Expr::Array(elems, _) => {
+            let mut values = Vec::with_capacity(elems.len());
+            for elem in elems {
+                let v = evaluate_expr(elem, ctx);
+                values.push(v);
+            }
+            Value::Array(values)
+        }
+
         // ── Function calls ──────────────────────────────────────────────────
         Expr::FunctionCall { name, args, .. } => {
             match ctx.registry.get(name) {

--- a/crates/core/src/eval/tests/array_literal.rs
+++ b/crates/core/src/eval/tests/array_literal.rs
@@ -1,0 +1,54 @@
+use crate::types::Value;
+use std::collections::HashMap;
+
+fn run_formula(formula: &str) -> Value {
+    crate::evaluate(formula, &HashMap::new())
+}
+
+#[test]
+fn array_literal_evaluates_to_array() {
+    let result = run_formula("={1,2,3}");
+    assert!(matches!(result, Value::Array(ref v) if v.len() == 3));
+}
+
+#[test]
+fn array_literal_values_are_correct() {
+    let result = run_formula("={1,2,3}");
+    match result {
+        Value::Array(v) => {
+            assert_eq!(v[0], Value::Number(1.0));
+            assert_eq!(v[1], Value::Number(2.0));
+            assert_eq!(v[2], Value::Number(3.0));
+        }
+        _ => panic!("Expected Array"),
+    }
+}
+
+#[test]
+fn array_literal_empty() {
+    let result = run_formula("={}");
+    assert!(matches!(result, Value::Array(ref v) if v.is_empty()));
+}
+
+#[test]
+fn array_literal_mixed_types() {
+    let result = run_formula("={1,\"hello\",TRUE}");
+    match result {
+        Value::Array(v) => {
+            assert_eq!(v.len(), 3);
+            assert_eq!(v[0], Value::Number(1.0));
+            assert_eq!(v[1], Value::Text("hello".to_string()));
+            assert_eq!(v[2], Value::Bool(true));
+        }
+        _ => panic!("Expected Array"),
+    }
+}
+
+#[test]
+fn array_literal_in_function_does_not_panic() {
+    // SUM with an array arg returns #VALUE! today — that's expected
+    // The important thing is no panic.
+    let result = run_formula("=SUM({1,2,3})");
+    // Either a Value or an Error is fine; just must not panic.
+    let _ = result;
+}

--- a/crates/core/src/eval/tests/mod.rs
+++ b/crates/core/src/eval/tests/mod.rs
@@ -1,3 +1,4 @@
 mod success;
 mod failure;
 mod edge;
+mod array_literal;

--- a/crates/core/src/parser/ast.rs
+++ b/crates/core/src/parser/ast.rs
@@ -46,6 +46,7 @@ pub enum Expr {
         args: Vec<Expr>,
         span: Span,
     },
+    Array(Vec<Expr>, Span),
 }
 
 impl Expr {
@@ -55,6 +56,7 @@ impl Expr {
             Expr::UnaryOp { span, .. }
             | Expr::BinaryOp { span, .. }
             | Expr::FunctionCall { span, .. } => span,
+            Expr::Array(_, span) => span,
         }
     }
 }

--- a/crates/core/src/parser/mod.rs
+++ b/crates/core/src/parser/mod.rs
@@ -37,6 +37,19 @@ impl<'a> Parser<'a> {
             return Ok((rest, Expr::Text(text, self.span(i, rest))));
         }
 
+        // Array literal: {expr, expr, ...}
+        if let Some(inner) = i.strip_prefix('{') {
+            let (rest, elems) = self.parse_array_elements(inner)?;
+            let rest = multispace0(rest)?.0;
+            if let Some(after) = rest.strip_prefix('}') {
+                return Ok((after, Expr::Array(elems, self.span(i, after))));
+            }
+            return Err(nom::Err::Error(nom::error::Error::new(
+                rest,
+                nom::error::ErrorKind::Char,
+            )));
+        }
+
         // Parenthesised expression
         if let Some(inner) = i.strip_prefix('(') {
             let (rest, expr) = self.parse_comparison(inner)?;
@@ -104,6 +117,28 @@ impl<'a> Parser<'a> {
         }
 
         Ok((rest, args))
+    }
+
+    fn parse_array_elements(&self, i: &'a str) -> IResult<&'a str, Vec<Expr>> {
+        let mut elems = Vec::new();
+        let mut rest = multispace0(i)?.0;
+        if rest.starts_with('}') {
+            return Ok((rest, elems)); // empty array {}
+        }
+        let (r, first) = self.parse_comparison(rest)?;
+        elems.push(first);
+        rest = r;
+        loop {
+            rest = multispace0(rest)?.0;
+            if let Some(after_comma) = rest.strip_prefix(',') {
+                let (r, elem) = self.parse_comparison(after_comma)?;
+                elems.push(elem);
+                rest = r;
+            } else {
+                break;
+            }
+        }
+        Ok((rest, elems))
     }
 
     // ── postfix % ─────────────────────────────────────────────────────────
@@ -379,6 +414,40 @@ mod tests {
     fn parse_variable() {
         let expr = parse("=myVar").unwrap();
         assert!(matches!(expr, Expr::Variable(ref n, _) if n == "myVar"));
+    }
+
+    #[test]
+    fn parse_array_literal_numbers() {
+        let expr = parse("={1,2,3}").unwrap();
+        match expr {
+            Expr::Array(elems, _) => assert_eq!(elems.len(), 3),
+            _ => panic!("Expected Array"),
+        }
+    }
+
+    #[test]
+    fn parse_array_literal_mixed() {
+        let expr = parse("={1,\"hello\",TRUE}").unwrap();
+        assert!(matches!(expr, Expr::Array(_, _)));
+    }
+
+    #[test]
+    fn parse_array_literal_empty() {
+        let expr = parse("={}").unwrap();
+        assert!(matches!(expr, Expr::Array(ref e, _) if e.is_empty()));
+    }
+
+    #[test]
+    fn parse_array_in_function_call() {
+        let expr = parse("=SUM({1,2,3})").unwrap();
+        match expr {
+            Expr::FunctionCall { name, args, .. } => {
+                assert_eq!(name, "SUM");
+                assert_eq!(args.len(), 1);
+                assert!(matches!(args[0], Expr::Array(_, _)));
+            }
+            _ => panic!("Expected FunctionCall"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

- New `Expr::Array(Vec<Expr>, Span)` AST node in `parser/ast.rs`
- `parse_primary` handles `{` as array start, parsing `{expr, expr, ...}` via new `parse_array_elements` helper
- `evaluate_expr` evaluates each element into `Value::Array` (all elements evaluated, errors propagate inside the array)
- 4 parser tests + 5 eval integration tests

## Why

Required by all COUNTIF/SUMIF/AVERAGEIF/COUNTBLANK conformance test formulas which use `{1,2,3}` syntax. Without this, `=COUNTIF({1,2,3}, ">2")` fails to parse entirely.

## Test results

All 972 existing tests continue to pass. New tests cover:
- `={1,2,3}` → `Value::Array` with 3 elements
- `={}` → empty `Value::Array`
- `={1,"hello",TRUE}` → mixed-type array
- `=SUM({1,2,3})` → no panic (returns `#VALUE!` until SUM gains array-aware evaluation)

Closes #269