### PR TITLE
test: enable M2 statistical conformance test

### DIFF
--- a/crates/core/src/eval/functions/logical/is_checks/mod.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/mod.rs
@@ -33,12 +33,17 @@ pub fn isna_fn(args: &[Value]) -> Value {
 // ── Lazy versions (registered — can inspect error arguments) ─────────────────
 
 /// `ISNUMBER(value)` — TRUE if value is a Number.
+/// When given an array, checks the first element (implicit intersection).
 pub fn isnumber_lazy_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     if check_arity_len(args.len(), 1, 1).is_some() {
         return Value::Error(ErrorKind::NA);
     }
     let val = evaluate_expr(&args[0], ctx);
-    Value::Bool(matches!(val, Value::Number(_) | Value::Date(_)))
+    let scalar = match val {
+        Value::Array(ref elems) => elems.first().cloned().unwrap_or(Value::Empty),
+        other => other,
+    };
+    Value::Bool(matches!(scalar, Value::Number(_) | Value::Date(_)))
 }
 
 /// `ISTEXT(value)` — TRUE if value is a Text string.

--- a/crates/core/src/eval/functions/math/sum/mod.rs
+++ b/crates/core/src/eval/functions/math/sum/mod.rs
@@ -13,8 +13,7 @@ pub fn sum_fn(args: &[Value]) -> Value {
     }
     let mut sum = 0.0_f64;
     for arg in args {
-        // .clone() required because to_number takes ownership; coercion API is fixed.
-        match to_number(arg.clone()) {
+        match sum_value(arg) {
             Err(e) => return e,
             Ok(n) => sum += n,
         }
@@ -23,6 +22,21 @@ pub fn sum_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::Num);
     }
     Value::Number(sum)
+}
+
+/// Recursively sum a value, flattening arrays.
+fn sum_value(v: &Value) -> Result<f64, Value> {
+    match v {
+        Value::Array(elems) => {
+            let mut total = 0.0_f64;
+            for elem in elems {
+                total += sum_value(elem)?;
+            }
+            Ok(total)
+        }
+        // .clone() required because to_number takes ownership; coercion API is fixed.
+        other => to_number(other.clone()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/covariance_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/mod.rs
@@ -15,7 +15,7 @@ pub fn covariance_s_fn(args: &[Value]) -> Value {
     }
     let n = xs.len();
     if n < 2 {
-        return Value::Error(ErrorKind::DivByZero);
+        return Value::Error(ErrorKind::Num);
     }
     let mean_x = xs.iter().sum::<f64>() / n as f64;
     let mean_y = ys.iter().sum::<f64>() / n as f64;

--- a/crates/core/src/eval/functions/statistical/covariance_s/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/tests/edge.rs
@@ -16,10 +16,10 @@ fn covariance_s_all_same_both_returns_zero() {
 }
 
 #[test]
-fn covariance_s_plain_number_args_single_each_div_zero() {
-    // Two plain numbers → n=1 → DivByZero
+fn covariance_s_plain_number_args_single_each_returns_num() {
+    // Two plain numbers → n=1 → Num (Google Sheets oracle)
     assert_eq!(
         covariance_s_fn(&[Value::Number(5.0), Value::Number(10.0)]),
-        Value::Error(crate::types::ErrorKind::DivByZero)
+        Value::Error(crate::types::ErrorKind::Num)
     );
 }

--- a/crates/core/src/eval/functions/statistical/covariance_s/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/tests/failure.rs
@@ -28,16 +28,16 @@ fn covariance_s_unequal_lengths_returns_na() {
 }
 
 #[test]
-fn covariance_s_single_point_returns_div_zero() {
-    // n < 2 → DivByZero
+fn covariance_s_single_point_returns_num() {
+    // n < 2 → Num (Google Sheets oracle)
     let arr1 = Value::Array(vec![Value::Number(5.0)]);
     let arr2 = Value::Array(vec![Value::Number(10.0)]);
-    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Error(ErrorKind::DivByZero));
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Error(ErrorKind::Num));
 }
 
 #[test]
-fn covariance_s_empty_arrays_returns_div_zero() {
+fn covariance_s_empty_arrays_returns_num() {
     let arr1 = Value::Array(vec![]);
     let arr2 = Value::Array(vec![]);
-    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Error(ErrorKind::DivByZero));
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Error(ErrorKind::Num));
 }

--- a/crates/core/src/eval/functions/statistical/geomean/mod.rs
+++ b/crates/core/src/eval/functions/statistical/geomean/mod.rs
@@ -18,6 +18,9 @@ pub fn geomean_fn(args: &[Value]) -> Value {
             _ => {}
         }
     }
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }

--- a/crates/core/src/eval/functions/statistical/geomean/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/geomean/tests/failure.rs
@@ -18,6 +18,6 @@ fn geomean_zero_value_returns_num() {
 }
 
 #[test]
-fn geomean_no_values_returns_num() {
-    assert_eq!(geomean_fn(&[]), Value::Error(ErrorKind::Num));
+fn geomean_no_values_returns_na() {
+    assert_eq!(geomean_fn(&[]), Value::Error(ErrorKind::NA));
 }

--- a/crates/core/src/eval/functions/statistical/harmean/mod.rs
+++ b/crates/core/src/eval/functions/statistical/harmean/mod.rs
@@ -18,6 +18,9 @@ pub fn harmean_fn(args: &[Value]) -> Value {
             _ => {}
         }
     }
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }

--- a/crates/core/src/eval/functions/statistical/harmean/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/harmean/tests/failure.rs
@@ -18,6 +18,6 @@ fn harmean_zero_value_returns_num() {
 }
 
 #[test]
-fn harmean_no_values_returns_num() {
-    assert_eq!(harmean_fn(&[]), Value::Error(ErrorKind::Num));
+fn harmean_no_values_returns_na() {
+    assert_eq!(harmean_fn(&[]), Value::Error(ErrorKind::NA));
 }

--- a/crates/core/src/eval/functions/statistical/kurt/mod.rs
+++ b/crates/core/src/eval/functions/statistical/kurt/mod.rs
@@ -21,6 +21,9 @@ pub fn kurt_fn(args: &[Value]) -> Value {
         }
     }
     let n = nums.len();
+    if n == 0 {
+        return Value::Error(ErrorKind::NA);
+    }
     if n < 4 {
         return Value::Error(ErrorKind::DivByZero);
     }

--- a/crates/core/src/eval/functions/statistical/median/mod.rs
+++ b/crates/core/src/eval/functions/statistical/median/mod.rs
@@ -1,15 +1,25 @@
 use crate::types::{ErrorKind, Value};
 
-/// `MEDIAN(value1, ...)` — middle value of numeric arguments.
-/// Ignores Text, Bool, Empty, Error. Even count: average of two middle values. Odd count: middle value.
-/// Returns `Value::Error(ErrorKind::Num)` if no numeric values are present.
-pub fn median_fn(args: &[Value]) -> Value {
-    let mut nums: Vec<f64> = Vec::new();
+fn collect_nums_into(args: &[Value], out: &mut Vec<f64>) {
     for arg in args {
-        if let Value::Number(n) = arg {
-            nums.push(*n);
+        match arg {
+            Value::Number(n) => out.push(*n),
+            Value::Array(inner) => collect_nums_into(inner, out),
+            _ => {}
         }
     }
+}
+
+/// `MEDIAN(value1, ...)` — middle value of numeric arguments.
+/// Flattens `Value::Array` args. Ignores Text, Bool, Empty, Error.
+/// Even count: average of two middle values. Odd count: middle value.
+/// Returns `Value::Error(ErrorKind::NA)` if no args, `#NUM!` if no numeric values.
+pub fn median_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    let mut nums: Vec<f64> = Vec::new();
+    collect_nums_into(args, &mut nums);
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }

--- a/crates/core/src/eval/functions/statistical/median/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/median/tests/failure.rs
@@ -2,9 +2,9 @@ use super::super::*;
 use crate::types::{ErrorKind, Value};
 
 #[test]
-fn median_no_numeric_returns_num_error() {
-    // MEDIAN() → #NUM!
-    assert_eq!(median_fn(&[]), Value::Error(ErrorKind::Num));
+fn median_no_args_returns_na() {
+    // MEDIAN() → #N/A (Google Sheets oracle)
+    assert_eq!(median_fn(&[]), Value::Error(ErrorKind::NA));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/mode_mult/mod.rs
+++ b/crates/core/src/eval/functions/statistical/mode_mult/mod.rs
@@ -1,12 +1,64 @@
-use crate::types::Value;
-use super::mode::mode_fn;
+use crate::types::{ErrorKind, Value};
 
-/// `MODE.MULT(value1, ...)` — in scalar context, behaves like MODE.SNGL.
-/// Returns the most frequently occurring value (smallest if tied).
-/// Flattens `Value::Array` args. Ignores Text, Bool, Empty.
-/// Returns `#N/A` if all values unique or no values.
+fn collect_nums(args: &[Value]) -> Vec<f64> {
+    let mut nums: Vec<f64> = Vec::new();
+    for arg in args {
+        match arg {
+            Value::Number(n) => nums.push(*n),
+            Value::Array(arr) => {
+                for v in arr {
+                    if let Value::Number(n) = v {
+                        nums.push(*n);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    nums
+}
+
+/// `MODE.MULT(value1, ...)` — returns all most frequently occurring values as an array.
+/// If no value appears more than once, returns `#N/A`.
+/// If there is a single mode, returns `Value::Number` for that mode.
+/// If there are tied modes, returns `Value::Array` of those modes sorted ascending.
 pub fn mode_mult_fn(args: &[Value]) -> Value {
-    mode_fn(args)
+    let nums = collect_nums(args);
+    if nums.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+
+    let mut sorted = nums.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    // Count frequency of each distinct value
+    let mut freq: Vec<(f64, usize)> = Vec::new();
+    let mut i = 0;
+    while i < sorted.len() {
+        let val = sorted[i];
+        let mut count = 0;
+        while i < sorted.len() && sorted[i] == val {
+            count += 1;
+            i += 1;
+        }
+        freq.push((val, count));
+    }
+
+    let max_count = freq.iter().map(|(_, c)| *c).max().unwrap_or(0);
+    if max_count < 2 {
+        return Value::Error(ErrorKind::NA);
+    }
+
+    let modes: Vec<f64> = freq.iter()
+        .filter(|(_, c)| *c == max_count)
+        .map(|(v, _)| *v)
+        .collect();
+
+    if modes.len() == 1 {
+        Value::Number(modes[0])
+    } else {
+        Value::Array(modes.into_iter().map(Value::Number).collect())
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/skew/mod.rs
+++ b/crates/core/src/eval/functions/statistical/skew/mod.rs
@@ -21,6 +21,9 @@ pub fn skew_fn(args: &[Value]) -> Value {
         }
     }
     let n = nums.len();
+    if n == 0 {
+        return Value::Error(ErrorKind::NA);
+    }
     if n < 3 {
         return Value::Error(ErrorKind::DivByZero);
     }

--- a/crates/core/src/eval/functions/statistical/skew_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/skew_p/mod.rs
@@ -4,7 +4,7 @@ use crate::types::{ErrorKind, Value};
 /// Formula: (1/n) * Σ((x-mean)/σ)^3
 /// where σ is the population standard deviation (sqrt(Σ(x-mean)²/n)).
 /// Flattens `Value::Array` args. Ignores Text, Bool, Empty.
-/// Requires n ≥ 1. Returns `#DIV/0!` if n < 1 or σ = 0.
+/// Requires n ≥ 3. Returns `#N/A` if n=0, `#DIV/0!` if n < 3 or σ = 0.
 pub fn skew_p_fn(args: &[Value]) -> Value {
     let mut nums: Vec<f64> = Vec::new();
     for arg in args {
@@ -21,7 +21,10 @@ pub fn skew_p_fn(args: &[Value]) -> Value {
         }
     }
     let n = nums.len();
-    if n < 1 {
+    if n == 0 {
+        return Value::Error(ErrorKind::NA);
+    }
+    if n < 3 {
         return Value::Error(ErrorKind::DivByZero);
     }
     let mean = nums.iter().sum::<f64>() / n as f64;

--- a/crates/core/src/eval/functions/statistical/skew_p/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/skew_p/tests/failure.rs
@@ -2,8 +2,8 @@ use super::super::*;
 use crate::types::{ErrorKind, Value};
 
 #[test]
-fn skew_p_no_values_returns_div0() {
-    assert_eq!(skew_p_fn(&[]), Value::Error(ErrorKind::DivByZero));
+fn skew_p_no_values_returns_na() {
+    assert_eq!(skew_p_fn(&[]), Value::Error(ErrorKind::NA));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/stdeva/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/mod.rs
@@ -7,6 +7,9 @@ pub fn stdeva_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
+    if args.iter().any(|a| matches!(a, Value::Text(_))) {
+        return Value::Error(ErrorKind::Value);
+    }
     let nums = collect_nums_a(args);
     match sample_variance(&nums) {
         Value::Number(v) => {

--- a/crates/core/src/eval/functions/statistical/stdeva/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/tests/edge.rs
@@ -24,14 +24,10 @@ fn stdeva_false_counts_as_zero() {
 }
 
 #[test]
-fn stdeva_text_counts_as_zero() {
-    // Text=0.0; [0.0, 4.0]: sample var=8, stdev=sqrt(8)
+fn stdeva_text_returns_value_error() {
+    // Literal text as direct arg → #VALUE! (Google Sheets oracle)
     let result = stdeva_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    if let Value::Number(v) = result {
-        assert!((v - 8.0_f64.sqrt()).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+    assert_eq!(result, Value::Error(crate::types::ErrorKind::Value));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/stdevpa/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/mod.rs
@@ -7,6 +7,9 @@ pub fn stdevpa_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
+    if args.iter().any(|a| matches!(a, Value::Text(_))) {
+        return Value::Error(ErrorKind::Value);
+    }
     let nums = collect_nums_a(args);
     match pop_variance(&nums) {
         Value::Number(v) => {

--- a/crates/core/src/eval/functions/statistical/stdevpa/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/tests/edge.rs
@@ -14,10 +14,10 @@ fn stdevpa_false_counts_as_zero() {
 }
 
 #[test]
-fn stdevpa_text_counts_as_zero() {
-    // Text=0.0; [0.0, 4.0]: pop var=4, stdev=2.0
+fn stdevpa_text_returns_value_error() {
+    // Literal text as direct arg → #VALUE! (Google Sheets oracle)
     let result = stdevpa_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    assert_eq!(result, Value::Number(2.0));
+    assert_eq!(result, Value::Error(crate::types::ErrorKind::Value));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/vara/mod.rs
+++ b/crates/core/src/eval/functions/statistical/vara/mod.rs
@@ -7,6 +7,9 @@ pub fn vara_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
+    if args.iter().any(|a| matches!(a, Value::Text(_))) {
+        return Value::Error(ErrorKind::Value);
+    }
     let nums = collect_nums_a(args);
     sample_variance(&nums)
 }

--- a/crates/core/src/eval/functions/statistical/vara/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/vara/tests/edge.rs
@@ -16,10 +16,10 @@ fn vara_false_counts_as_zero() {
 }
 
 #[test]
-fn vara_text_counts_as_zero() {
-    // Text=0.0 is included; [0.0, 4.0]: mean=2, var=8
+fn vara_text_returns_value_error() {
+    // Literal text as direct arg → #VALUE! (Google Sheets oracle)
     let result = vara_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    assert_eq!(result, Value::Number(8.0));
+    assert_eq!(result, Value::Error(crate::types::ErrorKind::Value));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/varpa/mod.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/mod.rs
@@ -7,6 +7,9 @@ pub fn varpa_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
+    if args.iter().any(|a| matches!(a, Value::Text(_))) {
+        return Value::Error(ErrorKind::Value);
+    }
     let nums = collect_nums_a(args);
     pop_variance(&nums)
 }

--- a/crates/core/src/eval/functions/statistical/varpa/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/tests/edge.rs
@@ -14,10 +14,10 @@ fn varpa_false_counts_as_zero() {
 }
 
 #[test]
-fn varpa_text_counts_as_zero() {
-    // Text=0.0 included; [0.0, 4.0]: mean=2, pop var=((0-2)²+(4-2)²)/2=4
+fn varpa_text_returns_value_error() {
+    // Literal text as direct arg → #VALUE! (Google Sheets oracle)
     let result = varpa_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    assert_eq!(result, Value::Number(4.0));
+    assert_eq!(result, Value::Error(crate::types::ErrorKind::Value));
 }
 
 #[test]

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -226,7 +226,7 @@ conformance_test!(pending, m2_logical_conformance,     "m2", "Logical.xlsx");
 conformance_test!(pending, m2_lookup_conformance,      "m2", "Lookup.xlsx");
 conformance_test!(pending, m2_math_conformance,        "m2", "Math.xlsx");
 conformance_test!(m2_parser_conformance,               "m2", "Parser.xlsx");
-conformance_test!(pending, m2_statistical_conformance, "m2", "Statistical.xlsx");
+conformance_test!(m2_statistical_conformance,          "m2", "Statistical.xlsx");
 conformance_test!(pending, m2_text_conformance,        "m2", "Text.xlsx");
 
 conformance_test!(pending, m3_database_conformance,    "m3", "Database.xlsx");


### PR DESCRIPTION
All 46 M2 statistical functions from epic #82 are now implemented and merged:
- PR #295: AVEDEV, DEVSQ, COVARIANCE.P/S, STDEV/P/S/A, STDEVP/PA, VAR/P/S/A, VARP/PA
- PR #296: GEOMEAN, HARMEAN, KURT, MODE/MULT/SNGL, SKEW/P, TRIMMEAN + MEDIAN fix
- PR #297: AVERAGEA, AVERAGEIF, AVERAGEIFS, MAXA, MINA, MAXIFS, MINIFS
- PR #298: LARGE, SMALL, RANK/AVG/EQ, QUARTILE/EXC/INC, PERCENTILE/EXC/INC, PERCENTRANK/EXC/INC

Removes the `pending` / `#[ignore]` annotation so `m2_statistical_conformance` runs in every CI check.

This PR also fixes 19 oracle mismatches discovered when the test was re-enabled:
- MEDIAN: flatten Array args; return #N/A for no-arg call
- GEOMEAN/HARMEAN: return #N/A for no-arg call
- KURT/SKEW: return #N/A for zero-count (was #DIV/0!)
- SKEW.P: require n≥3 for #DIV/0!; return #N/A for n=0
- COVARIANCE.S: return #NUM! for n<2 (was #DIV/0!)
- STDEVA/STDEVPA/VARA/VARPA: return #VALUE! for literal text args
- MODE.MULT: return array of all tied modes to support SUM aggregation
- SUM: flatten Value::Array args recursively
- ISNUMBER: use first element of array (implicit intersection)

closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)