### PR TITLE
feat: implement variance and stddev statistical functions (M2 #82)

### DIFF
--- a/crates/core/src/eval/functions/statistical/avedev/mod.rs
+++ b/crates/core/src/eval/functions/statistical/avedev/mod.rs
@@ -1,0 +1,21 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+
+/// `AVEDEV(value1, ...)` — average of absolute deviations from the mean.
+/// Ignores text, bool, empty. Returns `#DIV/0!` if no numeric values.
+pub fn avedev_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums(args);
+    let n = nums.len();
+    if n == 0 {
+        return Value::Error(ErrorKind::DivByZero);
+    }
+    let mean = nums.iter().sum::<f64>() / n as f64;
+    let avedev = nums.iter().map(|x| (x - mean).abs()).sum::<f64>() / n as f64;
+    if !avedev.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(avedev)
+}

--- a/crates/core/src/eval/functions/statistical/avedev/mod.rs
+++ b/crates/core/src/eval/functions/statistical/avedev/mod.rs
@@ -19,3 +19,6 @@ pub fn avedev_fn(args: &[Value]) -> Value {
     }
     Value::Number(avedev)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/avedev/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/avedev/tests/edge.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn avedev_single_value_returns_zero() {
+    // Single value: mean=7, |7-7|=0 → avedev=0
+    assert_eq!(avedev_fn(&[Value::Number(7.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn avedev_all_same_values_returns_zero() {
+    assert_eq!(
+        avedev_fn(&[Value::Number(4.0), Value::Number(4.0), Value::Number(4.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn avedev_negative_numbers() {
+    // mean=-3, deviations: |-5-(-3)|=2, |-1-(-3)|=2 → avedev=2.0
+    let result = avedev_fn(&[Value::Number(-5.0), Value::Number(-1.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}

--- a/crates/core/src/eval/functions/statistical/avedev/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/avedev/tests/failure.rs
@@ -1,0 +1,24 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn avedev_no_args_returns_na() {
+    assert_eq!(avedev_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn avedev_no_numeric_values_returns_div_zero() {
+    // Only text/bool — no numeric values
+    assert_eq!(
+        avedev_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}
+
+#[test]
+fn avedev_empty_only_returns_div_zero() {
+    assert_eq!(
+        avedev_fn(&[Value::Empty]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/avedev/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/avedev/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/avedev/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/avedev/tests/success.rs
@@ -1,0 +1,34 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn avedev_basic() {
+    // mean=3, deviations: |1-3|=2, |2-3|=1, |3-3|=0, |4-3|=1, |5-3|=2 → avedev=6/5=1.2
+    let result = avedev_fn(&[
+        Value::Number(1.0),
+        Value::Number(2.0),
+        Value::Number(3.0),
+        Value::Number(4.0),
+        Value::Number(5.0),
+    ]);
+    assert_eq!(result, Value::Number(1.2));
+}
+
+#[test]
+fn avedev_two_values() {
+    // mean=3, deviations: |1-3|=2, |5-3|=2 → avedev=2.0
+    let result = avedev_fn(&[Value::Number(1.0), Value::Number(5.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn avedev_ignores_bool_and_text() {
+    // bool and text are ignored, only numbers count
+    // mean=5, deviations: |5-5|=0 → avedev=0
+    let result = avedev_fn(&[
+        Value::Number(5.0),
+        Value::Bool(true),
+        Value::Text("hello".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/statistical/covariance_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_p/mod.rs
@@ -1,0 +1,29 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+
+/// `COVARIANCE.P(array1, array2)` — population covariance of two arrays.
+/// Requires exactly 2 args of equal non-zero length. Returns `#N/A` if lengths differ.
+/// Returns `#DIV/0!` if arrays are empty.
+pub fn covariance_p_fn(args: &[Value]) -> Value {
+    if args.len() != 2 {
+        return Value::Error(ErrorKind::NA);
+    }
+    let xs = collect_nums(std::slice::from_ref(&args[0]));
+    let ys = collect_nums(std::slice::from_ref(&args[1]));
+    if xs.len() != ys.len() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let n = xs.len();
+    if n == 0 {
+        return Value::Error(ErrorKind::DivByZero);
+    }
+    let mean_x = xs.iter().sum::<f64>() / n as f64;
+    let mean_y = ys.iter().sum::<f64>() / n as f64;
+    let cov = xs.iter().zip(ys.iter())
+        .map(|(x, y)| (x - mean_x) * (y - mean_y))
+        .sum::<f64>() / n as f64;
+    if !cov.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(cov)
+}

--- a/crates/core/src/eval/functions/statistical/covariance_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_p/mod.rs
@@ -27,3 +27,6 @@ pub fn covariance_p_fn(args: &[Value]) -> Value {
     }
     Value::Number(cov)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/covariance_p/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_p/tests/edge.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn covariance_p_single_point_returns_zero() {
+    // Single point: cov = ((x-mean_x)(y-mean_y))/1 = 0
+    let arr1 = Value::Array(vec![Value::Number(5.0)]);
+    let arr2 = Value::Array(vec![Value::Number(10.0)]);
+    assert_eq!(covariance_p_fn(&[arr1, arr2]), Value::Number(0.0));
+}
+
+#[test]
+fn covariance_p_all_same_values_returns_zero() {
+    let arr1 = Value::Array(vec![Value::Number(3.0), Value::Number(3.0), Value::Number(3.0)]);
+    let arr2 = Value::Array(vec![Value::Number(7.0), Value::Number(7.0), Value::Number(7.0)]);
+    assert_eq!(covariance_p_fn(&[arr1, arr2]), Value::Number(0.0));
+}
+
+#[test]
+fn covariance_p_plain_number_args() {
+    // Two plain numbers — collect_nums treats them as single-element collections
+    assert_eq!(covariance_p_fn(&[Value::Number(5.0), Value::Number(10.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/statistical/covariance_p/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_p/tests/failure.rs
@@ -1,0 +1,35 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn covariance_p_no_args_returns_na() {
+    assert_eq!(covariance_p_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn covariance_p_one_arg_returns_na() {
+    let arr = Value::Array(vec![Value::Number(1.0), Value::Number(2.0)]);
+    assert_eq!(covariance_p_fn(&[arr]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn covariance_p_three_args_returns_na() {
+    let arr1 = Value::Array(vec![Value::Number(1.0)]);
+    let arr2 = Value::Array(vec![Value::Number(2.0)]);
+    let arr3 = Value::Array(vec![Value::Number(3.0)]);
+    assert_eq!(covariance_p_fn(&[arr1, arr2, arr3]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn covariance_p_unequal_lengths_returns_na() {
+    let arr1 = Value::Array(vec![Value::Number(1.0), Value::Number(2.0)]);
+    let arr2 = Value::Array(vec![Value::Number(3.0)]);
+    assert_eq!(covariance_p_fn(&[arr1, arr2]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn covariance_p_empty_arrays_returns_div_zero() {
+    let arr1 = Value::Array(vec![]);
+    let arr2 = Value::Array(vec![]);
+    assert_eq!(covariance_p_fn(&[arr1, arr2]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/covariance_p/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_p/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/covariance_p/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_p/tests/success.rs
@@ -1,0 +1,35 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn covariance_p_basic() {
+    // xs=[1,2,3], ys=[4,5,6]
+    // mean_x=2, mean_y=5
+    // cov = ((1-2)(4-5) + (2-2)(5-5) + (3-2)(6-5)) / 3 = (1+0+1)/3 = 2/3
+    let arr1 = Value::Array(vec![Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]);
+    let arr2 = Value::Array(vec![Value::Number(4.0), Value::Number(5.0), Value::Number(6.0)]);
+    let result = covariance_p_fn(&[arr1, arr2]);
+    if let Value::Number(v) = result {
+        assert!((v - 2.0 / 3.0).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn covariance_p_two_points() {
+    // xs=[1,3], ys=[2,4], mean_x=2, mean_y=3
+    // cov = ((1-2)(2-3) + (3-2)(4-3)) / 2 = (1+1)/2 = 1.0
+    let arr1 = Value::Array(vec![Value::Number(1.0), Value::Number(3.0)]);
+    let arr2 = Value::Array(vec![Value::Number(2.0), Value::Number(4.0)]);
+    assert_eq!(covariance_p_fn(&[arr1, arr2]), Value::Number(1.0));
+}
+
+#[test]
+fn covariance_p_negative_covariance() {
+    // xs=[1,3], ys=[4,2], mean_x=2, mean_y=3
+    // cov = ((1-2)(4-3) + (3-2)(2-3)) / 2 = (-1-1)/2 = -1.0
+    let arr1 = Value::Array(vec![Value::Number(1.0), Value::Number(3.0)]);
+    let arr2 = Value::Array(vec![Value::Number(4.0), Value::Number(2.0)]);
+    assert_eq!(covariance_p_fn(&[arr1, arr2]), Value::Number(-1.0));
+}

--- a/crates/core/src/eval/functions/statistical/covariance_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/mod.rs
@@ -1,0 +1,29 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+
+/// `COVARIANCE.S(array1, array2)` — sample covariance of two arrays.
+/// Requires exactly 2 args of equal length ≥2. Returns `#N/A` if lengths differ.
+/// Returns `#DIV/0!` if n < 2.
+pub fn covariance_s_fn(args: &[Value]) -> Value {
+    if args.len() != 2 {
+        return Value::Error(ErrorKind::NA);
+    }
+    let xs = collect_nums(std::slice::from_ref(&args[0]));
+    let ys = collect_nums(std::slice::from_ref(&args[1]));
+    if xs.len() != ys.len() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let n = xs.len();
+    if n < 2 {
+        return Value::Error(ErrorKind::DivByZero);
+    }
+    let mean_x = xs.iter().sum::<f64>() / n as f64;
+    let mean_y = ys.iter().sum::<f64>() / n as f64;
+    let cov = xs.iter().zip(ys.iter())
+        .map(|(x, y)| (x - mean_x) * (y - mean_y))
+        .sum::<f64>() / (n - 1) as f64;
+    if !cov.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(cov)
+}

--- a/crates/core/src/eval/functions/statistical/covariance_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/mod.rs
@@ -27,3 +27,6 @@ pub fn covariance_s_fn(args: &[Value]) -> Value {
     }
     Value::Number(cov)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/covariance_s/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/tests/edge.rs
@@ -1,0 +1,25 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn covariance_s_all_same_x_returns_zero() {
+    let arr1 = Value::Array(vec![Value::Number(3.0), Value::Number(3.0), Value::Number(3.0)]);
+    let arr2 = Value::Array(vec![Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]);
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Number(0.0));
+}
+
+#[test]
+fn covariance_s_all_same_both_returns_zero() {
+    let arr1 = Value::Array(vec![Value::Number(4.0), Value::Number(4.0)]);
+    let arr2 = Value::Array(vec![Value::Number(7.0), Value::Number(7.0)]);
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Number(0.0));
+}
+
+#[test]
+fn covariance_s_plain_number_args_single_each_div_zero() {
+    // Two plain numbers → n=1 → DivByZero
+    assert_eq!(
+        covariance_s_fn(&[Value::Number(5.0), Value::Number(10.0)]),
+        Value::Error(crate::types::ErrorKind::DivByZero)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/covariance_s/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/tests/failure.rs
@@ -1,0 +1,43 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn covariance_s_no_args_returns_na() {
+    assert_eq!(covariance_s_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn covariance_s_one_arg_returns_na() {
+    let arr = Value::Array(vec![Value::Number(1.0), Value::Number(2.0)]);
+    assert_eq!(covariance_s_fn(&[arr]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn covariance_s_three_args_returns_na() {
+    let arr1 = Value::Array(vec![Value::Number(1.0)]);
+    let arr2 = Value::Array(vec![Value::Number(2.0)]);
+    let arr3 = Value::Array(vec![Value::Number(3.0)]);
+    assert_eq!(covariance_s_fn(&[arr1, arr2, arr3]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn covariance_s_unequal_lengths_returns_na() {
+    let arr1 = Value::Array(vec![Value::Number(1.0), Value::Number(2.0)]);
+    let arr2 = Value::Array(vec![Value::Number(3.0)]);
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn covariance_s_single_point_returns_div_zero() {
+    // n < 2 → DivByZero
+    let arr1 = Value::Array(vec![Value::Number(5.0)]);
+    let arr2 = Value::Array(vec![Value::Number(10.0)]);
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Error(ErrorKind::DivByZero));
+}
+
+#[test]
+fn covariance_s_empty_arrays_returns_div_zero() {
+    let arr1 = Value::Array(vec![]);
+    let arr2 = Value::Array(vec![]);
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/covariance_s/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/covariance_s/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/tests/success.rs
@@ -1,0 +1,30 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn covariance_s_basic() {
+    // xs=[1,2,3], ys=[4,5,6]
+    // mean_x=2, mean_y=5
+    // cov = ((1-2)(4-5) + (2-2)(5-5) + (3-2)(6-5)) / (3-1) = 2/2 = 1.0
+    let arr1 = Value::Array(vec![Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]);
+    let arr2 = Value::Array(vec![Value::Number(4.0), Value::Number(5.0), Value::Number(6.0)]);
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Number(1.0));
+}
+
+#[test]
+fn covariance_s_two_points() {
+    // xs=[1,3], ys=[2,4], mean_x=2, mean_y=3
+    // cov = ((1-2)(2-3) + (3-2)(4-3)) / (2-1) = (1+1)/1 = 2.0
+    let arr1 = Value::Array(vec![Value::Number(1.0), Value::Number(3.0)]);
+    let arr2 = Value::Array(vec![Value::Number(2.0), Value::Number(4.0)]);
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Number(2.0));
+}
+
+#[test]
+fn covariance_s_negative_covariance() {
+    // xs=[1,3], ys=[4,2], mean_x=2, mean_y=3
+    // cov = ((1-2)(4-3) + (3-2)(2-3)) / (2-1) = (-1-1)/1 = -2.0
+    let arr1 = Value::Array(vec![Value::Number(1.0), Value::Number(3.0)]);
+    let arr2 = Value::Array(vec![Value::Number(4.0), Value::Number(2.0)]);
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Number(-2.0));
+}

--- a/crates/core/src/eval/functions/statistical/devsq/mod.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/mod.rs
@@ -1,0 +1,21 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+
+/// `DEVSQ(value1, ...)` — sum of squared deviations from the mean.
+/// Ignores text, bool, empty. Returns `#NUM!` if no numeric values.
+pub fn devsq_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums(args);
+    let n = nums.len();
+    if n == 0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let mean = nums.iter().sum::<f64>() / n as f64;
+    let devsq = nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>();
+    if !devsq.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(devsq)
+}

--- a/crates/core/src/eval/functions/statistical/devsq/mod.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/mod.rs
@@ -19,3 +19,6 @@ pub fn devsq_fn(args: &[Value]) -> Value {
     }
     Value::Number(devsq)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/devsq/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/tests/edge.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn devsq_single_value_returns_zero() {
+    // Single value: mean=7, devsq=(7-7)²=0
+    assert_eq!(devsq_fn(&[Value::Number(7.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn devsq_all_same_values_returns_zero() {
+    assert_eq!(
+        devsq_fn(&[Value::Number(4.0), Value::Number(4.0), Value::Number(4.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn devsq_negative_numbers() {
+    // mean=-3, devsq=(-5-(-3))²+(-1-(-3))²=4+4=8
+    let result = devsq_fn(&[Value::Number(-5.0), Value::Number(-1.0)]);
+    assert_eq!(result, Value::Number(8.0));
+}

--- a/crates/core/src/eval/functions/statistical/devsq/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn devsq_no_args_returns_na() {
+    assert_eq!(devsq_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn devsq_no_numeric_values_returns_num_error() {
+    assert_eq!(
+        devsq_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn devsq_empty_only_returns_num_error() {
+    assert_eq!(devsq_fn(&[Value::Empty]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/statistical/devsq/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/devsq/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/tests/success.rs
@@ -1,0 +1,35 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn devsq_basic() {
+    // mean=3, deviations squared: (1-3)²=4, (2-3)²=1, (3-3)²=0, (4-3)²=1, (5-3)²=4 → devsq=10
+    let result = devsq_fn(&[
+        Value::Number(1.0),
+        Value::Number(2.0),
+        Value::Number(3.0),
+        Value::Number(4.0),
+        Value::Number(5.0),
+    ]);
+    assert_eq!(result, Value::Number(10.0));
+}
+
+#[test]
+fn devsq_two_values() {
+    // mean=3, deviations squared: (1-3)²=4, (5-3)²=4 → devsq=8
+    let result = devsq_fn(&[Value::Number(1.0), Value::Number(5.0)]);
+    assert_eq!(result, Value::Number(8.0));
+}
+
+#[test]
+fn devsq_ignores_bool_and_text() {
+    // bool and text are ignored
+    let result = devsq_fn(&[
+        Value::Number(2.0),
+        Value::Number(4.0),
+        Value::Bool(true),
+        Value::Text("x".to_string()),
+    ]);
+    // mean=3, devsq=(2-3)²+(4-3)²=2
+    assert_eq!(result, Value::Number(2.0));
+}

--- a/crates/core/src/eval/functions/statistical/mod.rs
+++ b/crates/core/src/eval/functions/statistical/mod.rs
@@ -5,6 +5,24 @@ pub mod countblank;
 pub mod max;
 pub mod median;
 pub mod min;
+pub mod stat_helpers;
+
+pub mod avedev;
+pub mod covariance_p;
+pub mod covariance_s;
+pub mod devsq;
+pub mod stdev;
+pub mod stdev_p;
+pub mod stdev_s;
+pub mod stdeva;
+pub mod stdevp;
+pub mod stdevpa;
+pub mod var;
+pub mod var_p;
+pub mod var_s;
+pub mod vara;
+pub mod varp;
+pub mod varpa;
 
 pub fn register_statistical(registry: &mut Registry) {
     registry.register_lazy("COUNT",  count::count_lazy_fn,  FunctionMeta { category: "statistical", signature: "COUNT(value1,...)",  description: "Count numeric values" });
@@ -13,4 +31,21 @@ pub fn register_statistical(registry: &mut Registry) {
     registry.register_eager("MAX",   max::max_fn,           FunctionMeta { category: "statistical", signature: "MAX(value1,...)",    description: "Maximum value" });
     registry.register_eager("MIN",   min::min_fn,           FunctionMeta { category: "statistical", signature: "MIN(value1,...)",    description: "Minimum value" });
     registry.register_eager("MEDIAN",median::median_fn,     FunctionMeta { category: "statistical", signature: "MEDIAN(value1,...)", description: "Median value" });
+
+    registry.register_eager("AVEDEV",      avedev::avedev_fn,           FunctionMeta { category: "statistical", signature: "AVEDEV(value1,...)",       description: "Average of absolute deviations from the mean" });
+    registry.register_eager("DEVSQ",       devsq::devsq_fn,             FunctionMeta { category: "statistical", signature: "DEVSQ(value1,...)",        description: "Sum of squared deviations from the mean" });
+    registry.register_eager("COVARIANCE.P",covariance_p::covariance_p_fn, FunctionMeta { category: "statistical", signature: "COVARIANCE.P(array1,array2)", description: "Population covariance" });
+    registry.register_eager("COVARIANCE.S",covariance_s::covariance_s_fn, FunctionMeta { category: "statistical", signature: "COVARIANCE.S(array1,array2)", description: "Sample covariance" });
+    registry.register_eager("STDEV",       stdev::stdev_fn,             FunctionMeta { category: "statistical", signature: "STDEV(value1,...)",         description: "Sample standard deviation" });
+    registry.register_eager("STDEV.P",     stdev_p::stdev_p_fn,         FunctionMeta { category: "statistical", signature: "STDEV.P(value1,...)",       description: "Population standard deviation" });
+    registry.register_eager("STDEV.S",     stdev_s::stdev_s_fn,         FunctionMeta { category: "statistical", signature: "STDEV.S(value1,...)",       description: "Sample standard deviation" });
+    registry.register_eager("STDEVA",      stdeva::stdeva_fn,           FunctionMeta { category: "statistical", signature: "STDEVA(value1,...)",        description: "Sample standard deviation including text and logical values" });
+    registry.register_eager("STDEVP",      stdevp::stdevp_fn,           FunctionMeta { category: "statistical", signature: "STDEVP(value1,...)",        description: "Population standard deviation" });
+    registry.register_eager("STDEVPA",     stdevpa::stdevpa_fn,         FunctionMeta { category: "statistical", signature: "STDEVPA(value1,...)",       description: "Population standard deviation including text and logical values" });
+    registry.register_eager("VAR",         var::var_fn,                 FunctionMeta { category: "statistical", signature: "VAR(value1,...)",           description: "Sample variance" });
+    registry.register_eager("VAR.P",       var_p::var_p_fn,             FunctionMeta { category: "statistical", signature: "VAR.P(value1,...)",         description: "Population variance" });
+    registry.register_eager("VAR.S",       var_s::var_s_fn,             FunctionMeta { category: "statistical", signature: "VAR.S(value1,...)",         description: "Sample variance" });
+    registry.register_eager("VARA",        vara::vara_fn,               FunctionMeta { category: "statistical", signature: "VARA(value1,...)",          description: "Sample variance including text and logical values" });
+    registry.register_eager("VARP",        varp::varp_fn,               FunctionMeta { category: "statistical", signature: "VARP(value1,...)",          description: "Population variance" });
+    registry.register_eager("VARPA",       varpa::varpa_fn,             FunctionMeta { category: "statistical", signature: "VARPA(value1,...)",         description: "Population variance including text and logical values" });
 }

--- a/crates/core/src/eval/functions/statistical/stat_helpers.rs
+++ b/crates/core/src/eval/functions/statistical/stat_helpers.rs
@@ -1,0 +1,42 @@
+use crate::types::Value;
+
+/// Collect numeric values from args, flattening arrays.
+/// Numbers and Dates are included. Bool/Text/Empty are ignored.
+pub fn collect_nums(args: &[Value]) -> Vec<f64> {
+    let mut nums = Vec::new();
+    collect_nums_into(args, &mut nums);
+    nums
+}
+
+fn collect_nums_into(args: &[Value], out: &mut Vec<f64>) {
+    for arg in args {
+        match arg {
+            Value::Number(n) => out.push(*n),
+            Value::Date(n) => out.push(*n),
+            Value::Array(inner) => collect_nums_into(inner, out),
+            _ => {}
+        }
+    }
+}
+
+/// Collect numeric values from args, flattening arrays.
+/// "A" variant: also includes Bool (TRUE=1, FALSE=0) and Text as 0.
+pub fn collect_nums_a(args: &[Value]) -> Vec<f64> {
+    let mut nums = Vec::new();
+    collect_nums_a_into(args, &mut nums);
+    nums
+}
+
+fn collect_nums_a_into(args: &[Value], out: &mut Vec<f64>) {
+    for arg in args {
+        match arg {
+            Value::Number(n) => out.push(*n),
+            Value::Date(n) => out.push(*n),
+            Value::Bool(b) => out.push(if *b { 1.0 } else { 0.0 }),
+            Value::Text(_) => out.push(0.0),
+            Value::Array(inner) => collect_nums_a_into(inner, out),
+            Value::Empty => {}
+            Value::Error(_) => {}
+        }
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdev/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev/mod.rs
@@ -1,0 +1,22 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+use super::var_s::sample_variance;
+
+/// `STDEV(value1, ...)` — sample standard deviation (same as STDEV.S).
+pub fn stdev_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums(args);
+    match sample_variance(&nums) {
+        Value::Number(v) => {
+            let s = v.sqrt();
+            if !s.is_finite() {
+                Value::Error(ErrorKind::Num)
+            } else {
+                Value::Number(s)
+            }
+        }
+        other => other,
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdev/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev/mod.rs
@@ -20,3 +20,6 @@ pub fn stdev_fn(args: &[Value]) -> Value {
         other => other,
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/stdev/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdev/tests/edge.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdev_all_same_values_returns_zero() {
+    assert_eq!(
+        stdev_fn(&[Value::Number(4.0), Value::Number(4.0), Value::Number(4.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn stdev_ignores_bool_and_text() {
+    // Text/bool ignored; [2, 6] → mean=4, sample var=8, stdev=sqrt(8)
+    let result = stdev_fn(&[
+        Value::Number(2.0),
+        Value::Number(6.0),
+        Value::Bool(true),
+        Value::Text("x".to_string()),
+    ]);
+    if let Value::Number(v) = result {
+        assert!((v - 8.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdev/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/stdev/tests/failure.rs
@@ -1,0 +1,12 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn stdev_no_args_returns_na() {
+    assert_eq!(stdev_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn stdev_one_value_returns_div_zero() {
+    assert_eq!(stdev_fn(&[Value::Number(5.0)]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/stdev/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/stdev/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/stdev/tests/success.rs
@@ -1,0 +1,21 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdev_matches_stdev_s_result() {
+    // STDEV delegates to STDEV.S (sample stdev)
+    // [2, 4, 6]: sample var=4, stdev=2.0
+    let result = stdev_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn stdev_two_values() {
+    // [1, 3]: sample var=2, stdev=sqrt(2)
+    let result = stdev_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 2.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdev_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_p/mod.rs
@@ -1,0 +1,23 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+use super::var_p::pop_variance;
+
+/// `STDEV.P(value1, ...)` — population standard deviation: sqrt(population variance).
+/// Requires n≥1. Returns `#DIV/0!` if no numeric values.
+pub fn stdev_p_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums(args);
+    match pop_variance(&nums) {
+        Value::Number(v) => {
+            let s = v.sqrt();
+            if !s.is_finite() {
+                Value::Error(ErrorKind::Num)
+            } else {
+                Value::Number(s)
+            }
+        }
+        other => other,
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdev_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_p/mod.rs
@@ -21,3 +21,6 @@ pub fn stdev_p_fn(args: &[Value]) -> Value {
         other => other,
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/stdev_p/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_p/tests/edge.rs
@@ -1,0 +1,24 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdev_p_all_same_values_returns_zero() {
+    assert_eq!(
+        stdev_p_fn(&[Value::Number(4.0), Value::Number(4.0), Value::Number(4.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn stdev_p_negative_numbers() {
+    // [-3, -1]: pop var=1, stdev=1.0
+    let result = stdev_p_fn(&[Value::Number(-3.0), Value::Number(-1.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}
+
+#[test]
+fn stdev_p_large_spread() {
+    // [0, 10]: pop var=25, stdev=5.0
+    let result = stdev_p_fn(&[Value::Number(0.0), Value::Number(10.0)]);
+    assert_eq!(result, Value::Number(5.0));
+}

--- a/crates/core/src/eval/functions/statistical/stdev_p/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_p/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn stdev_p_no_args_returns_na() {
+    assert_eq!(stdev_p_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn stdev_p_no_numeric_values_returns_div_zero() {
+    assert_eq!(
+        stdev_p_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}
+
+#[test]
+fn stdev_p_empty_only_returns_div_zero() {
+    assert_eq!(stdev_p_fn(&[Value::Empty]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/stdev_p/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_p/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/stdev_p/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_p/tests/success.rs
@@ -1,0 +1,38 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdev_p_basic() {
+    // [2, 4, 6]: pop var=8/3, stdev=sqrt(8/3)
+    let result = stdev_p_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - (8.0_f64 / 3.0).sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdev_p_single_value_returns_zero() {
+    // Pop stdev of one value is 0
+    assert_eq!(stdev_p_fn(&[Value::Number(7.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn stdev_p_two_values() {
+    // [1, 3]: pop var=1, stdev=1.0
+    let result = stdev_p_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}
+
+#[test]
+fn stdev_p_ignores_bool_and_text() {
+    // Only numbers counted: [2, 6] → pop var=4, stdev=2
+    let result = stdev_p_fn(&[
+        Value::Number(2.0),
+        Value::Number(6.0),
+        Value::Bool(true),
+        Value::Text("x".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(2.0));
+}

--- a/crates/core/src/eval/functions/statistical/stdev_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_s/mod.rs
@@ -1,0 +1,23 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+use super::var_s::sample_variance;
+
+/// `STDEV.S(value1, ...)` — sample standard deviation: sqrt(sample variance).
+/// Requires n≥2. Returns `#DIV/0!` if fewer than 2 numeric values.
+pub fn stdev_s_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums(args);
+    match sample_variance(&nums) {
+        Value::Number(v) => {
+            let s = v.sqrt();
+            if !s.is_finite() {
+                Value::Error(ErrorKind::Num)
+            } else {
+                Value::Number(s)
+            }
+        }
+        other => other,
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdev_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_s/mod.rs
@@ -21,3 +21,6 @@ pub fn stdev_s_fn(args: &[Value]) -> Value {
         other => other,
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/stdev_s/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_s/tests/edge.rs
@@ -1,0 +1,32 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdev_s_all_same_values_returns_zero() {
+    assert_eq!(
+        stdev_s_fn(&[Value::Number(4.0), Value::Number(4.0), Value::Number(4.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn stdev_s_negative_numbers() {
+    // [-3, -1]: sample var=2, stdev=sqrt(2)
+    let result = stdev_s_fn(&[Value::Number(-3.0), Value::Number(-1.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 2.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdev_s_large_spread() {
+    // [0, 10]: sample var=50, stdev=sqrt(50)
+    let result = stdev_s_fn(&[Value::Number(0.0), Value::Number(10.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 50.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdev_s/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_s/tests/failure.rs
@@ -1,0 +1,25 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn stdev_s_no_args_returns_na() {
+    assert_eq!(stdev_s_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn stdev_s_one_value_returns_div_zero() {
+    assert_eq!(stdev_s_fn(&[Value::Number(5.0)]), Value::Error(ErrorKind::DivByZero));
+}
+
+#[test]
+fn stdev_s_no_numeric_values_returns_div_zero() {
+    assert_eq!(
+        stdev_s_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}
+
+#[test]
+fn stdev_s_empty_only_returns_div_zero() {
+    assert_eq!(stdev_s_fn(&[Value::Empty]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/stdev_s/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_s/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/stdev_s/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_s/tests/success.rs
@@ -1,0 +1,56 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdev_s_basic() {
+    // [2, 4, 6]: sample var=4, stdev=2.0
+    let result = stdev_s_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn stdev_s_two_values() {
+    // [1, 3]: sample var=2, stdev=sqrt(2)
+    let result = stdev_s_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 2.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdev_s_ignores_bool_and_text() {
+    // Only numbers counted: [2, 6] → mean=4, sample var=8, stdev=sqrt(8)
+    let result = stdev_s_fn(&[
+        Value::Number(2.0),
+        Value::Number(6.0),
+        Value::Bool(true),
+        Value::Text("x".to_string()),
+    ]);
+    if let Value::Number(v) = result {
+        assert!((v - 8.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdev_s_known_dataset() {
+    // [2,4,4,4,5,5,7,9]: sample var≈4.5714, stdev≈2.1381
+    let result = stdev_s_fn(&[
+        Value::Number(2.0),
+        Value::Number(4.0),
+        Value::Number(4.0),
+        Value::Number(4.0),
+        Value::Number(5.0),
+        Value::Number(5.0),
+        Value::Number(7.0),
+        Value::Number(9.0),
+    ]);
+    if let Value::Number(v) = result {
+        assert!((v - (32.0_f64 / 7.0).sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdeva/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/mod.rs
@@ -1,0 +1,22 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums_a;
+use super::var_s::sample_variance;
+
+/// `STDEVA(value1, ...)` — sample standard deviation, text/FALSE=0, TRUE=1.
+pub fn stdeva_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums_a(args);
+    match sample_variance(&nums) {
+        Value::Number(v) => {
+            let s = v.sqrt();
+            if !s.is_finite() {
+                Value::Error(ErrorKind::Num)
+            } else {
+                Value::Number(s)
+            }
+        }
+        other => other,
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdeva/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/mod.rs
@@ -20,3 +20,6 @@ pub fn stdeva_fn(args: &[Value]) -> Value {
         other => other,
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/stdeva/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/tests/edge.rs
@@ -1,0 +1,43 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdeva_true_counts_as_one() {
+    // Bool(true)=1.0; [1.0, 3.0]: sample var=2, stdev=sqrt(2)
+    let result = stdeva_fn(&[Value::Bool(true), Value::Number(3.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 2.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdeva_false_counts_as_zero() {
+    // Bool(false)=0.0; [0.0, 2.0]: sample var=2, stdev=sqrt(2)
+    let result = stdeva_fn(&[Value::Bool(false), Value::Number(2.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 2.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdeva_text_counts_as_zero() {
+    // Text=0.0; [0.0, 4.0]: sample var=8, stdev=sqrt(8)
+    let result = stdeva_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 8.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdeva_all_same_values_returns_zero() {
+    assert_eq!(
+        stdeva_fn(&[Value::Number(5.0), Value::Number(5.0), Value::Number(5.0)]),
+        Value::Number(0.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/stdeva/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/tests/failure.rs
@@ -1,0 +1,19 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn stdeva_no_args_returns_na() {
+    assert_eq!(stdeva_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn stdeva_single_value_returns_div_zero() {
+    // Sample stddev: n < 2 → DivByZero
+    assert_eq!(stdeva_fn(&[Value::Number(5.0)]), Value::Error(ErrorKind::DivByZero));
+}
+
+#[test]
+fn stdeva_only_empty_returns_div_zero() {
+    // Empty is skipped; n < 2 → DivByZero
+    assert_eq!(stdeva_fn(&[Value::Empty]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/stdeva/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/stdeva/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/tests/success.rs
@@ -1,0 +1,31 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdeva_basic_numbers() {
+    // [2, 4, 6]: sample var=4, stdev=2.0
+    let result = stdeva_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn stdeva_two_values() {
+    // [1, 3]: sample var=2, stdev=sqrt(2)
+    let result = stdeva_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 2.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdeva_numbers_only() {
+    // Same as STDEV.S when only numbers present
+    let result = stdeva_fn(&[Value::Number(0.0), Value::Number(10.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 50.0_f64.sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdevp/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdevp/mod.rs
@@ -1,0 +1,22 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+use super::var_p::pop_variance;
+
+/// `STDEVP(value1, ...)` — population standard deviation (same as STDEV.P).
+pub fn stdevp_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums(args);
+    match pop_variance(&nums) {
+        Value::Number(v) => {
+            let s = v.sqrt();
+            if !s.is_finite() {
+                Value::Error(ErrorKind::Num)
+            } else {
+                Value::Number(s)
+            }
+        }
+        other => other,
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdevp/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdevp/mod.rs
@@ -20,3 +20,6 @@ pub fn stdevp_fn(args: &[Value]) -> Value {
         other => other,
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/stdevp/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdevp/tests/edge.rs
@@ -1,0 +1,29 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdevp_all_same_values_returns_zero() {
+    assert_eq!(
+        stdevp_fn(&[Value::Number(4.0), Value::Number(4.0), Value::Number(4.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn stdevp_ignores_bool_and_text() {
+    // Text/bool ignored; [2, 6] → pop var=4, stdev=2
+    let result = stdevp_fn(&[
+        Value::Number(2.0),
+        Value::Number(6.0),
+        Value::Bool(true),
+        Value::Text("x".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn stdevp_negative_numbers() {
+    // [-3, -1]: pop var=1, stdev=1.0
+    let result = stdevp_fn(&[Value::Number(-3.0), Value::Number(-1.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/statistical/stdevp/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/stdevp/tests/failure.rs
@@ -1,0 +1,15 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn stdevp_no_args_returns_na() {
+    assert_eq!(stdevp_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn stdevp_no_numeric_values_returns_div_zero() {
+    assert_eq!(
+        stdevp_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/stdevp/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdevp/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/stdevp/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/stdevp/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdevp_matches_stdev_p_result() {
+    // STDEVP delegates to STDEV.P (population stdev)
+    // [2, 4, 6]: pop var=8/3, stdev=sqrt(8/3)
+    let result = stdevp_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - (8.0_f64 / 3.0).sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdevp_single_value_returns_zero() {
+    // Population stdev of one value is 0
+    assert_eq!(stdevp_fn(&[Value::Number(7.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn stdevp_two_values() {
+    // [1, 3]: pop var=1, stdev=1.0
+    let result = stdevp_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/statistical/stdevpa/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/mod.rs
@@ -1,0 +1,22 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums_a;
+use super::var_p::pop_variance;
+
+/// `STDEVPA(value1, ...)` — population standard deviation, text/FALSE=0, TRUE=1.
+pub fn stdevpa_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums_a(args);
+    match pop_variance(&nums) {
+        Value::Number(v) => {
+            let s = v.sqrt();
+            if !s.is_finite() {
+                Value::Error(ErrorKind::Num)
+            } else {
+                Value::Number(s)
+            }
+        }
+        other => other,
+    }
+}

--- a/crates/core/src/eval/functions/statistical/stdevpa/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/mod.rs
@@ -20,3 +20,6 @@ pub fn stdevpa_fn(args: &[Value]) -> Value {
         other => other,
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/stdevpa/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/tests/edge.rs
@@ -1,0 +1,40 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdevpa_true_counts_as_one() {
+    // Bool(true)=1.0; single value → pop stdev=0
+    assert_eq!(stdevpa_fn(&[Value::Bool(true)]), Value::Number(0.0));
+}
+
+#[test]
+fn stdevpa_false_counts_as_zero() {
+    // Bool(false)=0.0; single value → pop stdev=0
+    assert_eq!(stdevpa_fn(&[Value::Bool(false)]), Value::Number(0.0));
+}
+
+#[test]
+fn stdevpa_text_counts_as_zero() {
+    // Text=0.0; [0.0, 4.0]: pop var=4, stdev=2.0
+    let result = stdevpa_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn stdevpa_bool_and_number() {
+    // [true=1, false=0, 5.0]: pop var=14/3, stdev=sqrt(14/3)
+    let result = stdevpa_fn(&[Value::Bool(true), Value::Bool(false), Value::Number(5.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - (14.0_f64 / 3.0).sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdevpa_all_same_values_returns_zero() {
+    assert_eq!(
+        stdevpa_fn(&[Value::Number(3.0), Value::Number(3.0), Value::Number(3.0)]),
+        Value::Number(0.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/stdevpa/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/tests/failure.rs
@@ -1,0 +1,13 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn stdevpa_no_args_returns_na() {
+    assert_eq!(stdevpa_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn stdevpa_only_empty_returns_div_zero() {
+    // Empty is skipped; n == 0 → DivByZero
+    assert_eq!(stdevpa_fn(&[Value::Empty]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/stdevpa/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/stdevpa/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn stdevpa_basic_numbers() {
+    // [2, 4, 6]: pop var=8/3, stdev=sqrt(8/3)
+    let result = stdevpa_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - (8.0_f64 / 3.0).sqrt()).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn stdevpa_single_value_returns_zero() {
+    // Pop stdev of one value is 0
+    assert_eq!(stdevpa_fn(&[Value::Number(7.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn stdevpa_two_values() {
+    // [1, 3]: pop var=1, stdev=1.0
+    let result = stdevpa_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/statistical/var/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var/mod.rs
@@ -1,0 +1,12 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+use super::var_s::sample_variance;
+
+/// `VAR(value1, ...)` — sample variance (same as VAR.S).
+pub fn var_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums(args);
+    sample_variance(&nums)
+}

--- a/crates/core/src/eval/functions/statistical/var/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var/mod.rs
@@ -10,3 +10,6 @@ pub fn var_fn(args: &[Value]) -> Value {
     let nums = collect_nums(args);
     sample_variance(&nums)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/var/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/var/tests/edge.rs
@@ -1,0 +1,22 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn var_all_same_values_returns_zero() {
+    assert_eq!(
+        var_fn(&[Value::Number(4.0), Value::Number(4.0), Value::Number(4.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn var_ignores_bool_and_text() {
+    // Text/bool ignored; [2, 6] → mean=4, sample var=8
+    let result = var_fn(&[
+        Value::Number(2.0),
+        Value::Number(6.0),
+        Value::Bool(true),
+        Value::Text("x".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(8.0));
+}

--- a/crates/core/src/eval/functions/statistical/var/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/var/tests/failure.rs
@@ -1,0 +1,12 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn var_no_args_returns_na() {
+    assert_eq!(var_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn var_one_value_returns_div_zero() {
+    assert_eq!(var_fn(&[Value::Number(5.0)]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/var/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/var/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/var/tests/success.rs
@@ -1,0 +1,17 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn var_matches_var_s_result() {
+    // VAR delegates to VAR.S (sample variance)
+    // [2, 4, 6]: sample var=4
+    let result = var_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    assert_eq!(result, Value::Number(4.0));
+}
+
+#[test]
+fn var_two_values() {
+    // [1, 3]: sample var=2
+    let result = var_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}

--- a/crates/core/src/eval/functions/statistical/var_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var_p/mod.rs
@@ -1,0 +1,26 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+
+/// `VAR.P(value1, ...)` — population variance: Σ(x-mean)²/n.
+/// Requires n≥1. Returns `#DIV/0!` if no numeric values.
+pub fn var_p_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums(args);
+    pop_variance(&nums)
+}
+
+/// Compute population variance from a slice of f64 values.
+pub(crate) fn pop_variance(nums: &[f64]) -> Value {
+    let n = nums.len();
+    if n == 0 {
+        return Value::Error(ErrorKind::DivByZero);
+    }
+    let mean = nums.iter().sum::<f64>() / n as f64;
+    let var = nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n as f64;
+    if !var.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(var)
+}

--- a/crates/core/src/eval/functions/statistical/var_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var_p/mod.rs
@@ -24,3 +24,6 @@ pub(crate) fn pop_variance(nums: &[f64]) -> Value {
     }
     Value::Number(var)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/var_p/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/var_p/tests/edge.rs
@@ -1,0 +1,24 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn var_p_all_same_values_returns_zero() {
+    assert_eq!(
+        var_p_fn(&[Value::Number(4.0), Value::Number(4.0), Value::Number(4.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn var_p_negative_numbers() {
+    // [-3, -1]: mean=-2, var=((-3-(-2))²+(-1-(-2))²)/2 = (1+1)/2 = 1
+    let result = var_p_fn(&[Value::Number(-3.0), Value::Number(-1.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}
+
+#[test]
+fn var_p_large_spread() {
+    // [0, 10]: mean=5, var=((0-5)²+(10-5)²)/2 = 50/2 = 25
+    let result = var_p_fn(&[Value::Number(0.0), Value::Number(10.0)]);
+    assert_eq!(result, Value::Number(25.0));
+}

--- a/crates/core/src/eval/functions/statistical/var_p/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/var_p/tests/failure.rs
@@ -1,0 +1,20 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn var_p_no_args_returns_na() {
+    assert_eq!(var_p_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn var_p_no_numeric_values_returns_div_zero() {
+    assert_eq!(
+        var_p_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}
+
+#[test]
+fn var_p_empty_only_returns_div_zero() {
+    assert_eq!(var_p_fn(&[Value::Empty]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/var_p/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var_p/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/var_p/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/var_p/tests/success.rs
@@ -1,0 +1,38 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn var_p_basic() {
+    // [2, 4, 6]: mean=4, var=((2-4)²+(4-4)²+(6-4)²)/3=8/3
+    let result = var_p_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 8.0 / 3.0).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn var_p_two_values() {
+    // [1, 3]: mean=2, var=((1-2)²+(3-2)²)/2=1
+    let result = var_p_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}
+
+#[test]
+fn var_p_single_value_returns_zero() {
+    // n=1: mean=5, var=0/1=0
+    assert_eq!(var_p_fn(&[Value::Number(5.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn var_p_ignores_bool_and_text() {
+    // Only numbers: [2, 6] → mean=4, var=(4+4)/2=4
+    let result = var_p_fn(&[
+        Value::Number(2.0),
+        Value::Number(6.0),
+        Value::Bool(true),
+        Value::Text("x".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(4.0));
+}

--- a/crates/core/src/eval/functions/statistical/var_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var_s/mod.rs
@@ -1,0 +1,26 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+
+/// `VAR.S(value1, ...)` — sample variance: Σ(x-mean)²/(n-1).
+/// Requires n≥2. Returns `#DIV/0!` if fewer than 2 numeric values.
+pub fn var_s_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums(args);
+    sample_variance(&nums)
+}
+
+/// Compute sample variance from a slice of f64 values.
+pub(crate) fn sample_variance(nums: &[f64]) -> Value {
+    let n = nums.len();
+    if n < 2 {
+        return Value::Error(ErrorKind::DivByZero);
+    }
+    let mean = nums.iter().sum::<f64>() / n as f64;
+    let var = nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (n - 1) as f64;
+    if !var.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(var)
+}

--- a/crates/core/src/eval/functions/statistical/var_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var_s/mod.rs
@@ -24,3 +24,6 @@ pub(crate) fn sample_variance(nums: &[f64]) -> Value {
     }
     Value::Number(var)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/var_s/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/var_s/tests/edge.rs
@@ -1,0 +1,24 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn var_s_all_same_values_returns_zero() {
+    assert_eq!(
+        var_s_fn(&[Value::Number(4.0), Value::Number(4.0), Value::Number(4.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn var_s_negative_numbers() {
+    // [-3, -1]: mean=-2, var=((-3-(-2))²+(-1-(-2))²)/1 = (1+1)/1 = 2
+    let result = var_s_fn(&[Value::Number(-3.0), Value::Number(-1.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn var_s_large_spread() {
+    // [0, 10]: mean=5, var=((0-5)²+(10-5)²)/1 = 50
+    let result = var_s_fn(&[Value::Number(0.0), Value::Number(10.0)]);
+    assert_eq!(result, Value::Number(50.0));
+}

--- a/crates/core/src/eval/functions/statistical/var_s/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/var_s/tests/failure.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn var_s_no_args_returns_na() {
+    assert_eq!(var_s_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn var_s_one_value_returns_div_zero() {
+    // n < 2 → DivByZero
+    assert_eq!(var_s_fn(&[Value::Number(5.0)]), Value::Error(ErrorKind::DivByZero));
+}
+
+#[test]
+fn var_s_no_numeric_values_returns_div_zero() {
+    assert_eq!(
+        var_s_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}
+
+#[test]
+fn var_s_empty_only_returns_div_zero() {
+    assert_eq!(var_s_fn(&[Value::Empty]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/var_s/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var_s/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/var_s/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/var_s/tests/success.rs
@@ -1,0 +1,29 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn var_s_basic() {
+    // [2, 4, 4, 4, 5, 5, 7, 9]: mean=5, sample var=4.571...
+    // Using simpler: [2, 4, 6]: mean=4, var=((2-4)²+(4-4)²+(6-4)²)/(3-1)=8/2=4
+    let result = var_s_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    assert_eq!(result, Value::Number(4.0));
+}
+
+#[test]
+fn var_s_two_values() {
+    // [1, 3]: mean=2, var=((1-2)²+(3-2)²)/1 = 2/1 = 2
+    let result = var_s_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn var_s_ignores_bool_and_text() {
+    // Only numbers counted: [2, 6] → mean=4, sample var=((2-4)²+(6-4)²)/1=8
+    let result = var_s_fn(&[
+        Value::Number(2.0),
+        Value::Number(6.0),
+        Value::Bool(true),
+        Value::Text("x".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(8.0));
+}

--- a/crates/core/src/eval/functions/statistical/vara/mod.rs
+++ b/crates/core/src/eval/functions/statistical/vara/mod.rs
@@ -1,0 +1,12 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums_a;
+use super::var_s::sample_variance;
+
+/// `VARA(value1, ...)` — sample variance, text/FALSE=0, TRUE=1.
+pub fn vara_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums_a(args);
+    sample_variance(&nums)
+}

--- a/crates/core/src/eval/functions/statistical/vara/mod.rs
+++ b/crates/core/src/eval/functions/statistical/vara/mod.rs
@@ -10,3 +10,6 @@ pub fn vara_fn(args: &[Value]) -> Value {
     let nums = collect_nums_a(args);
     sample_variance(&nums)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/vara/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/vara/tests/edge.rs
@@ -1,0 +1,31 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn vara_true_counts_as_one() {
+    // Bool(true)=1.0 is included; [1.0, 3.0]: mean=2, var=2
+    let result = vara_fn(&[Value::Bool(true), Value::Number(3.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn vara_false_counts_as_zero() {
+    // Bool(false)=0.0 is included; [0.0, 2.0]: mean=1, var=2
+    let result = vara_fn(&[Value::Bool(false), Value::Number(2.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn vara_text_counts_as_zero() {
+    // Text=0.0 is included; [0.0, 4.0]: mean=2, var=8
+    let result = vara_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
+    assert_eq!(result, Value::Number(8.0));
+}
+
+#[test]
+fn vara_all_same_values_returns_zero() {
+    assert_eq!(
+        vara_fn(&[Value::Number(5.0), Value::Number(5.0), Value::Number(5.0)]),
+        Value::Number(0.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/vara/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/vara/tests/failure.rs
@@ -1,0 +1,19 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn vara_no_args_returns_na() {
+    assert_eq!(vara_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn vara_single_value_returns_div_zero() {
+    // VARA uses sample variance: n < 2 → DivByZero
+    assert_eq!(vara_fn(&[Value::Number(5.0)]), Value::Error(ErrorKind::DivByZero));
+}
+
+#[test]
+fn vara_only_empty_returns_div_zero() {
+    // Empty is skipped; no collected values → n < 2 → DivByZero
+    assert_eq!(vara_fn(&[Value::Empty]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/vara/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/vara/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/vara/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/vara/tests/success.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn vara_basic_numbers() {
+    // [2, 4, 6]: mean=4, sample var=((2-4)²+(4-4)²+(6-4)²)/2=8/2=4
+    let result = vara_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    assert_eq!(result, Value::Number(4.0));
+}
+
+#[test]
+fn vara_two_values() {
+    // [1, 3]: mean=2, var=((1-2)²+(3-2)²)/1=2
+    let result = vara_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn vara_numbers_only() {
+    // Same as VAR.S when only numbers present
+    let result = vara_fn(&[Value::Number(0.0), Value::Number(10.0)]);
+    assert_eq!(result, Value::Number(50.0));
+}

--- a/crates/core/src/eval/functions/statistical/varp/mod.rs
+++ b/crates/core/src/eval/functions/statistical/varp/mod.rs
@@ -1,0 +1,12 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums;
+use super::var_p::pop_variance;
+
+/// `VARP(value1, ...)` — population variance (same as VAR.P).
+pub fn varp_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums(args);
+    pop_variance(&nums)
+}

--- a/crates/core/src/eval/functions/statistical/varp/mod.rs
+++ b/crates/core/src/eval/functions/statistical/varp/mod.rs
@@ -10,3 +10,6 @@ pub fn varp_fn(args: &[Value]) -> Value {
     let nums = collect_nums(args);
     pop_variance(&nums)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/varp/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/varp/tests/edge.rs
@@ -1,0 +1,22 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn varp_all_same_values_returns_zero() {
+    assert_eq!(
+        varp_fn(&[Value::Number(4.0), Value::Number(4.0), Value::Number(4.0)]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn varp_ignores_bool_and_text() {
+    // Text/bool ignored; [2, 6] → pop var=4
+    let result = varp_fn(&[
+        Value::Number(2.0),
+        Value::Number(6.0),
+        Value::Bool(true),
+        Value::Text("x".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(4.0));
+}

--- a/crates/core/src/eval/functions/statistical/varp/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/varp/tests/failure.rs
@@ -1,0 +1,15 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn varp_no_args_returns_na() {
+    assert_eq!(varp_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn varp_no_numeric_values_returns_div_zero() {
+    assert_eq!(
+        varp_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
+        Value::Error(ErrorKind::DivByZero)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/varp/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/varp/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/varp/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/varp/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn varp_matches_var_p_result() {
+    // VARP delegates to VAR.P (population variance)
+    // [2, 4, 6]: pop var=8/3
+    let result = varp_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 8.0 / 3.0).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn varp_single_value_returns_zero() {
+    // Population variance of one value is 0
+    assert_eq!(varp_fn(&[Value::Number(5.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn varp_two_values() {
+    // [1, 3]: pop var=1
+    let result = varp_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/statistical/varpa/mod.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/mod.rs
@@ -1,0 +1,12 @@
+use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums_a;
+use super::var_p::pop_variance;
+
+/// `VARPA(value1, ...)` — population variance, text/FALSE=0, TRUE=1.
+pub fn varpa_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let nums = collect_nums_a(args);
+    pop_variance(&nums)
+}

--- a/crates/core/src/eval/functions/statistical/varpa/mod.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/mod.rs
@@ -10,3 +10,6 @@ pub fn varpa_fn(args: &[Value]) -> Value {
     let nums = collect_nums_a(args);
     pop_variance(&nums)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/statistical/varpa/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/tests/edge.rs
@@ -1,0 +1,40 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn varpa_true_counts_as_one() {
+    // Bool(true)=1.0; single value → pop var=0
+    assert_eq!(varpa_fn(&[Value::Bool(true)]), Value::Number(0.0));
+}
+
+#[test]
+fn varpa_false_counts_as_zero() {
+    // Bool(false)=0.0; single value → pop var=0
+    assert_eq!(varpa_fn(&[Value::Bool(false)]), Value::Number(0.0));
+}
+
+#[test]
+fn varpa_text_counts_as_zero() {
+    // Text=0.0 included; [0.0, 4.0]: mean=2, pop var=((0-2)²+(4-2)²)/2=4
+    let result = varpa_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
+    assert_eq!(result, Value::Number(4.0));
+}
+
+#[test]
+fn varpa_bool_and_number() {
+    // [true=1, false=0, 5.0]: mean=2, pop var=((1-2)²+(0-2)²+(5-2)²)/3=(1+4+9)/3=14/3
+    let result = varpa_fn(&[Value::Bool(true), Value::Bool(false), Value::Number(5.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 14.0 / 3.0).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn varpa_all_same_values_returns_zero() {
+    assert_eq!(
+        varpa_fn(&[Value::Number(3.0), Value::Number(3.0), Value::Number(3.0)]),
+        Value::Number(0.0)
+    );
+}

--- a/crates/core/src/eval/functions/statistical/varpa/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/tests/failure.rs
@@ -1,0 +1,13 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn varpa_no_args_returns_na() {
+    assert_eq!(varpa_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn varpa_only_empty_returns_div_zero() {
+    // Empty is skipped; no collected values → n == 0 → DivByZero
+    assert_eq!(varpa_fn(&[Value::Empty]), Value::Error(ErrorKind::DivByZero));
+}

--- a/crates/core/src/eval/functions/statistical/varpa/tests/mod.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/statistical/varpa/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/tests/success.rs
@@ -1,0 +1,26 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn varpa_basic_numbers() {
+    // [2, 4, 6]: mean=4, pop var=((2-4)²+(4-4)²+(6-4)²)/3=8/3
+    let result = varpa_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
+    if let Value::Number(v) = result {
+        assert!((v - 8.0 / 3.0).abs() < 1e-10);
+    } else {
+        panic!("Expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn varpa_single_value_returns_zero() {
+    // Population variance of one value is always 0
+    assert_eq!(varpa_fn(&[Value::Number(7.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn varpa_two_values() {
+    // [1, 3]: mean=2, pop var=((1-2)²+(3-2)²)/2=1
+    let result = varpa_fn(&[Value::Number(1.0), Value::Number(3.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}


### PR DESCRIPTION
## Summary

Implements 16 Excel-compatible statistical functions for the `ganit-core` crate:

- **AVEDEV** — average of absolute deviations from the mean
- **DEVSQ** — sum of squared deviations from the mean
- **COVARIANCE.P** — population covariance of two arrays
- **COVARIANCE.S** — sample covariance of two arrays
- **STDEV** — sample standard deviation (alias for STDEV.S)
- **STDEV.P** — population standard deviation (alias for STDEVP)
- **STDEV.S** — sample standard deviation
- **STDEVA** — sample standard deviation (text/FALSE=0, TRUE=1)
- **STDEVP** — population standard deviation (alias for STDEV.P)
- **STDEVPA** — population standard deviation (text/FALSE=0, TRUE=1)
- **VAR** — sample variance (alias for VAR.S)
- **VAR.P** — population variance (alias for VARP)
- **VAR.S** — sample variance
- **VARA** — sample variance (text/FALSE=0, TRUE=1)
- **VARP** — population variance (alias for VAR.P)
- **VARPA** — population variance (text/FALSE=0, TRUE=1)

Shared helper module (`stat_helpers.rs`) provides `collect_nums` and `collect_nums_a` for number collection with array flattening.

All functions pass the M2 statistical conformance tests. Clippy clean, 1130 tests pass.

closes #90
closes #97
closes #99
closes #101
closes #243
closes #245
closes #247
closes #250
closes #251
closes #252
closes #254
closes #255
closes #256
closes #257
closes #258
closes #259

## Test plan
- [x] `cargo test m2_statistical_conformance -- --include-ignored` — no failures for implemented functions
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p ganit-core` — 1130 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)