### PR TITLE
feat: implement COUNTIFS, COUNTUNIQUE, SUMIFS conditional aggregation functions

### DIFF
--- a/crates/core/src/eval/functions/math/countifs/mod.rs
+++ b/crates/core/src/eval/functions/math/countifs/mod.rs
@@ -1,0 +1,41 @@
+use crate::types::{ErrorKind, Value};
+use super::criterion::{flatten_to_vec, matches_criterion, parse_criterion};
+
+/// `COUNTIFS(range1, criterion1, [range2, criterion2, ...])` — count rows where
+/// all (range, criterion) pairs match simultaneously.
+///
+/// Arguments must come in pairs: even total count >= 2.
+/// All ranges must have the same length; if they differ, zip stops at the shortest.
+pub fn countifs_fn(args: &[Value]) -> Value {
+    // Need at least 2 args, and even count.
+    if args.len() < 2 || !args.len().is_multiple_of(2) {
+        return Value::Error(ErrorKind::NA);
+    }
+
+    // Build (range_vec, criterion) pairs.
+    let pairs: Vec<(Vec<&Value>, _)> = args
+        .chunks(2)
+        .map(|chunk| {
+            let range = flatten_to_vec(&chunk[0]);
+            let crit = parse_criterion(&chunk[1]);
+            (range, crit)
+        })
+        .collect();
+
+    // Use the first range's length as the row count.
+    let row_count = pairs[0].0.len();
+
+    let mut count = 0usize;
+    for i in 0..row_count {
+        if pairs.iter().all(|(range, crit)| {
+            range.get(i).is_some_and(|v| matches_criterion(v, crit))
+        }) {
+            count += 1;
+        }
+    }
+
+    Value::Number(count as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/countifs/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/countifs/tests/edge.rs
@@ -1,0 +1,45 @@
+use super::super::countifs_fn;
+use crate::types::Value;
+
+fn nums(ns: &[f64]) -> Value {
+    Value::Array(ns.iter().map(|&n| Value::Number(n)).collect())
+}
+
+#[test]
+fn no_matches_returns_zero() {
+    // COUNTIFS({1,2,3}, ">5", {1,2,3}, "<10") → 0
+    let range = nums(&[1.0, 2.0, 3.0]);
+    let result = countifs_fn(&[
+        range.clone(),
+        Value::Text(">5".to_string()),
+        range.clone(),
+        Value::Text("<10".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(0.0));
+}
+
+#[test]
+fn all_match_returns_full_count() {
+    // COUNTIFS({1,2,3}, ">=1", {1,2,3}, "<=3") → 3
+    let range = nums(&[1.0, 2.0, 3.0]);
+    let result = countifs_fn(&[
+        range.clone(),
+        Value::Text(">=1".to_string()),
+        range.clone(),
+        Value::Text("<=3".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(3.0));
+}
+
+#[test]
+fn empty_array_returns_zero() {
+    let result = countifs_fn(&[Value::Array(vec![]), Value::Number(1.0)]);
+    assert_eq!(result, Value::Number(0.0));
+}
+
+#[test]
+fn scalar_range_single_element() {
+    // COUNTIFS(5, 5) → 1 (scalar treated as single-element range)
+    let result = countifs_fn(&[Value::Number(5.0), Value::Number(5.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/math/countifs/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/countifs/tests/failure.rs
@@ -1,0 +1,28 @@
+use super::super::countifs_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn zero_args_returns_na() {
+    assert_eq!(countifs_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg_returns_na() {
+    assert_eq!(
+        countifs_fn(&[Value::Number(1.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}
+
+#[test]
+fn odd_args_returns_na() {
+    // 3 args — not an even number of range/criterion pairs
+    assert_eq!(
+        countifs_fn(&[
+            Value::Number(1.0),
+            Value::Number(1.0),
+            Value::Number(1.0),
+        ]),
+        Value::Error(ErrorKind::NA)
+    );
+}

--- a/crates/core/src/eval/functions/math/countifs/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/countifs/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/countifs/tests/success.rs
+++ b/crates/core/src/eval/functions/math/countifs/tests/success.rs
@@ -1,0 +1,82 @@
+use super::super::countifs_fn;
+use crate::types::Value;
+
+fn nums(ns: &[f64]) -> Value {
+    Value::Array(ns.iter().map(|&n| Value::Number(n)).collect())
+}
+
+fn texts(ss: &[&str]) -> Value {
+    Value::Array(ss.iter().map(|s| Value::Text(s.to_string())).collect())
+}
+
+#[test]
+fn single_criterion_gt() {
+    // COUNTIFS({1,2,3,4,5}, ">2") → 3
+    let result = countifs_fn(&[nums(&[1.0, 2.0, 3.0, 4.0, 5.0]), Value::Text(">2".to_string())]);
+    assert_eq!(result, Value::Number(3.0));
+}
+
+#[test]
+fn two_criteria_both_match() {
+    // COUNTIFS({1,2,3,4,5}, ">1", {1,2,3,4,5}, "<5") → 3
+    let range = nums(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+    let result = countifs_fn(&[
+        range.clone(),
+        Value::Text(">1".to_string()),
+        range.clone(),
+        Value::Text("<5".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(3.0));
+}
+
+#[test]
+fn two_criteria_different_ranges() {
+    // COUNTIFS({1,2,3,4}, ">1", {10,20,30,40}, ">20") → 2 (rows 3,4: 3→30, 4→40)
+    let result = countifs_fn(&[
+        nums(&[1.0, 2.0, 3.0, 4.0]),
+        Value::Text(">1".to_string()),
+        nums(&[10.0, 20.0, 30.0, 40.0]),
+        Value::Text(">20".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn single_criterion_exact_number() {
+    // COUNTIFS({1,2,3,2,1}, 2) → 2
+    let result = countifs_fn(&[
+        nums(&[1.0, 2.0, 3.0, 2.0, 1.0]),
+        Value::Number(2.0),
+    ]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn text_criterion() {
+    // COUNTIFS({"a","b","a","c"}, "a") → 2
+    let result = countifs_fn(&[
+        texts(&["a", "b", "a", "c"]),
+        Value::Text("a".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn wildcard_criterion() {
+    // COUNTIFS({"apple","apricot","banana"}, "a*") → 2
+    let result = countifs_fn(&[
+        texts(&["apple", "apricot", "banana"]),
+        Value::Text("a*".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn ne_criterion() {
+    // COUNTIFS({1,2,3,2,1}, "<>2") → 3
+    let result = countifs_fn(&[
+        nums(&[1.0, 2.0, 3.0, 2.0, 1.0]),
+        Value::Text("<>2".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(3.0));
+}

--- a/crates/core/src/eval/functions/math/countunique/mod.rs
+++ b/crates/core/src/eval/functions/math/countunique/mod.rs
@@ -1,0 +1,56 @@
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+use std::collections::HashSet;
+
+/// A key for deduplication. Numbers and text are distinct types even when they
+/// have the same "display" value (e.g. `1` vs `"1"`). Text comparison is
+/// case-insensitive. Empty values (Empty or Text("")) are ignored.
+#[derive(PartialEq, Eq, Hash)]
+enum UniqueKey {
+    Number(u64),   // bit-cast of f64 for hashing
+    Text(String),  // lowercased
+    Bool(bool),
+}
+
+fn to_unique_key(v: &Value) -> Option<UniqueKey> {
+    match v {
+        Value::Number(n) => Some(UniqueKey::Number(n.to_bits())),
+        Value::Bool(b) => Some(UniqueKey::Bool(*b)),
+        Value::Text(s) if !s.is_empty() => Some(UniqueKey::Text(s.to_lowercase())),
+        Value::Text(_) | Value::Empty => None, // blank — ignore
+        Value::Error(_) | Value::Date(_) | Value::Array(_) => None,
+    }
+}
+
+/// `COUNTUNIQUE(value1, value2, ...)` — count unique distinct values across all
+/// arguments. Text comparison is case-insensitive. Empty / blank values are ignored.
+/// Numbers and text with the same display are treated as different types.
+pub fn countunique_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 255) {
+        return err;
+    }
+
+    let mut seen: HashSet<UniqueKey> = HashSet::new();
+
+    for arg in args {
+        match arg {
+            Value::Array(arr) => {
+                for v in arr {
+                    if let Some(key) = to_unique_key(v) {
+                        seen.insert(key);
+                    }
+                }
+            }
+            other => {
+                if let Some(key) = to_unique_key(other) {
+                    seen.insert(key);
+                }
+            }
+        }
+    }
+
+    Value::Number(seen.len() as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/countunique/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/countunique/tests/edge.rs
@@ -1,0 +1,45 @@
+use super::super::countunique_fn;
+use crate::types::Value;
+
+#[test]
+fn empty_strings_ignored() {
+    // COUNTUNIQUE("", "", "a") → 1 (empty strings are blank and ignored)
+    let result = countunique_fn(&[
+        Value::Text("".into()),
+        Value::Text("".into()),
+        Value::Text("a".into()),
+    ]);
+    assert_eq!(result, Value::Number(1.0));
+}
+
+#[test]
+fn empty_value_ignored() {
+    // Value::Empty is treated as blank and ignored
+    let result = countunique_fn(&[
+        Value::Empty,
+        Value::Number(1.0),
+        Value::Number(2.0),
+    ]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn all_empty_returns_zero() {
+    // COUNTUNIQUE("", "") → 0
+    let result = countunique_fn(&[Value::Text("".into()), Value::Text("".into())]);
+    assert_eq!(result, Value::Number(0.0));
+}
+
+#[test]
+fn mixed_scalar_and_array() {
+    // COUNTUNIQUE(1, {2,2,3}) → 3
+    let result = countunique_fn(&[
+        Value::Number(1.0),
+        Value::Array(vec![
+            Value::Number(2.0),
+            Value::Number(2.0),
+            Value::Number(3.0),
+        ]),
+    ]);
+    assert_eq!(result, Value::Number(3.0));
+}

--- a/crates/core/src/eval/functions/math/countunique/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/countunique/tests/failure.rs
@@ -1,0 +1,7 @@
+use super::super::countunique_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn zero_args_returns_na() {
+    assert_eq!(countunique_fn(&[]), Value::Error(ErrorKind::NA));
+}

--- a/crates/core/src/eval/functions/math/countunique/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/countunique/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/countunique/tests/success.rs
+++ b/crates/core/src/eval/functions/math/countunique/tests/success.rs
@@ -1,0 +1,93 @@
+use super::super::countunique_fn;
+use crate::types::Value;
+
+#[test]
+fn three_unique_from_six() {
+    // COUNTUNIQUE(1,2,2,3,3,3) → 3
+    let result = countunique_fn(&[
+        Value::Number(1.0),
+        Value::Number(2.0),
+        Value::Number(2.0),
+        Value::Number(3.0),
+        Value::Number(3.0),
+        Value::Number(3.0),
+    ]);
+    assert_eq!(result, Value::Number(3.0));
+}
+
+#[test]
+fn two_unique_text() {
+    // COUNTUNIQUE("a","b","a") → 2
+    let result = countunique_fn(&[
+        Value::Text("a".into()),
+        Value::Text("b".into()),
+        Value::Text("a".into()),
+    ]);
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn single_value() {
+    // COUNTUNIQUE(1) → 1
+    let result = countunique_fn(&[Value::Number(1.0)]);
+    assert_eq!(result, Value::Number(1.0));
+}
+
+#[test]
+fn array_with_duplicates() {
+    // COUNTUNIQUE({1,2,2,3}) → 3
+    let arr = Value::Array(vec![
+        Value::Number(1.0),
+        Value::Number(2.0),
+        Value::Number(2.0),
+        Value::Number(3.0),
+    ]);
+    let result = countunique_fn(&[arr]);
+    assert_eq!(result, Value::Number(3.0));
+}
+
+#[test]
+fn all_same_returns_one() {
+    // COUNTUNIQUE(5,5,5) → 1
+    let result = countunique_fn(&[
+        Value::Number(5.0),
+        Value::Number(5.0),
+        Value::Number(5.0),
+    ]);
+    assert_eq!(result, Value::Number(1.0));
+}
+
+#[test]
+fn five_unique_values() {
+    // COUNTUNIQUE(1,2,3,4,5) → 5
+    let result = countunique_fn(&[
+        Value::Number(1.0),
+        Value::Number(2.0),
+        Value::Number(3.0),
+        Value::Number(4.0),
+        Value::Number(5.0),
+    ]);
+    assert_eq!(result, Value::Number(5.0));
+}
+
+#[test]
+fn mixed_types_number_text_bool() {
+    // COUNTUNIQUE(1, "1", TRUE) → 3 (all different types)
+    let result = countunique_fn(&[
+        Value::Number(1.0),
+        Value::Text("1".into()),
+        Value::Bool(true),
+    ]);
+    assert_eq!(result, Value::Number(3.0));
+}
+
+#[test]
+fn text_case_insensitive() {
+    // COUNTUNIQUE("a","b","A") → 2 (case-insensitive)
+    let result = countunique_fn(&[
+        Value::Text("a".into()),
+        Value::Text("b".into()),
+        Value::Text("A".into()),
+    ]);
+    assert_eq!(result, Value::Number(2.0));
+}

--- a/crates/core/src/eval/functions/math/mod.rs
+++ b/crates/core/src/eval/functions/math/mod.rs
@@ -9,6 +9,8 @@ pub mod ceiling_floor_math;
 pub mod combin;
 pub mod combina;
 pub mod countif;
+pub mod countifs;
+pub mod countunique;
 pub mod criterion;
 pub mod decimal;
 pub mod exp;
@@ -31,6 +33,7 @@ pub mod sqrt;
 pub mod sqrtpi;
 pub mod sum;
 pub mod sumif;
+pub mod sumifs;
 pub mod sumsq;
 pub mod trig;
 
@@ -93,7 +96,10 @@ pub fn register_math(registry: &mut Registry) {
     registry.register_eager("MROUND",     round::mround_fn,             FunctionMeta { category: "math",        signature: "MROUND(number, multiple)",               description: "Round to nearest multiple" });
     registry.register_eager("TRUNC",      round::trunc_fn,              FunctionMeta { category: "math",        signature: "TRUNC(number, digits)",                 description: "Truncate to integer or decimal places" });
     registry.register_eager("COUNTIF",    countif::countif_fn,          FunctionMeta { category: "math",        signature: "COUNTIF(range, criterion)",              description: "Count cells matching criterion" });
+    registry.register_eager("COUNTIFS",   countifs::countifs_fn,        FunctionMeta { category: "math",        signature: "COUNTIFS(range1, criterion1, ...)",                     description: "Count rows where all criteria match" });
+    registry.register_eager("COUNTUNIQUE",countunique::countunique_fn,  FunctionMeta { category: "math",        signature: "COUNTUNIQUE(value1, ...)",                              description: "Count unique distinct values" });
     registry.register_eager("SUMIF",      sumif::sumif_fn,              FunctionMeta { category: "math",        signature: "SUMIF(range, criterion, [sum_range])",   description: "Sum cells where range matches criterion" });
+    registry.register_eager("SUMIFS",     sumifs::sumifs_fn,            FunctionMeta { category: "math",        signature: "SUMIFS(sum_range, range1, criterion1, ...)",            description: "Sum cells where all criteria match" });
     registry.register_eager("AVERAGEIF",  averageif::averageif_fn,      FunctionMeta { category: "statistical", signature: "AVERAGEIF(range, criterion, [avg_range])", description: "Average cells where range matches criterion" });
     registry.register_eager("SQRTPI",     sqrtpi::sqrtpi_fn,            FunctionMeta { category: "math",        signature: "SQRTPI(n)",                                 description: "Square root of n times pi" });
     registry.register_eager("SUMSQ",      sumsq::sumsq_fn,              FunctionMeta { category: "math",        signature: "SUMSQ(value1,...)",                          description: "Sum of squares of arguments" });

--- a/crates/core/src/eval/functions/math/sumifs/mod.rs
+++ b/crates/core/src/eval/functions/math/sumifs/mod.rs
@@ -1,0 +1,53 @@
+use crate::types::{ErrorKind, Value};
+use super::criterion::{flatten_to_vec, matches_criterion, parse_criterion};
+
+/// `SUMIFS(sum_range, range1, criterion1, [range2, criterion2, ...])` — sum
+/// values in `sum_range` where all (range, criterion) pairs match.
+///
+/// Requires at least 3 arguments: sum_range + one (range, criterion) pair.
+/// After sum_range, remaining args must come in (range, criterion) pairs (even count).
+pub fn sumifs_fn(args: &[Value]) -> Value {
+    // Need at least 3 args, and (args.len() - 1) must be even → args.len() odd and >= 3
+    if args.len() < 3 || args.len().is_multiple_of(2) {
+        return Value::Error(ErrorKind::NA);
+    }
+
+    let sum_range = flatten_to_vec(&args[0]);
+
+    // Build (range_vec, criterion) pairs from remaining args.
+    let pairs: Vec<(Vec<&Value>, _)> = args[1..]
+        .chunks(2)
+        .map(|chunk| {
+            let range = flatten_to_vec(&chunk[0]);
+            let crit = parse_criterion(&chunk[1]);
+            (range, crit)
+        })
+        .collect();
+
+    let mut total = 0.0_f64;
+
+    for (i, s_val) in sum_range.iter().enumerate() {
+        if pairs.iter().all(|(range, crit)| {
+            range.get(i).is_some_and(|v| matches_criterion(v, crit))
+        }) {
+            match s_val {
+                Value::Number(n) => total += n,
+                Value::Bool(b) => total += if *b { 1.0 } else { 0.0 },
+                Value::Text(s) => {
+                    if let Ok(n) = s.parse::<f64>() {
+                        total += n;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if !total.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(total)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/sumifs/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/sumifs/tests/edge.rs
@@ -1,0 +1,57 @@
+use super::super::sumifs_fn;
+use crate::types::Value;
+
+fn nums(ns: &[f64]) -> Value {
+    Value::Array(ns.iter().map(|&n| Value::Number(n)).collect())
+}
+
+#[test]
+fn no_matches_returns_zero() {
+    // SUMIFS({1,2,3}, {1,2,3}, ">10") → 0
+    let range = nums(&[1.0, 2.0, 3.0]);
+    let result = sumifs_fn(&[
+        range.clone(),
+        range.clone(),
+        Value::Text(">10".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(0.0));
+}
+
+#[test]
+fn ne_criterion() {
+    // SUMIFS({10,20,30}, {1,2,3}, "<>2") → 40 (10+30)
+    let result = sumifs_fn(&[
+        nums(&[10.0, 20.0, 30.0]),
+        nums(&[1.0, 2.0, 3.0]),
+        Value::Text("<>2".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(40.0));
+}
+
+#[test]
+fn empty_sum_range_returns_zero() {
+    let result = sumifs_fn(&[
+        Value::Array(vec![]),
+        Value::Array(vec![]),
+        Value::Number(1.0),
+    ]);
+    assert_eq!(result, Value::Number(0.0));
+}
+
+#[test]
+fn two_criteria_text_and_number() {
+    // SUMIFS({100,200,300,400}, {"a","b","a","b"}, "a", {1,2,1,2}, 1) → 400 (100+300)
+    let result = sumifs_fn(&[
+        nums(&[100.0, 200.0, 300.0, 400.0]),
+        Value::Array(vec![
+            Value::Text("a".into()),
+            Value::Text("b".into()),
+            Value::Text("a".into()),
+            Value::Text("b".into()),
+        ]),
+        Value::Text("a".to_string()),
+        nums(&[1.0, 2.0, 1.0, 2.0]),
+        Value::Number(1.0),
+    ]);
+    assert_eq!(result, Value::Number(400.0));
+}

--- a/crates/core/src/eval/functions/math/sumifs/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/sumifs/tests/failure.rs
@@ -1,0 +1,38 @@
+use super::super::sumifs_fn;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn zero_args_returns_na() {
+    assert_eq!(sumifs_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg_returns_na() {
+    assert_eq!(
+        sumifs_fn(&[Value::Number(1.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}
+
+#[test]
+fn two_args_returns_na() {
+    // Only sum_range + range, missing criterion
+    assert_eq!(
+        sumifs_fn(&[Value::Number(1.0), Value::Number(1.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}
+
+#[test]
+fn even_args_after_sum_range_returns_na() {
+    // sum_range + 3 more (odd number after sum_range, i.e. incomplete pair)
+    assert_eq!(
+        sumifs_fn(&[
+            Value::Number(1.0),
+            Value::Number(1.0),
+            Value::Number(1.0),
+            Value::Number(1.0),
+        ]),
+        Value::Error(ErrorKind::NA)
+    );
+}

--- a/crates/core/src/eval/functions/math/sumifs/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/sumifs/tests/mod.rs
@@ -1,0 +1,3 @@
+mod success;
+mod failure;
+mod edge;

--- a/crates/core/src/eval/functions/math/sumifs/tests/success.rs
+++ b/crates/core/src/eval/functions/math/sumifs/tests/success.rs
@@ -1,0 +1,82 @@
+use super::super::sumifs_fn;
+use crate::types::Value;
+
+fn nums(ns: &[f64]) -> Value {
+    Value::Array(ns.iter().map(|&n| Value::Number(n)).collect())
+}
+
+fn texts(ss: &[&str]) -> Value {
+    Value::Array(ss.iter().map(|s| Value::Text(s.to_string())).collect())
+}
+
+#[test]
+fn single_criterion_gt() {
+    // SUMIFS({1,2,3,4,5}, {1,2,3,4,5}, ">2") → 12 (3+4+5)
+    let range = nums(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+    let result = sumifs_fn(&[
+        range.clone(),
+        range.clone(),
+        Value::Text(">2".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(12.0));
+}
+
+#[test]
+fn two_criteria() {
+    // SUMIFS({1,2,3,4,5}, {1,2,3,4,5}, ">1", {1,2,3,4,5}, "<5") → 9 (2+3+4)
+    let range = nums(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+    let result = sumifs_fn(&[
+        range.clone(),
+        range.clone(),
+        Value::Text(">1".to_string()),
+        range.clone(),
+        Value::Text("<5".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(9.0));
+}
+
+#[test]
+fn text_criterion_on_sum_range() {
+    // SUMIFS({10,20,30}, {"a","b","a"}, "a") → 40 (10+30)
+    let result = sumifs_fn(&[
+        nums(&[10.0, 20.0, 30.0]),
+        texts(&["a", "b", "a"]),
+        Value::Text("a".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(40.0));
+}
+
+#[test]
+fn two_criteria_different_ranges() {
+    // SUMIFS({100,200,300,400}, {1,2,3,4}, ">1", {10,20,30,40}, ">20") → 700 (300+400)
+    let result = sumifs_fn(&[
+        nums(&[100.0, 200.0, 300.0, 400.0]),
+        nums(&[1.0, 2.0, 3.0, 4.0]),
+        Value::Text(">1".to_string()),
+        nums(&[10.0, 20.0, 30.0, 40.0]),
+        Value::Text(">20".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(700.0));
+}
+
+#[test]
+fn exact_match_criterion() {
+    // SUMIFS({10,20,30}, {1,2,3}, 2) → 20
+    let result = sumifs_fn(&[
+        nums(&[10.0, 20.0, 30.0]),
+        nums(&[1.0, 2.0, 3.0]),
+        Value::Number(2.0),
+    ]);
+    assert_eq!(result, Value::Number(20.0));
+}
+
+#[test]
+fn wildcard_criterion() {
+    // SUMIFS({10,20,30}, {"apple","apricot","banana"}, "a*") → 30 (10+20)
+    let result = sumifs_fn(&[
+        nums(&[10.0, 20.0, 30.0]),
+        texts(&["apple", "apricot", "banana"]),
+        Value::Text("a*".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(30.0));
+}


### PR DESCRIPTION
## Summary

- Add `COUNTIFS(range1, criterion1, ...)` — counts rows where all criteria pairs match simultaneously
- Add `COUNTUNIQUE(value1, ...)` — counts unique distinct values (case-insensitive text, ignores blanks)
- Add `SUMIFS(sum_range, range1, criterion1, ...)` — sums values where all criteria pairs match
- Note: COUNTBLANK (#143) was already implemented in the statistical module; this PR adds the three remaining functions

## Implementation details

Each function follows the established pattern from COUNTIF/SUMIF:
- Uses `criterion.rs` helpers (`flatten_to_vec`, `parse_criterion`, `matches_criterion`)
- COUNTUNIQUE uses a `HashSet` with a typed key (Number/Text/Bool) for O(n) deduplication; text is lowercased for case-insensitive comparison; blanks (`Value::Empty` and `Value::Text("")`) are ignored
- COUNTIFS and SUMIFS validate even/odd arg parity and return `Error(NA)` on invalid arity

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p ganit-core` — 1699 tests pass
- [x] COUNTIFS: 14 tests (success, failure, edge)
- [x] COUNTUNIQUE: 13 tests (success, failure, edge)
- [x] SUMIFS: 14 tests (success, failure, edge)

closes #143
closes #148
closes #150
closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)