### PR TITLE
feat: add Value::Date and implement ISDATE (#208)

### DIFF
--- a/crates/core/src/eval/coercion/mod.rs
+++ b/crates/core/src/eval/coercion/mod.rs
@@ -11,7 +11,7 @@ use crate::types::{ErrorKind, Value};
 /// - `Array` → `Value::Error(ErrorKind::Value)`
 pub fn to_number(v: Value) -> Result<f64, Value> {
     match v {
-        Value::Number(n) => Ok(n),
+        Value::Number(n) | Value::Date(n) => Ok(n),
         Value::Bool(b)   => Ok(if b { 1.0 } else { 0.0 }),
         Value::Empty     => Ok(0.0),
         Value::Text(s)   => {
@@ -34,7 +34,7 @@ pub fn to_number(v: Value) -> Result<f64, Value> {
 pub fn to_string_val(v: Value) -> Result<String, Value> {
     match v {
         Value::Text(s)  => Ok(s),
-        Value::Number(n) => Ok(display_number(n)),
+        Value::Number(n) | Value::Date(n) => Ok(display_number(n)),
         Value::Bool(b)  => Ok(if b { "TRUE".to_string() } else { "FALSE".to_string() }),
         Value::Empty    => Ok(String::new()),
         Value::Error(_) => Err(v),
@@ -53,7 +53,7 @@ pub fn to_string_val(v: Value) -> Result<String, Value> {
 pub fn to_bool(v: Value) -> Result<bool, Value> {
     match v {
         Value::Bool(b)   => Ok(b),
-        Value::Number(n) => Ok(n != 0.0),
+        Value::Number(n) | Value::Date(n) => Ok(n != 0.0),
         Value::Error(_)  => Err(v),
         Value::Text(ref s) => match s.to_uppercase().as_str() {
             "TRUE"  => Ok(true),

--- a/crates/core/src/eval/functions/date/date_fn/mod.rs
+++ b/crates/core/src/eval/functions/date/date_fn/mod.rs
@@ -51,7 +51,7 @@ pub fn date_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::Num);
     }
 
-    Value::Number(serial)
+    Value::Date(serial)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/date_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/date_fn/tests/edge.rs
@@ -5,47 +5,47 @@ use crate::types::{ErrorKind, Value};
 fn month_13_overflow() {
     // DATE(2024,13,1) -> Jan 1 2025 = 45658
     let args = [Value::Number(2024.0), Value::Number(13.0), Value::Number(1.0)];
-    assert_eq!(date_fn(&args), Value::Number(45658.0));
+    assert_eq!(date_fn(&args), Value::Date(45658.0));
 }
 
 #[test]
 fn day_32_overflow() {
     // DATE(2024,1,32) -> Feb 1 2024 = 45323
     let args = [Value::Number(2024.0), Value::Number(1.0), Value::Number(32.0)];
-    assert_eq!(date_fn(&args), Value::Number(45323.0));
+    assert_eq!(date_fn(&args), Value::Date(45323.0));
 }
 
 #[test]
 fn month_0_underflow() {
     // DATE(2024,0,1) -> Dec 1 2023 = 45261
     let args = [Value::Number(2024.0), Value::Number(0.0), Value::Number(1.0)];
-    assert_eq!(date_fn(&args), Value::Number(45261.0));
+    assert_eq!(date_fn(&args), Value::Date(45261.0));
 }
 
 #[test]
 fn day_0_prev_month() {
     // DATE(2024,3,0) -> last day of Feb 2024 = 45351
     let args = [Value::Number(2024.0), Value::Number(3.0), Value::Number(0.0)];
-    assert_eq!(date_fn(&args), Value::Number(45351.0));
+    assert_eq!(date_fn(&args), Value::Date(45351.0));
 }
 
 #[test]
 fn negative_day() {
     // DATE(2024,3,-1) = 45350
     let args = [Value::Number(2024.0), Value::Number(3.0), Value::Number(-1.0)];
-    assert_eq!(date_fn(&args), Value::Number(45350.0));
+    assert_eq!(date_fn(&args), Value::Date(45350.0));
 }
 
 #[test]
 fn max_date() {
     // DATE(9999,12,31) = 2958465
     let args = [Value::Number(9999.0), Value::Number(12.0), Value::Number(31.0)];
-    assert_eq!(date_fn(&args), Value::Number(2958465.0));
+    assert_eq!(date_fn(&args), Value::Date(2958465.0));
 }
 
 #[test]
 fn decimal_inputs_truncated() {
     // DATE(2024.9,6.9,15.9) -> same as DATE(2024,6,15) = 45458
     let args = [Value::Number(2024.9), Value::Number(6.9), Value::Number(15.9)];
-    assert_eq!(date_fn(&args), Value::Number(45458.0));
+    assert_eq!(date_fn(&args), Value::Date(45458.0));
 }

--- a/crates/core/src/eval/functions/date/date_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/date/date_fn/tests/success.rs
@@ -4,29 +4,29 @@ use crate::types::Value;
 #[test]
 fn basic_date_2024_01_15() {
     let args = [Value::Number(2024.0), Value::Number(1.0), Value::Number(15.0)];
-    assert_eq!(date_fn(&args), Value::Number(45306.0));
+    assert_eq!(date_fn(&args), Value::Date(45306.0));
 }
 
 #[test]
 fn basic_date_2024_06_15() {
     let args = [Value::Number(2024.0), Value::Number(6.0), Value::Number(15.0)];
-    assert_eq!(date_fn(&args), Value::Number(45458.0));
+    assert_eq!(date_fn(&args), Value::Date(45458.0));
 }
 
 #[test]
 fn jan_1_1900() {
     let args = [Value::Number(1900.0), Value::Number(1.0), Value::Number(1.0)];
-    assert_eq!(date_fn(&args), Value::Number(2.0));
+    assert_eq!(date_fn(&args), Value::Date(2.0));
 }
 
 #[test]
 fn leap_day_2000() {
     let args = [Value::Number(2000.0), Value::Number(2.0), Value::Number(29.0)];
-    assert_eq!(date_fn(&args), Value::Number(36585.0));
+    assert_eq!(date_fn(&args), Value::Date(36585.0));
 }
 
 #[test]
 fn leap_day_2024() {
     let args = [Value::Number(2024.0), Value::Number(2.0), Value::Number(29.0)];
-    assert_eq!(date_fn(&args), Value::Number(45351.0));
+    assert_eq!(date_fn(&args), Value::Date(45351.0));
 }

--- a/crates/core/src/eval/functions/date/today/mod.rs
+++ b/crates/core/src/eval/functions/date/today/mod.rs
@@ -9,7 +9,7 @@ pub fn today_fn(args: &[Value]) -> Value {
         return e;
     }
     let today = Local::now().date_naive();
-    Value::Number(date_to_serial(today))
+    Value::Date(date_to_serial(today))
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/today/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/today/tests/edge.rs
@@ -4,9 +4,9 @@ use crate::types::Value;
 #[test]
 fn result_is_reasonable_upper_bound() {
     // Sanity: the result should not be unreasonably large (e.g., > serial for 2100-01-01 ≈ 73051).
-    if let Value::Number(n) = today_fn(&[]) {
+    if let Value::Date(n) = today_fn(&[]) {
         assert!(n < 73051.0, "today serial {n} seems unreasonably large");
     } else {
-        panic!("expected Number");
+        panic!("expected Date");
     }
 }

--- a/crates/core/src/eval/functions/date/today/tests/success.rs
+++ b/crates/core/src/eval/functions/date/today/tests/success.rs
@@ -6,23 +6,23 @@ const MIN_SERIAL: f64 = 45292.0;
 
 #[test]
 fn returns_a_number() {
-    assert!(matches!(today_fn(&[]), Value::Number(_)));
+    assert!(matches!(today_fn(&[]), Value::Date(_)));
 }
 
 #[test]
 fn result_is_after_2024_jan_01() {
-    if let Value::Number(n) = today_fn(&[]) {
+    if let Value::Date(n) = today_fn(&[]) {
         assert!(n >= MIN_SERIAL, "today serial {n} should be >= {MIN_SERIAL}");
     } else {
-        panic!("expected Number");
+        panic!("expected Date");
     }
 }
 
 #[test]
 fn result_has_no_fractional_part() {
-    if let Value::Number(n) = today_fn(&[]) {
+    if let Value::Date(n) = today_fn(&[]) {
         assert_eq!(n.fract(), 0.0, "TODAY() should be a whole number, got {n}");
     } else {
-        panic!("expected Number");
+        panic!("expected Date");
     }
 }

--- a/crates/core/src/eval/functions/logical/info.rs
+++ b/crates/core/src/eval/functions/logical/info.rs
@@ -29,7 +29,7 @@ pub fn n_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     }
     let val = evaluate_expr(&args[0], ctx);
     match val {
-        Value::Number(n)        => Value::Number(n),
+        Value::Number(n) | Value::Date(n) => Value::Number(n),
         Value::Bool(b)          => Value::Number(if b { 1.0 } else { 0.0 }),
         Value::Empty | Value::Text(_) | Value::Array(_) => Value::Number(0.0),
         Value::Error(_)         => val,
@@ -44,7 +44,7 @@ pub fn type_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     }
     let val = evaluate_expr(&args[0], ctx);
     let code = match val {
-        Value::Number(_) => 1.0,
+        Value::Number(_) | Value::Date(_) => 1.0,
         Value::Text(_)   => 2.0,
         Value::Bool(_)   => 4.0,
         Value::Error(_)  => 16.0,

--- a/crates/core/src/eval/functions/logical/is_checks/mod.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/mod.rs
@@ -7,7 +7,7 @@ use crate::types::{ErrorKind, Value};
 
 pub fn isnumber_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 1, 1) { return err; }
-    Value::Bool(matches!(args[0], Value::Number(_)))
+    Value::Bool(matches!(args[0], Value::Number(_) | Value::Date(_)))
 }
 
 pub fn istext_fn(args: &[Value]) -> Value {
@@ -38,7 +38,7 @@ pub fn isnumber_lazy_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let val = evaluate_expr(&args[0], ctx);
-    Value::Bool(matches!(val, Value::Number(_)))
+    Value::Bool(matches!(val, Value::Number(_) | Value::Date(_)))
 }
 
 /// `ISTEXT(value)` — TRUE if value is a Text string.
@@ -134,3 +134,30 @@ pub fn isformula_fn(args: &[Expr], _ctx: &mut EvalCtx<'_>) -> Value {
 
 #[cfg(test)]
 mod tests;
+
+/// `ISDATE(value)` — TRUE if value is a date (typed as Date, or a valid ISO date string).
+pub fn isdate_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if check_arity_len(args.len(), 1, 1).is_some() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let val = evaluate_expr(&args[0], ctx);
+    match val {
+        Value::Error(_) => val,
+        Value::Date(_) => Value::Bool(true),
+        Value::Text(ref s) => Value::Bool(is_date_string(s)),
+        _ => Value::Bool(false),
+    }
+}
+
+fn is_date_string(s: &str) -> bool {
+    // Match ISO 8601: YYYY-MM-DD
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 3 { return false; }
+    let ok_year  = parts[0].len() == 4 && parts[0].chars().all(|c| c.is_ascii_digit());
+    let ok_month = parts[1].len() == 2 && parts[1].chars().all(|c| c.is_ascii_digit());
+    let ok_day   = parts[2].len() == 2 && parts[2].chars().all(|c| c.is_ascii_digit());
+    if !(ok_year && ok_month && ok_day) { return false; }
+    let month: u32 = parts[1].parse().unwrap_or(0);
+    let day: u32   = parts[2].parse().unwrap_or(0);
+    month >= 1 && month <= 12 && day >= 1 && day <= 31
+}

--- a/crates/core/src/eval/functions/logical/is_checks/mod.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/mod.rs
@@ -159,5 +159,5 @@ fn is_date_string(s: &str) -> bool {
     if !(ok_year && ok_month && ok_day) { return false; }
     let month: u32 = parts[1].parse().unwrap_or(0);
     let day: u32   = parts[2].parse().unwrap_or(0);
-    month >= 1 && month <= 12 && day >= 1 && day <= 31
+    (1..=12).contains(&month) && (1..=31).contains(&day)
 }

--- a/crates/core/src/eval/functions/logical/mod.rs
+++ b/crates/core/src/eval/functions/logical/mod.rs
@@ -40,4 +40,5 @@ pub fn register_logical(registry: &mut Registry) {
     registry.register_lazy("ISREF",     is_checks::isref_fn,        FunctionMeta { category: "logical", signature: "ISREF(value)",                         description: "True if value is a cell reference" });
     registry.register_lazy("ISFORMULA", is_checks::isformula_fn,    FunctionMeta { category: "logical", signature: "ISFORMULA(ref)",                       description: "True if cell contains a formula" });
     registry.register_lazy("CELL",      cell_fn::cell_fn,           FunctionMeta { category: "logical", signature: "CELL(info_type, reference)",             description: "Returns information about a cell" });
+    registry.register_lazy("ISDATE",    is_checks::isdate_fn,        FunctionMeta { category: "logical", signature: "ISDATE(value)",                        description: "True if value is a date" });
 }

--- a/crates/core/src/eval/mod.rs
+++ b/crates/core/src/eval/mod.rs
@@ -92,7 +92,7 @@ pub fn evaluate_expr(expr: &Expr, ctx: &mut EvalCtx<'_>) -> Value {
 // Number < Text < Bool  (Empty counts as Number)
 fn type_rank(v: &Value) -> u8 {
     match v {
-        Value::Number(_) | Value::Empty => 0,
+        Value::Number(_) | Value::Date(_) | Value::Empty => 0,
         Value::Text(_)                  => 1,
         Value::Bool(_)                  => 2,
         // Error and Array cannot reach compare_values through the normal eval path
@@ -152,6 +152,9 @@ fn eval_binary(op: &BinaryOp, lv: Value, rv: Value) -> Value {
 fn compare_values(op: &BinaryOp, lv: &Value, rv: &Value) -> bool {
     match (lv, rv) {
         (Value::Number(a), Value::Number(b)) => apply_cmp(op, a.partial_cmp(b)),
+        (Value::Date(a),   Value::Date(b))   => apply_cmp(op, a.partial_cmp(b)),
+        (Value::Date(a),   Value::Number(b)) => apply_cmp(op, a.partial_cmp(b)),
+        (Value::Number(a), Value::Date(b))   => apply_cmp(op, a.partial_cmp(b)),
         (Value::Text(a),   Value::Text(b))   => apply_cmp(op, Some(a.cmp(b))),
         (Value::Bool(a),   Value::Bool(b))   => apply_cmp(op, Some(a.cmp(b))),
         (Value::Empty,     Value::Empty)     => apply_cmp(op, Some(std::cmp::Ordering::Equal)),

--- a/crates/core/src/types/value.rs
+++ b/crates/core/src/types/value.rs
@@ -10,4 +10,7 @@ pub enum Value {
     Error(ErrorKind),
     Empty,
     Array(Vec<Value>),
+    /// A spreadsheet serial date number — same float encoding as Number but
+    /// typed so ISDATE can distinguish it from a plain numeric literal.
+    Date(f64),
 }

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -103,6 +103,11 @@ fn values_match(actual: &Value, expected: &Value) -> bool {
             // still catching order-of-magnitude errors.
             (a - b).abs() <= b.abs() * 1e-4 + 1e-10
         }
+        // Date values from our engine are typed as Value::Date, but the oracle
+        // stores them as plain numbers in xlsx.
+        (Value::Date(a), Value::Number(b)) => {
+            (a - b).abs() <= b.abs() * 1e-4 + 1e-10
+        }
         // Oracle artifact: xlsx stores numeric-looking text (e.g. "0", "123") as a float.
         // Text functions like CHAR, LOWER, CONCATENATE correctly return Text; the oracle
         // appears as Number due to calamine reading the cell as a float.

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -225,7 +225,7 @@ fn parse_variables(vars_json: &JsonValue) -> HashMap<String, Value> {
 
 fn value_to_json(v: &Value) -> JsonValue {
     match v {
-        Value::Number(n) => json!({ "value": n, "type": "number" }),
+        Value::Number(n) | Value::Date(n) => json!({ "value": n, "type": "number" }),
         Value::Text(s) => json!({ "value": s, "type": "text" }),
         Value::Bool(b) => json!({ "value": b, "type": "bool" }),
         Value::Empty => json!({ "value": null, "type": "empty" }),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -70,7 +70,7 @@ pub fn evaluate(formula: &str, variables: JsValue) -> EvalResult {
     };
 
     match ganit_core::evaluate(formula, &vars) {
-        Value::Number(n) => EvalResult::Number { value: n },
+        Value::Number(n) | Value::Date(n) => EvalResult::Number { value: n },
         Value::Text(s) => EvalResult::Text { value: s },
         Value::Bool(b) => EvalResult::Bool { value: b },
         Value::Error(e) => EvalResult::Error { error: e.to_string() },


### PR DESCRIPTION
## Summary

- Adds `Value::Date(f64)` variant to the core `Value` enum — typed date serials that are distinct from plain `Number` values
- Makes `DATE()` and `TODAY()` return `Value::Date(serial)` instead of `Value::Number(serial)`
- Implements `ISDATE(value)` — `TRUE` for date values and ISO date strings (`"2024-01-01"`), `FALSE` for numbers/booleans/non-date text, propagates errors

## Key design decision

The only way to satisfy `ISDATE(DATE(2024,1,15)) = TRUE` **and** `ISDATE(45292) = FALSE` is a separate `Value::Date` variant. Dates are coerced to numbers transparently in arithmetic so date math (`DATE(...) + 1`) still works.

## Files changed

- `types/value.rs` — new `Date(f64)` variant
- `eval/coercion/mod.rs` — `Date` coerces to number/string/bool
- `eval/mod.rs` — `Date` in comparisons and type ranking
- `date/date_fn`, `date/today` — return `Value::Date`
- `logical/is_checks/mod.rs` — `isdate_fn` + `is_date_string`
- `logical/mod.rs` — register `ISDATE`
- `tests/conformance.rs` — `(Value::Date, Value::Number)` match arm for oracle comparison
- `crates/mcp`, `crates/wasm` — non-exhaustive match fixes

## Test plan

- [x] `cargo test` — 1056 passed, 0 failed
- [x] `cargo test m2_info_conformance -- --include-ignored` — ISDATE sheet (14 cases) passes

Closes #208