### PR TITLE
ci: raise WASM size budget to 200 KB for M2 functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           SIZE=$(gzip -c crates/wasm/pkg/ganit_wasm_bg.wasm | wc -c)
           echo "Gzipped WASM size: ${SIZE} bytes"
-          if [ "$SIZE" -gt 133120 ]; then
-            echo "WASM size ${SIZE} bytes exceeds 130 KB limit (133120 bytes)"
+          if [ "$SIZE" -gt 204800 ]; then
+            echo "WASM size ${SIZE} bytes exceeds 200 KB limit (204800 bytes)"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Date functions + 6 new M2 functions (PROPER, SEARCH, COUNTBLANK, COUNTIF, SUMIF, AVERAGEIF) grew the gzipped WASM from ~130 KB to 141+ KB
- Raise the CI cap from 130 KB (133,120 bytes) to 200 KB (204,800 bytes) to cover the full M2 milestone

## Test plan
- [ ] CI passes with new limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)