### PR TITLE
feat: implement ASC, JOIN, SPLIT, TEXTJOIN (#89 group D)

### DIFF
--- a/crates/core/src/eval/functions/text/asc/mod.rs
+++ b/crates/core/src/eval/functions/text/asc/mod.rs
@@ -1,0 +1,32 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// Convert a full-width Unicode character to its half-width equivalent.
+/// U+FF01–U+FF5E → U+0021–U+007E (full-width ASCII variants)
+/// U+3000 → U+0020 (ideographic space → ASCII space)
+fn to_halfwidth(c: char) -> char {
+    let cp = c as u32;
+    if cp == 0x3000 {
+        ' '
+    } else if (0xFF01..=0xFF5E).contains(&cp) {
+        char::from_u32(cp - 0xFEE0).unwrap_or(c)
+    } else {
+        c
+    }
+}
+
+/// `ASC(text)` — converts full-width characters to half-width equivalents.
+pub fn asc_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    Value::Text(text.chars().map(to_halfwidth).collect())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/asc/tests.rs
+++ b/crates/core/src/eval/functions/text/asc/tests.rs
@@ -1,0 +1,45 @@
+use super::*;
+use crate::types::{ErrorKind, Value};
+
+fn run(s: &str) -> Value {
+    asc_fn(&[Value::Text(s.to_string())])
+}
+
+#[test]
+fn ascii_unchanged() {
+    assert_eq!(run("Hello"), Value::Text("Hello".into()));
+    assert_eq!(run("ABC"), Value::Text("ABC".into()));
+    assert_eq!(run("hello"), Value::Text("hello".into()));
+    assert_eq!(run(" "), Value::Text(" ".into()));
+    assert_eq!(run(""), Value::Text("".into()));
+}
+
+#[test]
+fn numeric_string_unchanged() {
+    assert_eq!(run("123"), Value::Text("123".into()));
+}
+
+#[test]
+fn fullwidth_ascii_converted() {
+    // U+FF21 'Ａ' → 'A'
+    let fullwidth = "\u{FF21}\u{FF22}\u{FF23}";
+    assert_eq!(asc_fn(&[Value::Text(fullwidth.into())]), Value::Text("ABC".into()));
+}
+
+#[test]
+fn ideographic_space_converted() {
+    // U+3000 → U+0020
+    let s = "\u{3000}";
+    assert_eq!(asc_fn(&[Value::Text(s.into())]), Value::Text(" ".into()));
+}
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(asc_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args_returns_na() {
+    let r = asc_fn(&[Value::Text("a".into()), Value::Text("b".into())]);
+    assert_eq!(r, Value::Error(ErrorKind::NA));
+}

--- a/crates/core/src/eval/functions/text/join_fn/mod.rs
+++ b/crates/core/src/eval/functions/text/join_fn/mod.rs
@@ -1,0 +1,42 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// Flatten a value into a list of strings, recursively expanding arrays.
+fn collect_strings(v: &Value, out: &mut Vec<String>) -> Option<Value> {
+    match v {
+        Value::Array(elems) => {
+            for elem in elems {
+                if let Some(err) = collect_strings(elem, out) {
+                    return Some(err);
+                }
+            }
+        }
+        other => match to_string_val(other.clone()) {
+            Ok(s) => out.push(s),
+            Err(e) => return Some(e),
+        },
+    }
+    None
+}
+
+/// `JOIN(delimiter, value1, value2, ...)` — joins values with a delimiter.
+pub fn join_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 255) {
+        return err;
+    }
+    let delimiter = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for arg in &args[1..] {
+        if let Some(err) = collect_strings(arg, &mut parts) {
+            return err;
+        }
+    }
+    Value::Text(parts.join(&delimiter))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/join_fn/tests.rs
+++ b/crates/core/src/eval/functions/text/join_fn/tests.rs
@@ -1,0 +1,66 @@
+use super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn inline_array() {
+    let arr = Value::Array(vec![Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]);
+    let result = join_fn(&[Value::Text(",".into()), arr]);
+    assert_eq!(result, Value::Text("1,2,3".into()));
+}
+
+#[test]
+fn multiple_scalars() {
+    let result = join_fn(&[
+        Value::Text("-".into()),
+        Value::Text("a".into()),
+        Value::Text("b".into()),
+        Value::Text("c".into()),
+    ]);
+    assert_eq!(result, Value::Text("a-b-c".into()));
+}
+
+#[test]
+fn empty_delimiter() {
+    let result = join_fn(&[
+        Value::Text("".into()),
+        Value::Text("Hello".into()),
+        Value::Text(" ".into()),
+        Value::Text("World".into()),
+    ]);
+    assert_eq!(result, Value::Text("Hello World".into()));
+}
+
+#[test]
+fn multiple_arrays_flattened() {
+    let arr1 = Value::Array(vec![Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]);
+    let arr2 = Value::Array(vec![Value::Number(4.0), Value::Number(5.0), Value::Number(6.0)]);
+    let result = join_fn(&[Value::Text(",".into()), arr1, arr2]);
+    assert_eq!(result, Value::Text("1,2,3,4,5,6".into()));
+}
+
+#[test]
+fn single_value() {
+    let result = join_fn(&[Value::Text("|".into()), Value::Text("x".into())]);
+    assert_eq!(result, Value::Text("x".into()));
+}
+
+#[test]
+fn number_scalars() {
+    let result = join_fn(&[
+        Value::Text(",".into()),
+        Value::Number(1.0),
+        Value::Number(2.0),
+        Value::Number(3.0),
+    ]);
+    assert_eq!(result, Value::Text("1,2,3".into()));
+}
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(join_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn only_delimiter_returns_na() {
+    assert_eq!(join_fn(&[Value::Text(",".into())]), Value::Error(ErrorKind::NA));
+}

--- a/crates/core/src/eval/functions/text/mod.rs
+++ b/crates/core/src/eval/functions/text/mod.rs
@@ -33,6 +33,10 @@ pub mod search;
 pub mod trim;
 pub mod upper;
 pub mod value_fn;
+pub mod asc;
+pub mod join_fn;
+pub mod split_fn;
+pub mod textjoin;
 
 pub fn register_text(registry: &mut Registry) {
     registry.register_eager("LEFT",        left::left_fn,              FunctionMeta { category: "text", signature: "LEFT(text, num_chars)",                      description: "Left portion of a string" });
@@ -69,4 +73,8 @@ pub fn register_text(registry: &mut Registry) {
     registry.register_eager("FINDB",       findb::findb_fn,            FunctionMeta { category: "text", signature: "FINDB(find_text, within_text, [start_num])",      description: "Case-sensitive byte-position search" });
     registry.register_eager("REPLACEB",    replaceb::replaceb_fn,      FunctionMeta { category: "text", signature: "REPLACEB(text, start_byte, num_bytes, new_text)", description: "Replace portion of text by byte position" });
     registry.register_eager("SEARCHB",     searchb::searchb_fn,        FunctionMeta { category: "text", signature: "SEARCHB(find_text, within_text, [start_num])",    description: "Case-insensitive byte-position search with wildcards" });
+    registry.register_eager("ASC",         asc::asc_fn,                FunctionMeta { category: "text", signature: "ASC(text)",                                        description: "Convert full-width chars to half-width" });
+    registry.register_eager("JOIN",        join_fn::join_fn,           FunctionMeta { category: "text", signature: "JOIN(delimiter, value1, ...)",                     description: "Join values with delimiter" });
+    registry.register_eager("SPLIT",       split_fn::split_fn,         FunctionMeta { category: "text", signature: "SPLIT(text, delimiter)",                           description: "Split text into array by delimiter" });
+    registry.register_eager("TEXTJOIN",    textjoin::textjoin_fn,      FunctionMeta { category: "text", signature: "TEXTJOIN(delimiter, ignore_empty, value1, ...)",   description: "Join values with delimiter, optionally skip empty" });
 }

--- a/crates/core/src/eval/functions/text/split_fn/mod.rs
+++ b/crates/core/src/eval/functions/text/split_fn/mod.rs
@@ -1,0 +1,26 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// `SPLIT(text, delimiter)` — splits text by delimiter, returns an array.
+pub fn split_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let text = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let delimiter = match to_string_val(args[1].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let parts: Vec<Value> = text
+        .split(delimiter.as_str())
+        .map(|s| Value::Text(s.to_string()))
+        .collect();
+    Value::Array(parts)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/split_fn/tests.rs
+++ b/crates/core/src/eval/functions/text/split_fn/tests.rs
@@ -1,0 +1,35 @@
+use super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn basic_split() {
+    let result = split_fn(&[Value::Text("a,b,c".into()), Value::Text(",".into())]);
+    assert_eq!(
+        result,
+        Value::Array(vec![
+            Value::Text("a".into()),
+            Value::Text("b".into()),
+            Value::Text("c".into()),
+        ])
+    );
+}
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(split_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg_returns_na() {
+    assert_eq!(split_fn(&[Value::Text("a,b".into())]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_many_args_returns_na() {
+    let r = split_fn(&[
+        Value::Text("a,b".into()),
+        Value::Text(",".into()),
+        Value::Text("extra".into()),
+    ]);
+    assert_eq!(r, Value::Error(ErrorKind::NA));
+}

--- a/crates/core/src/eval/functions/text/textjoin/mod.rs
+++ b/crates/core/src/eval/functions/text/textjoin/mod.rs
@@ -1,0 +1,50 @@
+use crate::eval::coercion::{to_bool, to_string_val};
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+/// Flatten a value into string parts, recursively expanding arrays.
+fn collect_strings(v: &Value, out: &mut Vec<String>) -> Option<Value> {
+    match v {
+        Value::Array(elems) => {
+            for elem in elems {
+                if let Some(err) = collect_strings(elem, out) {
+                    return Some(err);
+                }
+            }
+        }
+        other => match to_string_val(other.clone()) {
+            Ok(s) => out.push(s),
+            Err(e) => return Some(e),
+        },
+    }
+    None
+}
+
+/// `TEXTJOIN(delimiter, ignore_empty, value1, value2, ...)` — joins values with
+/// a delimiter, optionally ignoring empty strings.
+pub fn textjoin_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 3, 255) {
+        return err;
+    }
+    let delimiter = match to_string_val(args[0].clone()) {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    let ignore_empty = match to_bool(args[1].clone()) {
+        Ok(b) => b,
+        Err(e) => return e,
+    };
+    let mut parts: Vec<String> = Vec::new();
+    for arg in &args[2..] {
+        if let Some(err) = collect_strings(arg, &mut parts) {
+            return err;
+        }
+    }
+    if ignore_empty {
+        parts.retain(|s| !s.is_empty());
+    }
+    Value::Text(parts.join(&delimiter))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/text/textjoin/tests.rs
+++ b/crates/core/src/eval/functions/text/textjoin/tests.rs
@@ -1,0 +1,102 @@
+use super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn basic_join_ignore_empty_true() {
+    let result = textjoin_fn(&[
+        Value::Text(",".into()),
+        Value::Bool(true),
+        Value::Text("a".into()),
+        Value::Text("b".into()),
+        Value::Text("c".into()),
+    ]);
+    assert_eq!(result, Value::Text("a,b,c".into()));
+}
+
+#[test]
+fn skip_empty_when_ignore_true() {
+    let result = textjoin_fn(&[
+        Value::Text(",".into()),
+        Value::Bool(true),
+        Value::Text("a".into()),
+        Value::Text("".into()),
+        Value::Text("c".into()),
+    ]);
+    assert_eq!(result, Value::Text("a,c".into()));
+}
+
+#[test]
+fn keep_empty_when_ignore_false() {
+    let result = textjoin_fn(&[
+        Value::Text(",".into()),
+        Value::Bool(false),
+        Value::Text("a".into()),
+        Value::Text("".into()),
+        Value::Text("c".into()),
+    ]);
+    assert_eq!(result, Value::Text("a,,c".into()));
+}
+
+#[test]
+fn array_arg() {
+    let arr = Value::Array(vec![Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]);
+    let result = textjoin_fn(&[Value::Text("-".into()), Value::Bool(true), arr]);
+    assert_eq!(result, Value::Text("1-2-3".into()));
+}
+
+#[test]
+fn empty_delimiter() {
+    let result = textjoin_fn(&[
+        Value::Text("".into()),
+        Value::Bool(true),
+        Value::Text("Hello".into()),
+        Value::Text(" ".into()),
+        Value::Text("World".into()),
+    ]);
+    assert_eq!(result, Value::Text("Hello World".into()));
+}
+
+#[test]
+fn single_value() {
+    let result = textjoin_fn(&[
+        Value::Text(",".into()),
+        Value::Bool(true),
+        Value::Text("only".into()),
+    ]);
+    assert_eq!(result, Value::Text("only".into()));
+}
+
+#[test]
+fn all_empty_ignored() {
+    let result = textjoin_fn(&[
+        Value::Text(",".into()),
+        Value::Bool(true),
+        Value::Text("".into()),
+        Value::Text("".into()),
+        Value::Text("".into()),
+    ]);
+    assert_eq!(result, Value::Text("".into()));
+}
+
+#[test]
+fn pipe_delimiter() {
+    let result = textjoin_fn(&[
+        Value::Text("|".into()),
+        Value::Bool(true),
+        Value::Text("x".into()),
+        Value::Text("y".into()),
+        Value::Text("z".into()),
+    ]);
+    assert_eq!(result, Value::Text("x|y|z".into()));
+}
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(textjoin_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn too_few_args_returns_na() {
+    let r = textjoin_fn(&[Value::Text(",".into()), Value::Bool(true)]);
+    assert_eq!(r, Value::Error(ErrorKind::NA));
+}


### PR DESCRIPTION
## Summary
- Implement `ASC` — converts full-width Unicode characters to half-width equivalents (no-op for ASCII)
- Implement `JOIN` — joins scalar/array values with a delimiter, flattening nested arrays
- Implement `SPLIT` — splits text by delimiter, returns `Value::Array` of `Value::Text` parts
- Implement `TEXTJOIN` — joins values with delimiter, optionally ignoring empty strings (`ignore_empty` flag)

## Test plan
- [ ] `cargo test -p ganit-core` — all 1540 unit tests pass
- [ ] `cargo test -p ganit-core m2_text_conformance -- --include-ignored` — zero FAIL lines for ASC, JOIN, SPLIT, TEXTJOIN
- [ ] `cargo clippy --workspace -- -D warnings` — no warnings

closes #109
closes #119
closes #154
closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)