### PR TITLE
feat: implement ISREF and ISFORMULA (#211, #213)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,15 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
+## 5. Worktree-Based Development
+
+**Always develop on branches. Never commit directly to `main`.**
+
+- Each issue gets its own branch: `feat/<issue-number>-<short-description>`
+- Branches ship as PRs against `main`; they are never merged locally
+- When dispatching parallel agents, always pass `isolation: "worktree"` so each agent commits to its own branch — never to `main`
+- Tests must pass on the branch before the PR is opened
+
 ---
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +87,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,7 +108,9 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
+ "iana-time-zone",
  "num-traits",
+ "windows-link",
 ]
 
 [[package]]
@@ -100,6 +121,12 @@ checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
 dependencies = [
  "encoding_rs",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -168,6 +195,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -280,6 +313,30 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "id-arena"
@@ -610,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,10 +883,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/core/src/eval/functions/logical/is_checks/mod.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/mod.rs
@@ -109,5 +109,28 @@ pub fn isnontext_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     Value::Bool(!matches!(val, Value::Text(_)))
 }
 
+/// `ISREF(value)` — TRUE if the argument is a cell reference (Variable node).
+/// Errors in the argument are NOT propagated; they return FALSE.
+/// Only 0 args → `#N/A`.
+pub fn isref_fn(args: &[Expr], _ctx: &mut EvalCtx<'_>) -> Value {
+    if check_arity_len(args.len(), 1, 1).is_some() {
+        return Value::Error(ErrorKind::NA);
+    }
+    Value::Bool(matches!(args[0], Expr::Variable(_, _)))
+}
+
+/// `ISFORMULA(value)` — TRUE if the argument is a cell ref containing a formula.
+/// Requires exactly 1 arg that is a cell reference; otherwise → `#N/A`.
+/// We have no formula context, so a valid cell ref returns FALSE.
+pub fn isformula_fn(args: &[Expr], _ctx: &mut EvalCtx<'_>) -> Value {
+    if check_arity_len(args.len(), 1, 1).is_some() {
+        return Value::Error(ErrorKind::NA);
+    }
+    if !matches!(args[0], Expr::Variable(_, _)) {
+        return Value::Error(ErrorKind::NA);
+    }
+    Value::Bool(false)
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/core/src/eval/functions/logical/mod.rs
+++ b/crates/core/src/eval/functions/logical/mod.rs
@@ -36,4 +36,6 @@ pub fn register_logical(registry: &mut Registry) {
     registry.register_lazy("ERROR.TYPE",info::error_type_fn,        FunctionMeta { category: "logical", signature: "ERROR.TYPE(value)",                    description: "Number corresponding to the error type" });
     registry.register_lazy("N",         info::n_fn,                 FunctionMeta { category: "logical", signature: "N(value)",                             description: "Convert value to number" });
     registry.register_lazy("TYPE",      info::type_fn,              FunctionMeta { category: "logical", signature: "TYPE(value)",                          description: "Number indicating value type" });
+    registry.register_lazy("ISREF",     is_checks::isref_fn,        FunctionMeta { category: "logical", signature: "ISREF(value)",                         description: "True if value is a cell reference" });
+    registry.register_lazy("ISFORMULA", is_checks::isformula_fn,    FunctionMeta { category: "logical", signature: "ISFORMULA(ref)",                       description: "True if cell contains a formula" });
 }


### PR DESCRIPTION
## Summary

- Implements `ISREF(value)` — returns `TRUE` if the argument is a cell reference, `FALSE` otherwise (no error propagation)
- Implements `ISFORMULA(ref)` — returns `Error(NA)` for non-reference arguments; returns `FALSE` for cell references (no formula context in the evaluator)
- Adds worktree-based development rule to `CLAUDE.md`

## Implementation notes

Both functions are **lazy** (inspect the AST before evaluation). Cell references are represented as `Expr::Variable` in the parser, so ISREF checks the AST node type directly — this is why `ISREF(NA())` returns `Bool(false)` instead of propagating the error.

## Test plan

- [x] `cargo test` — 1056 passed, 0 failed
- [x] `cargo test m2_info_conformance -- --include-ignored` — ISREF (12 cases) and ISFORMULA (6 cases) pass

Closes #211, #213