### PR TITLE
feat: implement SQRTPI, SUMSQ, FACTDOUBLE, SERIESSUM

### DIFF
--- a/crates/core/src/eval/functions/math/combin/mod.rs
+++ b/crates/core/src/eval/functions/math/combin/mod.rs
@@ -1,0 +1,44 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// Helper: compute C(n, k) = n! / (k! * (n-k)!) for non-negative integers.
+fn combinations(n: u64, k: u64) -> f64 {
+    if k > n {
+        return 0.0;
+    }
+    let k = k.min(n - k); // take smaller k for efficiency
+    let mut result = 1.0f64;
+    for i in 0..k {
+        result *= (n - i) as f64;
+        result /= (i + 1) as f64;
+    }
+    result
+}
+
+/// `COMBIN(n, k)` — number of combinations (without repetition): C(n,k) = n! / (k! * (n-k)!)
+pub fn combin_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let k = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if n < 0.0 || k < 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let n_int = n.trunc() as u64;
+    let k_int = k.trunc() as u64;
+    if k_int > n_int {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(combinations(n_int, k_int))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/combin/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/combin/tests/edge.rs
@@ -1,0 +1,20 @@
+use super::super::combin_fn;
+use crate::types::Value;
+
+#[test]
+fn combin_0_0() {
+    // C(0,0) = 1 by convention
+    assert_eq!(combin_fn(&[Value::Number(0.0), Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn combin_n_0() {
+    // C(n,0) = 1 for any n
+    assert_eq!(combin_fn(&[Value::Number(100.0), Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn combin_n_n() {
+    // C(n,n) = 1 for any n
+    assert_eq!(combin_fn(&[Value::Number(50.0), Value::Number(50.0)]), Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/math/combin/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/combin/tests/failure.rs
@@ -1,0 +1,43 @@
+use super::super::combin_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(combin_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg() {
+    assert_eq!(combin_fn(&[Value::Number(5.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn three_args() {
+    assert_eq!(
+        combin_fn(&[Value::Number(5.0), Value::Number(2.0), Value::Number(1.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}
+
+#[test]
+fn k_greater_than_n() {
+    assert_eq!(combin_fn(&[Value::Number(2.0), Value::Number(5.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn negative_n() {
+    assert_eq!(combin_fn(&[Value::Number(-1.0), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn negative_k() {
+    assert_eq!(combin_fn(&[Value::Number(5.0), Value::Number(-1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_numeric_arg() {
+    assert_eq!(
+        combin_fn(&[Value::Text("abc".to_string()), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/combin/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/combin/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/combin/tests/success.rs
+++ b/crates/core/src/eval/functions/math/combin/tests/success.rs
@@ -1,0 +1,48 @@
+use super::super::combin_fn;
+use crate::types::Value;
+
+#[test]
+fn combin_5_2() {
+    assert_eq!(combin_fn(&[Value::Number(5.0), Value::Number(2.0)]), Value::Number(10.0));
+}
+
+#[test]
+fn combin_10_0() {
+    assert_eq!(combin_fn(&[Value::Number(10.0), Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn combin_10_10() {
+    assert_eq!(combin_fn(&[Value::Number(10.0), Value::Number(10.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn combin_10_5() {
+    assert_eq!(combin_fn(&[Value::Number(10.0), Value::Number(5.0)]), Value::Number(252.0));
+}
+
+#[test]
+fn combin_4_2() {
+    assert_eq!(combin_fn(&[Value::Number(4.0), Value::Number(2.0)]), Value::Number(6.0));
+}
+
+#[test]
+fn combin_1_1() {
+    assert_eq!(combin_fn(&[Value::Number(1.0), Value::Number(1.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn combin_20_10() {
+    assert_eq!(combin_fn(&[Value::Number(20.0), Value::Number(10.0)]), Value::Number(184756.0));
+}
+
+#[test]
+fn combin_8_2() {
+    assert_eq!(combin_fn(&[Value::Number(8.0), Value::Number(2.0)]), Value::Number(28.0));
+}
+
+#[test]
+fn combin_truncates_floats() {
+    // 5.9 truncates to 5, 2.9 truncates to 2 => C(5,2) = 10
+    assert_eq!(combin_fn(&[Value::Number(5.9), Value::Number(2.9)]), Value::Number(10.0));
+}

--- a/crates/core/src/eval/functions/math/combina/mod.rs
+++ b/crates/core/src/eval/functions/math/combina/mod.rs
@@ -1,0 +1,54 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// Helper: compute C(n, k) for non-negative integers.
+fn combinations(n: u64, k: u64) -> f64 {
+    if k == 0 {
+        return 1.0;
+    }
+    if k > n {
+        return 0.0;
+    }
+    let k = k.min(n - k);
+    let mut result = 1.0f64;
+    for i in 0..k {
+        result *= (n - i) as f64;
+        result /= (i + 1) as f64;
+    }
+    result
+}
+
+/// `COMBINA(n, k)` — combinations with repetition: C(n+k-1, k)
+/// Special cases: n=0,k=0 -> 1; n>0,k=0 -> 1; n=0,k>0 -> 0
+pub fn combina_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let k = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if n < 0.0 || k < 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let n_int = n.trunc() as u64;
+    let k_int = k.trunc() as u64;
+    // n=0, k>0 -> 0
+    if n_int == 0 && k_int > 0 {
+        return Value::Number(0.0);
+    }
+    // n=0,k=0 or k=0 -> 1
+    if k_int == 0 {
+        return Value::Number(1.0);
+    }
+    // C(n+k-1, k)
+    Value::Number(combinations(n_int + k_int - 1, k_int))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/combina/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/combina/tests/edge.rs
@@ -1,0 +1,19 @@
+use super::super::combina_fn;
+use crate::types::Value;
+
+#[test]
+fn combina_0_0() {
+    assert_eq!(combina_fn(&[Value::Number(0.0), Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn combina_0_k_returns_zero() {
+    // n=0, k>0 -> 0
+    assert_eq!(combina_fn(&[Value::Number(0.0), Value::Number(3.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn combina_truncates_floats() {
+    // 5.9 -> 5, 2.9 -> 2 => C(6,2) = 15
+    assert_eq!(combina_fn(&[Value::Number(5.9), Value::Number(2.9)]), Value::Number(15.0));
+}

--- a/crates/core/src/eval/functions/math/combina/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/combina/tests/failure.rs
@@ -1,0 +1,38 @@
+use super::super::combina_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(combina_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg() {
+    assert_eq!(combina_fn(&[Value::Number(5.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn three_args() {
+    assert_eq!(
+        combina_fn(&[Value::Number(5.0), Value::Number(2.0), Value::Number(1.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}
+
+#[test]
+fn negative_n() {
+    assert_eq!(combina_fn(&[Value::Number(-1.0), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn negative_k() {
+    assert_eq!(combina_fn(&[Value::Number(5.0), Value::Number(-1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_numeric_arg() {
+    assert_eq!(
+        combina_fn(&[Value::Text("abc".to_string()), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/combina/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/combina/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/combina/tests/success.rs
+++ b/crates/core/src/eval/functions/math/combina/tests/success.rs
@@ -1,0 +1,54 @@
+use super::super::combina_fn;
+use crate::types::Value;
+
+#[test]
+fn combina_5_2() {
+    // C(5+2-1, 2) = C(6,2) = 15
+    assert_eq!(combina_fn(&[Value::Number(5.0), Value::Number(2.0)]), Value::Number(15.0));
+}
+
+#[test]
+fn combina_3_2() {
+    // C(3+2-1, 2) = C(4,2) = 6
+    assert_eq!(combina_fn(&[Value::Number(3.0), Value::Number(2.0)]), Value::Number(6.0));
+}
+
+#[test]
+fn combina_1_1() {
+    // C(1+1-1, 1) = C(1,1) = 1
+    assert_eq!(combina_fn(&[Value::Number(1.0), Value::Number(1.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn combina_10_0() {
+    assert_eq!(combina_fn(&[Value::Number(10.0), Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn combina_5_0() {
+    assert_eq!(combina_fn(&[Value::Number(5.0), Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn combina_3_3() {
+    // C(3+3-1, 3) = C(5,3) = 10
+    assert_eq!(combina_fn(&[Value::Number(3.0), Value::Number(3.0)]), Value::Number(10.0));
+}
+
+#[test]
+fn combina_2_4() {
+    // C(2+4-1, 4) = C(5,4) = 5
+    assert_eq!(combina_fn(&[Value::Number(2.0), Value::Number(4.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn combina_10_2() {
+    // C(10+2-1, 2) = C(11,2) = 55
+    assert_eq!(combina_fn(&[Value::Number(10.0), Value::Number(2.0)]), Value::Number(55.0));
+}
+
+#[test]
+fn combina_4_3() {
+    // C(4+3-1, 3) = C(6,3) = 20
+    assert_eq!(combina_fn(&[Value::Number(4.0), Value::Number(3.0)]), Value::Number(20.0));
+}

--- a/crates/core/src/eval/functions/math/factdouble/mod.rs
+++ b/crates/core/src/eval/functions/math/factdouble/mod.rs
@@ -1,0 +1,35 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `FACTDOUBLE(n)` — double factorial: n!! = n * (n-2) * (n-4) * ... down to 1 or 2.
+/// FACTDOUBLE(0) = 1, FACTDOUBLE(-1) = #NUM!, n > 300 = #NUM! (overflow).
+pub fn factdouble_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if n < 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let n_int = n.trunc() as i64;
+    if n_int > 300 {
+        return Value::Error(ErrorKind::Num);
+    }
+    if n_int == 0 {
+        return Value::Number(1.0);
+    }
+    let mut result = 1.0_f64;
+    let mut i = n_int;
+    while i > 0 {
+        result *= i as f64;
+        i -= 2;
+    }
+    Value::Number(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/factdouble/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/factdouble/tests/edge.rs
@@ -1,0 +1,14 @@
+use super::super::factdouble_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn overflow_returns_num_error() {
+    // Very large n overflows -> #NUM!
+    assert_eq!(factdouble_fn(&[Value::Number(301.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn float_truncated() {
+    // FACTDOUBLE(5.9) truncates to 5: 5!! = 15
+    assert_eq!(factdouble_fn(&[Value::Number(5.9)]), Value::Number(15.0));
+}

--- a/crates/core/src/eval/functions/math/factdouble/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/factdouble/tests/failure.rs
@@ -1,0 +1,21 @@
+use super::super::factdouble_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn negative_returns_num_error() {
+    // FACTDOUBLE(-1) = #NUM!
+    assert_eq!(factdouble_fn(&[Value::Number(-1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn wrong_arity_zero_args() {
+    assert_eq!(factdouble_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn wrong_arity_two_args() {
+    assert_eq!(
+        factdouble_fn(&[Value::Number(1.0), Value::Number(2.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}

--- a/crates/core/src/eval/functions/math/factdouble/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/factdouble/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/factdouble/tests/success.rs
+++ b/crates/core/src/eval/functions/math/factdouble/tests/success.rs
@@ -1,0 +1,62 @@
+use super::super::factdouble_fn;
+use crate::types::Value;
+
+#[test]
+fn factdouble_odd_5() {
+    // 5!! = 5*3*1 = 15
+    assert_eq!(factdouble_fn(&[Value::Number(5.0)]), Value::Number(15.0));
+}
+
+#[test]
+fn factdouble_even_6() {
+    // 6!! = 6*4*2 = 48
+    assert_eq!(factdouble_fn(&[Value::Number(6.0)]), Value::Number(48.0));
+}
+
+#[test]
+fn factdouble_one() {
+    // 1!! = 1
+    assert_eq!(factdouble_fn(&[Value::Number(1.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn factdouble_zero() {
+    // 0!! = 1
+    assert_eq!(factdouble_fn(&[Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn factdouble_two() {
+    // 2!! = 2
+    assert_eq!(factdouble_fn(&[Value::Number(2.0)]), Value::Number(2.0));
+}
+
+#[test]
+fn factdouble_four() {
+    // 4!! = 4*2 = 8
+    assert_eq!(factdouble_fn(&[Value::Number(4.0)]), Value::Number(8.0));
+}
+
+#[test]
+fn factdouble_odd_7() {
+    // 7!! = 7*5*3*1 = 105
+    assert_eq!(factdouble_fn(&[Value::Number(7.0)]), Value::Number(105.0));
+}
+
+#[test]
+fn factdouble_even_8() {
+    // 8!! = 8*6*4*2 = 384
+    assert_eq!(factdouble_fn(&[Value::Number(8.0)]), Value::Number(384.0));
+}
+
+#[test]
+fn factdouble_10() {
+    // 10!! = 10*8*6*4*2 = 3840
+    assert_eq!(factdouble_fn(&[Value::Number(10.0)]), Value::Number(3840.0));
+}
+
+#[test]
+fn factdouble_9() {
+    // 9!! = 9*7*5*3*1 = 945
+    assert_eq!(factdouble_fn(&[Value::Number(9.0)]), Value::Number(945.0));
+}

--- a/crates/core/src/eval/functions/math/gcd/mod.rs
+++ b/crates/core/src/eval/functions/math/gcd/mod.rs
@@ -1,0 +1,31 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+fn gcd(a: u64, b: u64) -> u64 {
+    if b == 0 { a } else { gcd(b, a % b) }
+}
+
+/// `GCD(value1, value2, ...)` — greatest common divisor of all arguments.
+/// All args must be non-negative integers (floats are truncated).
+pub fn gcd_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, usize::MAX) {
+        return err;
+    }
+    let mut result: u64 = 0;
+    for arg in args {
+        let n = match to_number(arg.clone()) {
+            Err(e) => return e,
+            Ok(v) => v,
+        };
+        if n < 0.0 {
+            return Value::Error(ErrorKind::Num);
+        }
+        let n_int = n.trunc() as u64;
+        result = gcd(result, n_int);
+    }
+    Value::Number(result as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/gcd/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/gcd/tests/edge.rs
@@ -1,0 +1,14 @@
+use super::super::gcd_fn;
+use crate::types::Value;
+
+#[test]
+fn gcd_with_zero() {
+    // GCD(0, 5) = 5
+    assert_eq!(gcd_fn(&[Value::Number(0.0), Value::Number(5.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn gcd_both_zero() {
+    // GCD(0, 0) = 0
+    assert_eq!(gcd_fn(&[Value::Number(0.0), Value::Number(0.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/math/gcd/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/gcd/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::gcd_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(gcd_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn negative_value() {
+    assert_eq!(
+        gcd_fn(&[Value::Number(-1.0), Value::Number(5.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn non_numeric_arg() {
+    assert_eq!(
+        gcd_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/gcd/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/gcd/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/gcd/tests/success.rs
+++ b/crates/core/src/eval/functions/math/gcd/tests/success.rs
@@ -1,0 +1,46 @@
+use super::super::gcd_fn;
+use crate::types::Value;
+
+#[test]
+fn gcd_12_8() {
+    assert_eq!(gcd_fn(&[Value::Number(12.0), Value::Number(8.0)]), Value::Number(4.0));
+}
+
+#[test]
+fn gcd_15_25() {
+    assert_eq!(gcd_fn(&[Value::Number(15.0), Value::Number(25.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn gcd_coprime() {
+    assert_eq!(gcd_fn(&[Value::Number(7.0), Value::Number(13.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn gcd_three_args() {
+    assert_eq!(
+        gcd_fn(&[Value::Number(100.0), Value::Number(75.0), Value::Number(50.0)]),
+        Value::Number(25.0)
+    );
+}
+
+#[test]
+fn gcd_same_values() {
+    assert_eq!(gcd_fn(&[Value::Number(6.0), Value::Number(6.0)]), Value::Number(6.0));
+}
+
+#[test]
+fn gcd_one_value() {
+    assert_eq!(gcd_fn(&[Value::Number(5.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn gcd_1_1() {
+    assert_eq!(gcd_fn(&[Value::Number(1.0), Value::Number(1.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn gcd_truncates_floats() {
+    // 12.9 -> 12, 8.9 -> 8 => GCD(12, 8) = 4
+    assert_eq!(gcd_fn(&[Value::Number(12.9), Value::Number(8.9)]), Value::Number(4.0));
+}

--- a/crates/core/src/eval/functions/math/lcm/mod.rs
+++ b/crates/core/src/eval/functions/math/lcm/mod.rs
@@ -1,0 +1,39 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+fn gcd(a: u64, b: u64) -> u64 {
+    if b == 0 { a } else { gcd(b, a % b) }
+}
+
+fn lcm(a: u64, b: u64) -> u64 {
+    if a == 0 || b == 0 {
+        0
+    } else {
+        a / gcd(a, b) * b
+    }
+}
+
+/// `LCM(value1, value2, ...)` — least common multiple of all arguments.
+/// All args must be non-negative integers (floats are truncated).
+pub fn lcm_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, usize::MAX) {
+        return err;
+    }
+    let mut result: u64 = 1;
+    for arg in args {
+        let n = match to_number(arg.clone()) {
+            Err(e) => return e,
+            Ok(v) => v,
+        };
+        if n < 0.0 {
+            return Value::Error(ErrorKind::Num);
+        }
+        let n_int = n.trunc() as u64;
+        result = lcm(result, n_int);
+    }
+    Value::Number(result as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/lcm/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/lcm/tests/edge.rs
@@ -1,0 +1,14 @@
+use super::super::lcm_fn;
+use crate::types::Value;
+
+#[test]
+fn lcm_with_zero() {
+    // LCM(0, 5) = 0
+    assert_eq!(lcm_fn(&[Value::Number(0.0), Value::Number(5.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn lcm_both_zero() {
+    // LCM(0, 0) = 0
+    assert_eq!(lcm_fn(&[Value::Number(0.0), Value::Number(0.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/math/lcm/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/lcm/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::lcm_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(lcm_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn negative_value() {
+    assert_eq!(
+        lcm_fn(&[Value::Number(-1.0), Value::Number(5.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn non_numeric_arg() {
+    assert_eq!(
+        lcm_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/lcm/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/lcm/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/lcm/tests/success.rs
+++ b/crates/core/src/eval/functions/math/lcm/tests/success.rs
@@ -1,0 +1,51 @@
+use super::super::lcm_fn;
+use crate::types::Value;
+
+#[test]
+fn lcm_4_6() {
+    assert_eq!(lcm_fn(&[Value::Number(4.0), Value::Number(6.0)]), Value::Number(12.0));
+}
+
+#[test]
+fn lcm_5_3() {
+    assert_eq!(lcm_fn(&[Value::Number(5.0), Value::Number(3.0)]), Value::Number(15.0));
+}
+
+#[test]
+fn lcm_same_values() {
+    assert_eq!(lcm_fn(&[Value::Number(7.0), Value::Number(7.0)]), Value::Number(7.0));
+}
+
+#[test]
+fn lcm_1_5() {
+    assert_eq!(lcm_fn(&[Value::Number(1.0), Value::Number(5.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn lcm_three_args() {
+    assert_eq!(
+        lcm_fn(&[Value::Number(12.0), Value::Number(8.0), Value::Number(6.0)]),
+        Value::Number(24.0)
+    );
+}
+
+#[test]
+fn lcm_1_1() {
+    assert_eq!(lcm_fn(&[Value::Number(1.0), Value::Number(1.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn lcm_x_1() {
+    assert_eq!(lcm_fn(&[Value::Number(7.0), Value::Number(1.0)]), Value::Number(7.0));
+}
+
+#[test]
+fn lcm_single_value() {
+    assert_eq!(lcm_fn(&[Value::Number(5.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn lcm_truncates_floats() {
+    // 4.9 -> 4, 6.9 -> 6 => LCM(4, 6) = 12
+    assert_eq!(lcm_fn(&[Value::Number(4.9), Value::Number(6.9)]), Value::Number(12.0));
+}

--- a/crates/core/src/eval/functions/math/mod.rs
+++ b/crates/core/src/eval/functions/math/mod.rs
@@ -5,8 +5,6 @@ pub mod average;
 pub mod averageif;
 pub mod ceiling_floor;
 pub mod countif;
-pub mod countifs;
-pub mod countunique;
 pub mod criterion;
 pub mod exp;
 pub mod fact;
@@ -25,7 +23,6 @@ pub mod sqrt;
 pub mod sqrtpi;
 pub mod sum;
 pub mod sumif;
-pub mod sumifs;
 pub mod sumsq;
 pub mod trig;
 

--- a/crates/core/src/eval/functions/math/mod.rs
+++ b/crates/core/src/eval/functions/math/mod.rs
@@ -5,9 +5,12 @@ pub mod average;
 pub mod averageif;
 pub mod ceiling_floor;
 pub mod countif;
+pub mod countifs;
+pub mod countunique;
 pub mod criterion;
 pub mod exp;
 pub mod fact;
+pub mod factdouble;
 pub mod int_fn;
 pub mod log;
 pub mod mod_fn;
@@ -16,10 +19,14 @@ pub mod product;
 pub mod quotient;
 pub mod rand;
 pub mod round;
+pub mod seriessum;
 pub mod sign;
 pub mod sqrt;
+pub mod sqrtpi;
 pub mod sum;
 pub mod sumif;
+pub mod sumifs;
+pub mod sumsq;
 pub mod trig;
 
 pub fn register_math(registry: &mut Registry) {
@@ -76,4 +83,8 @@ pub fn register_math(registry: &mut Registry) {
     registry.register_eager("COUNTIF",    countif::countif_fn,          FunctionMeta { category: "math",        signature: "COUNTIF(range, criterion)",              description: "Count cells matching criterion" });
     registry.register_eager("SUMIF",      sumif::sumif_fn,              FunctionMeta { category: "math",        signature: "SUMIF(range, criterion, [sum_range])",   description: "Sum cells where range matches criterion" });
     registry.register_eager("AVERAGEIF",  averageif::averageif_fn,      FunctionMeta { category: "statistical", signature: "AVERAGEIF(range, criterion, [avg_range])", description: "Average cells where range matches criterion" });
+    registry.register_eager("SQRTPI",     sqrtpi::sqrtpi_fn,            FunctionMeta { category: "math",        signature: "SQRTPI(n)",                                 description: "Square root of n times pi" });
+    registry.register_eager("SUMSQ",      sumsq::sumsq_fn,              FunctionMeta { category: "math",        signature: "SUMSQ(value1,...)",                          description: "Sum of squares of arguments" });
+    registry.register_eager("FACTDOUBLE", factdouble::factdouble_fn,    FunctionMeta { category: "math",        signature: "FACTDOUBLE(n)",                              description: "Double factorial of a number" });
+    registry.register_eager("SERIESSUM",  seriessum::seriessum_fn,      FunctionMeta { category: "math",        signature: "SERIESSUM(x, n, m, coefficients)",           description: "Sum of a power series" });
 }

--- a/crates/core/src/eval/functions/math/multinomial/mod.rs
+++ b/crates/core/src/eval/functions/math/multinomial/mod.rs
@@ -1,0 +1,47 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `MULTINOMIAL(value1, value2, ...)` — (sum of args)! / product of factorials of each arg.
+pub fn multinomial_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, usize::MAX) {
+        return err;
+    }
+    let mut values: Vec<u64> = Vec::with_capacity(args.len());
+    for arg in args {
+        let n = match to_number(arg.clone()) {
+            Err(e) => return e,
+            Ok(v) => v,
+        };
+        if n < 0.0 {
+            return Value::Error(ErrorKind::Num);
+        }
+        values.push(n.trunc() as u64);
+    }
+    let sum: u64 = values.iter().sum();
+    // Compute sum! / product(i!)
+    // Use the identity: MULTINOMIAL = C(sum, v1) * C(sum-v1, v2) * ...
+    let mut result = 1.0f64;
+    let mut remaining = sum;
+    for &v in &values {
+        result *= combinations(remaining, v);
+        remaining -= v;
+    }
+    Value::Number(result)
+}
+
+fn combinations(n: u64, k: u64) -> f64 {
+    if k == 0 || k == n {
+        return 1.0;
+    }
+    let k = k.min(n - k);
+    let mut result = 1.0f64;
+    for i in 0..k {
+        result *= (n - i) as f64;
+        result /= (i + 1) as f64;
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/multinomial/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/multinomial/tests/edge.rs
@@ -1,0 +1,28 @@
+use super::super::multinomial_fn;
+use crate::types::Value;
+
+#[test]
+fn multinomial_with_zero() {
+    // MULTINOMIAL(0, 3) = (0+3)! / (0! * 3!) = 6 / (1 * 6) = 1
+    assert_eq!(
+        multinomial_fn(&[Value::Number(0.0), Value::Number(3.0)]),
+        Value::Number(1.0)
+    );
+}
+
+#[test]
+fn multinomial_all_zeros() {
+    assert_eq!(
+        multinomial_fn(&[Value::Number(0.0), Value::Number(0.0)]),
+        Value::Number(1.0)
+    );
+}
+
+#[test]
+fn multinomial_truncates_floats() {
+    // 2.9 -> 2, 3.9 -> 3 => same as MULTINOMIAL(2, 3) = 10
+    assert_eq!(
+        multinomial_fn(&[Value::Number(2.9), Value::Number(3.9)]),
+        Value::Number(10.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/multinomial/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/multinomial/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::multinomial_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args() {
+    assert_eq!(multinomial_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn negative_value() {
+    assert_eq!(
+        multinomial_fn(&[Value::Number(-1.0), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn non_numeric_arg() {
+    assert_eq!(
+        multinomial_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/math/multinomial/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/multinomial/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/multinomial/tests/success.rs
+++ b/crates/core/src/eval/functions/math/multinomial/tests/success.rs
@@ -1,0 +1,62 @@
+use super::super::multinomial_fn;
+use crate::types::Value;
+
+#[test]
+fn multinomial_2_3() {
+    // (2+3)! / (2! * 3!) = 120 / 12 = 10
+    assert_eq!(
+        multinomial_fn(&[Value::Number(2.0), Value::Number(3.0)]),
+        Value::Number(10.0)
+    );
+}
+
+#[test]
+fn multinomial_1_1_1() {
+    // (1+1+1)! / (1! * 1! * 1!) = 6
+    assert_eq!(
+        multinomial_fn(&[Value::Number(1.0), Value::Number(1.0), Value::Number(1.0)]),
+        Value::Number(6.0)
+    );
+}
+
+#[test]
+fn multinomial_single_value() {
+    // (4)! / 4! = 1
+    assert_eq!(multinomial_fn(&[Value::Number(4.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn multinomial_3_2_1() {
+    // (3+2+1)! / (3! * 2! * 1!) = 720 / 12 = 60
+    assert_eq!(
+        multinomial_fn(&[Value::Number(3.0), Value::Number(2.0), Value::Number(1.0)]),
+        Value::Number(60.0)
+    );
+}
+
+#[test]
+fn multinomial_1_2() {
+    // (1+2)! / (1! * 2!) = 6 / 2 = 3
+    assert_eq!(
+        multinomial_fn(&[Value::Number(1.0), Value::Number(2.0)]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn multinomial_2_3_4() {
+    // (2+3+4)! / (2! * 3! * 4!) = 362880 / (2 * 6 * 24) = 1260
+    assert_eq!(
+        multinomial_fn(&[Value::Number(2.0), Value::Number(3.0), Value::Number(4.0)]),
+        Value::Number(1260.0)
+    );
+}
+
+#[test]
+fn multinomial_2_2_2() {
+    // (2+2+2)! / (2! * 2! * 2!) = 720 / 8 = 90
+    assert_eq!(
+        multinomial_fn(&[Value::Number(2.0), Value::Number(2.0), Value::Number(2.0)]),
+        Value::Number(90.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/seriessum/mod.rs
+++ b/crates/core/src/eval/functions/math/seriessum/mod.rs
@@ -1,0 +1,58 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `SERIESSUM(x, n, m, coefficients)` — power series sum.
+/// Computes sum(coefficients[i] * x^(n + i*m)) for i = 0..len(coefficients)-1.
+pub fn seriessum_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 4, 4) {
+        return err;
+    }
+    let x = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let n = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let m = match to_number(args[2].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+
+    // Collect coefficients from the 4th argument (array or scalar)
+    let coeffs: Vec<f64> = match &args[3] {
+        Value::Array(elems) => {
+            let mut cs = Vec::with_capacity(elems.len());
+            for elem in elems {
+                match to_number(elem.clone()) {
+                    Err(e) => return e,
+                    Ok(v) => cs.push(v),
+                }
+            }
+            cs
+        }
+        other => match to_number(other.clone()) {
+            Err(e) => return e,
+            Ok(v) => vec![v],
+        },
+    };
+
+    let mut total = 0.0_f64;
+    for (i, &coeff) in coeffs.iter().enumerate() {
+        let power = n + (i as f64) * m;
+        let term = coeff * x.powf(power);
+        if !term.is_finite() {
+            return Value::Error(ErrorKind::Num);
+        }
+        total += term;
+    }
+    if !total.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(total)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/seriessum/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/seriessum/tests/edge.rs
@@ -1,0 +1,38 @@
+use super::super::seriessum_fn;
+use crate::types::Value;
+
+fn arr(ns: &[f64]) -> Value {
+    Value::Array(ns.iter().map(|&n| Value::Number(n)).collect())
+}
+
+#[test]
+fn three_coeffs_all_ones() {
+    // SERIESSUM(1, 1, 1, {1,1,1}) = 1*1^1 + 1*1^2 + 1*1^3 = 3
+    assert_eq!(
+        seriessum_fn(&[Value::Number(1.0), Value::Number(1.0), Value::Number(1.0), arr(&[1.0, 1.0, 1.0])]),
+        Value::Number(3.0)
+    );
+}
+
+#[test]
+fn scalar_coeff() {
+    // SERIESSUM(10, 0, 1, 1) = 1 * 10^0 = 1 (scalar treated as single element)
+    assert_eq!(
+        seriessum_fn(&[Value::Number(10.0), Value::Number(0.0), Value::Number(1.0), Value::Number(1.0)]),
+        Value::Number(1.0)
+    );
+}
+
+#[test]
+fn approx_series() {
+    // SERIESSUM(1, 0, 1, {1, 1, 0.5}) = 1 + 1 + 0.5 = 2.5
+    assert_eq!(
+        seriessum_fn(&[
+            Value::Number(1.0),
+            Value::Number(0.0),
+            Value::Number(1.0),
+            arr(&[1.0, 1.0, 0.5])
+        ]),
+        Value::Number(2.5)
+    );
+}

--- a/crates/core/src/eval/functions/math/seriessum/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/seriessum/tests/failure.rs
@@ -1,0 +1,15 @@
+use super::super::seriessum_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn wrong_arity_zero_args() {
+    assert_eq!(seriessum_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn wrong_arity_three_args() {
+    assert_eq!(
+        seriessum_fn(&[Value::Number(1.0), Value::Number(0.0), Value::Number(1.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}

--- a/crates/core/src/eval/functions/math/seriessum/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/seriessum/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/seriessum/tests/success.rs
+++ b/crates/core/src/eval/functions/math/seriessum/tests/success.rs
@@ -1,0 +1,51 @@
+use super::super::seriessum_fn;
+use crate::types::Value;
+
+fn arr(ns: &[f64]) -> Value {
+    Value::Array(ns.iter().map(|&n| Value::Number(n)).collect())
+}
+
+#[test]
+fn single_coeff_identity() {
+    // SERIESSUM(1, 0, 1, {1}) = 1^0 * 1 = 1
+    assert_eq!(
+        seriessum_fn(&[Value::Number(1.0), Value::Number(0.0), Value::Number(1.0), arr(&[1.0])]),
+        Value::Number(1.0)
+    );
+}
+
+#[test]
+fn two_coeffs() {
+    // SERIESSUM(2, 1, 1, {1, 1}) = 1*2^1 + 1*2^2 = 2 + 4 = 6
+    assert_eq!(
+        seriessum_fn(&[Value::Number(2.0), Value::Number(1.0), Value::Number(1.0), arr(&[1.0, 1.0])]),
+        Value::Number(6.0)
+    );
+}
+
+#[test]
+fn step_zero() {
+    // SERIESSUM(3, 0, 0, {5}) = 5 * 3^0 = 5
+    assert_eq!(
+        seriessum_fn(&[Value::Number(3.0), Value::Number(0.0), Value::Number(0.0), arr(&[5.0])]),
+        Value::Number(5.0)
+    );
+}
+
+#[test]
+fn x_zero() {
+    // SERIESSUM(0, 1, 1, {5, 3}) = 5*0^1 + 3*0^2 = 0
+    assert_eq!(
+        seriessum_fn(&[Value::Number(0.0), Value::Number(1.0), Value::Number(1.0), arr(&[5.0, 3.0])]),
+        Value::Number(0.0)
+    );
+}
+
+#[test]
+fn step_two() {
+    // SERIESSUM(2, 0, 2, {1, 1}) = 1*2^0 + 1*2^2 = 1 + 4 = 5
+    assert_eq!(
+        seriessum_fn(&[Value::Number(2.0), Value::Number(0.0), Value::Number(2.0), arr(&[1.0, 1.0])]),
+        Value::Number(5.0)
+    );
+}

--- a/crates/core/src/eval/functions/math/sqrtpi/mod.rs
+++ b/crates/core/src/eval/functions/math/sqrtpi/mod.rs
@@ -1,0 +1,21 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `SQRTPI(n)` — returns sqrt(n * PI). n must be >= 0, else #NUM!.
+pub fn sqrtpi_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let n = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if n < 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number((n * std::f64::consts::PI).sqrt())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/sqrtpi/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/sqrtpi/tests/edge.rs
@@ -1,0 +1,24 @@
+use super::super::sqrtpi_fn;
+use crate::types::Value;
+
+#[test]
+fn sqrtpi_pi() {
+    // SQRTPI(PI()) = sqrt(PI*PI) = PI ≈ 3.141593
+    let result = sqrtpi_fn(&[Value::Number(std::f64::consts::PI)]);
+    if let Value::Number(n) = result {
+        assert!((n - std::f64::consts::PI).abs() < 1e-6);
+    } else {
+        panic!("expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn sqrtpi_inverse_pi() {
+    // SQRTPI(1/PI()) = sqrt(1) = 1
+    let result = sqrtpi_fn(&[Value::Number(1.0 / std::f64::consts::PI)]);
+    if let Value::Number(n) = result {
+        assert!((n - 1.0).abs() < 1e-9);
+    } else {
+        panic!("expected Number, got {:?}", result);
+    }
+}

--- a/crates/core/src/eval/functions/math/sqrtpi/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/sqrtpi/tests/failure.rs
@@ -1,0 +1,21 @@
+use super::super::sqrtpi_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn negative_returns_num_error() {
+    // SQRTPI(-1) = #NUM!
+    assert_eq!(sqrtpi_fn(&[Value::Number(-1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn wrong_arity_zero_args() {
+    assert_eq!(sqrtpi_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn wrong_arity_two_args() {
+    assert_eq!(
+        sqrtpi_fn(&[Value::Number(1.0), Value::Number(2.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}

--- a/crates/core/src/eval/functions/math/sqrtpi/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/sqrtpi/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/sqrtpi/tests/success.rs
+++ b/crates/core/src/eval/functions/math/sqrtpi/tests/success.rs
@@ -1,0 +1,30 @@
+use super::super::sqrtpi_fn;
+use crate::types::Value;
+
+#[test]
+fn sqrtpi_one() {
+    // SQRTPI(1) = sqrt(PI) ≈ 1.7724538509
+    let result = sqrtpi_fn(&[Value::Number(1.0)]);
+    if let Value::Number(n) = result {
+        assert!((n - 1.7724538509_f64).abs() < 1e-9);
+    } else {
+        panic!("expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn sqrtpi_four() {
+    // SQRTPI(4) = 2*sqrt(PI) ≈ 3.544908
+    let result = sqrtpi_fn(&[Value::Number(4.0)]);
+    if let Value::Number(n) = result {
+        assert!((n - 3.5449077_f64).abs() < 1e-6);
+    } else {
+        panic!("expected Number, got {:?}", result);
+    }
+}
+
+#[test]
+fn sqrtpi_zero() {
+    // SQRTPI(0) = 0
+    assert_eq!(sqrtpi_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/math/sumsq/mod.rs
+++ b/crates/core/src/eval/functions/math/sumsq/mod.rs
@@ -1,0 +1,56 @@
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+/// `SUMSQ(value1, value2, ...)` — returns sum of squares of all arguments.
+/// Arrays are flattened. Non-numeric text is ignored. Errors are propagated.
+pub fn sumsq_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 255) {
+        return err;
+    }
+    let mut sum = 0.0_f64;
+    for arg in args {
+        match sumsq_value(arg) {
+            Err(e) => return e,
+            Ok(n) => sum += n,
+        }
+    }
+    if !sum.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(sum)
+}
+
+/// Recursively square-sum a value, flattening arrays.
+/// Non-numeric text and empty values contribute 0.
+fn sumsq_value(v: &Value) -> Result<f64, Value> {
+    match v {
+        Value::Array(elems) => {
+            let mut total = 0.0_f64;
+            for elem in elems {
+                total += sumsq_value(elem)?;
+            }
+            Ok(total)
+        }
+        Value::Number(n) => Ok(n * n),
+        Value::Bool(b) => {
+            let n = if *b { 1.0_f64 } else { 0.0_f64 };
+            Ok(n * n)
+        }
+        Value::Empty => Ok(0.0),
+        Value::Text(s) => {
+            if s.is_empty() {
+                Ok(0.0)
+            } else {
+                match s.parse::<f64>() {
+                    Ok(n) => Ok(n * n),
+                    Err(_) => Ok(0.0), // non-numeric text ignored
+                }
+            }
+        }
+        Value::Error(_) => Err(v.clone()),
+        Value::Date(n) => Ok(n * n),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/sumsq/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/sumsq/tests/edge.rs
@@ -1,0 +1,33 @@
+use super::super::sumsq_fn;
+use crate::types::Value;
+
+#[test]
+fn non_numeric_text_ignored() {
+    // Non-numeric text should contribute 0
+    let result = sumsq_fn(&[Value::Number(3.0), Value::Text("hello".to_string())]);
+    assert_eq!(result, Value::Number(9.0));
+}
+
+#[test]
+fn many_ones() {
+    // SUMSQ(1,1,1,1,1) = 5
+    assert_eq!(
+        sumsq_fn(&[
+            Value::Number(1.0),
+            Value::Number(1.0),
+            Value::Number(1.0),
+            Value::Number(1.0),
+            Value::Number(1.0),
+        ]),
+        Value::Number(5.0)
+    );
+}
+
+#[test]
+fn fractions() {
+    // SUMSQ(0.5, 0.5) = 0.25 + 0.25 = 0.5
+    assert_eq!(
+        sumsq_fn(&[Value::Number(0.5), Value::Number(0.5)]),
+        Value::Number(0.5)
+    );
+}

--- a/crates/core/src/eval/functions/math/sumsq/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/sumsq/tests/failure.rs
@@ -1,0 +1,13 @@
+use super::super::sumsq_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn wrong_arity_zero_args() {
+    assert_eq!(sumsq_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn error_propagated() {
+    let result = sumsq_fn(&[Value::Number(1.0), Value::Error(ErrorKind::Value)]);
+    assert_eq!(result, Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/math/sumsq/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/sumsq/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/sumsq/tests/success.rs
+++ b/crates/core/src/eval/functions/math/sumsq/tests/success.rs
@@ -1,0 +1,47 @@
+use super::super::sumsq_fn;
+use crate::types::Value;
+
+#[test]
+fn sumsq_two_args() {
+    // SUMSQ(3, 4) = 9 + 16 = 25
+    assert_eq!(sumsq_fn(&[Value::Number(3.0), Value::Number(4.0)]), Value::Number(25.0));
+}
+
+#[test]
+fn sumsq_three_args() {
+    // SUMSQ(1, 2, 3) = 1 + 4 + 9 = 14
+    assert_eq!(
+        sumsq_fn(&[Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]),
+        Value::Number(14.0)
+    );
+}
+
+#[test]
+fn sumsq_array() {
+    // SUMSQ({1,2,3,4}) = 1+4+9+16 = 30
+    let arr = Value::Array(vec![
+        Value::Number(1.0),
+        Value::Number(2.0),
+        Value::Number(3.0),
+        Value::Number(4.0),
+    ]);
+    assert_eq!(sumsq_fn(&[arr]), Value::Number(30.0));
+}
+
+#[test]
+fn sumsq_single() {
+    // SUMSQ(5) = 25
+    assert_eq!(sumsq_fn(&[Value::Number(5.0)]), Value::Number(25.0));
+}
+
+#[test]
+fn sumsq_zero() {
+    // SUMSQ(0) = 0
+    assert_eq!(sumsq_fn(&[Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn sumsq_negatives() {
+    // SUMSQ(-3, -4) = 9 + 16 = 25
+    assert_eq!(sumsq_fn(&[Value::Number(-3.0), Value::Number(-4.0)]), Value::Number(25.0));
+}


### PR DESCRIPTION
## Summary

- Implement `SQRTPI(n)` — returns `sqrt(n * PI)`, errors on negative input
- Implement `SUMSQ(v1, v2, ...)` — sum of squares, flattens arrays, ignores non-numeric text
- Implement `FACTDOUBLE(n)` — double factorial (`n!!`), errors on negative input or overflow (n > 300)
- Implement `SERIESSUM(x, n, m, coefficients)` — evaluates power series `sum(a[i] * x^(n + i*m))`

All 4 functions pass the Google Sheets oracle conformance test in `Math.xlsx`.

## Test plan

- [x] Unit tests (success/failure/edge) for each function in `math/<name>/tests/`
- [x] `cargo clippy --workspace -- -D warnings` passes clean
- [x] `cargo test -p ganit-core` — all tests pass
- [x] Conformance test `m2_math_conformance` — no failures for SQRTPI, SUMSQ, FACTDOUBLE, SERIESSUM

closes #190
closes #204
closes #155
closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)