### PR TITLE
fix: use PAT for release-plz to trigger downstream workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,14 +18,14 @@ jobs:
       - uses: MarcoIeni/release-plz-action@v0.5
         id: release-plz
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Trigger npm release for ganit-core
         if: steps.release-plz.outputs.releases != ''
         env:
           RELEASES: ${{ steps.release-plz.outputs.releases }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
           TAG=$(echo "$RELEASES" | python3 -c "
           import json, sys


### PR DESCRIPTION
## Summary

- Replaces `secrets.GITHUB_TOKEN` with `secrets.RELEASE_PLZ_TOKEN` (PAT) in `release-plz.yml`
- GitHub does not trigger downstream workflows for pushes made with `GITHUB_TOKEN` — this is why tags created by release-plz never fired `release.yml`, leaving npm stuck on old versions
- With a PAT, tag pushes from release-plz will correctly trigger `release.yml` → npm publish

## Test plan
- [ ] Merge this PR
- [ ] Merge any subsequent release-plz PR
- [ ] Verify `release.yml` fires automatically and npm updates without manual `workflow_dispatch`

closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)