### PR TITLE
fix(clippy): resolve clippy warnings in date functions

### DIFF
--- a/crates/core/src/eval/functions/date/date_fn/mod.rs
+++ b/crates/core/src/eval/functions/date/date_fn/mod.rs
@@ -10,6 +10,7 @@ use crate::types::{ErrorKind, Value};
 /// - Month 13 of 2024 → January 2025
 /// - Month 0 of 2024 → December 2023
 /// - Day 0 of March → last day of February
+///
 /// All inputs are truncated to integer before use.
 pub fn date_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 3, 3) {
@@ -30,7 +31,7 @@ pub fn date_fn(args: &[Value]) -> Value {
     let month_norm = (month_adj.rem_euclid(12) + 1) as u32; // back to 1-indexed
     year_i += year_delta;
 
-    if year_i < 0 || year_i > 9999 {
+    if !(0..=9999).contains(&year_i) {
         return Value::Error(ErrorKind::Num);
     }
 

--- a/crates/core/src/eval/functions/date/days360/mod.rs
+++ b/crates/core/src/eval/functions/date/days360/mod.rs
@@ -47,15 +47,11 @@ pub fn days360_fn(args: &[Value]) -> Value {
         let start_is_feb_end = m1 == 2 && is_last_day_of_month(start_date);
         let end_is_feb_end   = m2 == 2 && is_last_day_of_month(end_date);
 
-        if start_is_feb_end {
-            d1 = 30;
-        } else if d1 == 31 {
+        if start_is_feb_end || d1 == 31 {
             d1 = 30;
         }
 
-        if start_is_feb_end && end_is_feb_end {
-            d2 = 30;
-        } else if d2 == 31 && d1 == 30 {
+        if (start_is_feb_end && end_is_feb_end) || (d2 == 31 && d1 == 30) {
             d2 = 30;
         }
     }


### PR DESCRIPTION
## Summary
- Fix `doc_lazy_continuation` lint in `date_fn/mod.rs` (missing blank line in doc comment)
- Fix `manual_range_contains` lint: `year_i < 0 || year_i > 9999` → `!(0..=9999).contains(&year_i)`
- Fix two `if_same_then_else` lints in `days360/mod.rs` (merge identical branches)

## Test plan
- [ ] `cargo clippy -p ganit-core` passes with no warnings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)