### PR TITLE
feat: implement BITAND, BITOR, BITXOR, BITLSHIFT, BITRSHIFT, DELTA, GESTEP

### DIFF
--- a/crates/core/src/eval/functions/engineering/bitand/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitand/mod.rs
@@ -1,0 +1,27 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+const MAX_BIT: u64 = 281_474_976_710_655; // 2^48 - 1
+
+pub fn bitand_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let a = match to_number(args[0].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let b = match to_number(args[1].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    if a < 0.0 || b < 0.0 || a > MAX_BIT as f64 || b > MAX_BIT as f64 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let result = (a as u64) & (b as u64);
+    Value::Number(result as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/bitand/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/bitand/tests/failure.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(bitand_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg_returns_na() {
+    assert_eq!(bitand_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn negative_first_arg_returns_num() {
+    assert_eq!(bitand_fn(&[Value::Number(-1.0), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn negative_second_arg_returns_num() {
+    assert_eq!(bitand_fn(&[Value::Number(1.0), Value::Number(-1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn exceeds_max_returns_num() {
+    let too_big = 281_474_976_710_656.0_f64;
+    assert_eq!(bitand_fn(&[Value::Number(too_big), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_numeric_returns_value() {
+    assert_eq!(bitand_fn(&[Value::Text("abc".to_string()), Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/engineering/bitand/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitand/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/bitand/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/bitand/tests/success.rs
@@ -1,0 +1,28 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn both_zero() {
+    assert_eq!(bitand_fn(&[Value::Number(0.0), Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn basic_and() {
+    assert_eq!(bitand_fn(&[Value::Number(12.0), Value::Number(10.0)]), Value::Number(8.0));
+}
+
+#[test]
+fn all_ones() {
+    assert_eq!(bitand_fn(&[Value::Number(255.0), Value::Number(255.0)]), Value::Number(255.0));
+}
+
+#[test]
+fn no_overlap() {
+    assert_eq!(bitand_fn(&[Value::Number(5.0), Value::Number(2.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn max_value() {
+    let max = 281_474_976_710_655.0_f64;
+    assert_eq!(bitand_fn(&[Value::Number(max), Value::Number(max)]), Value::Number(max));
+}

--- a/crates/core/src/eval/functions/engineering/bitlshift/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitlshift/mod.rs
@@ -1,0 +1,45 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+const MAX_BIT: u64 = 281_474_976_710_655; // 2^48 - 1
+
+pub fn bitlshift_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let number = match to_number(args[0].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let shift = match to_number(args[1].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    if number < 0.0 || number > MAX_BIT as f64 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let num = number as u64;
+    let shift_amount = shift as i64;
+    let result = if shift_amount >= 0 {
+        let s = shift_amount as u32;
+        if s >= 48 {
+            return Value::Error(ErrorKind::Num);
+        }
+        num.checked_shl(s).unwrap_or(u64::MAX)
+    } else {
+        let s = (-shift_amount) as u32;
+        if s >= 64 {
+            0
+        } else {
+            num >> s
+        }
+    };
+    if result > MAX_BIT {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/bitlshift/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/bitlshift/tests/failure.rs
@@ -1,0 +1,34 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(bitlshift_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg_returns_na() {
+    assert_eq!(bitlshift_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn negative_number_returns_num() {
+    assert_eq!(bitlshift_fn(&[Value::Number(-1.0), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn exceeds_max_input_returns_num() {
+    let too_big = 281_474_976_710_656.0_f64;
+    assert_eq!(bitlshift_fn(&[Value::Number(too_big), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn result_exceeds_max_returns_num() {
+    let max = 281_474_976_710_655.0_f64;
+    assert_eq!(bitlshift_fn(&[Value::Number(max), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_numeric_returns_value() {
+    assert_eq!(bitlshift_fn(&[Value::Text("abc".to_string()), Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/engineering/bitlshift/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitlshift/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/bitlshift/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/bitlshift/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn shift_by_zero() {
+    assert_eq!(bitlshift_fn(&[Value::Number(4.0), Value::Number(0.0)]), Value::Number(4.0));
+}
+
+#[test]
+fn shift_left_by_one() {
+    assert_eq!(bitlshift_fn(&[Value::Number(4.0), Value::Number(1.0)]), Value::Number(8.0));
+}
+
+#[test]
+fn shift_left_by_two() {
+    assert_eq!(bitlshift_fn(&[Value::Number(1.0), Value::Number(2.0)]), Value::Number(4.0));
+}
+
+#[test]
+fn negative_shift_acts_as_right_shift() {
+    assert_eq!(bitlshift_fn(&[Value::Number(8.0), Value::Number(-1.0)]), Value::Number(4.0));
+}
+
+#[test]
+fn zero_number() {
+    assert_eq!(bitlshift_fn(&[Value::Number(0.0), Value::Number(4.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/engineering/bitor/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitor/mod.rs
@@ -1,0 +1,27 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+const MAX_BIT: u64 = 281_474_976_710_655; // 2^48 - 1
+
+pub fn bitor_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let a = match to_number(args[0].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let b = match to_number(args[1].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    if a < 0.0 || b < 0.0 || a > MAX_BIT as f64 || b > MAX_BIT as f64 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let result = (a as u64) | (b as u64);
+    Value::Number(result as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/bitor/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/bitor/tests/failure.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(bitor_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg_returns_na() {
+    assert_eq!(bitor_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn negative_first_arg_returns_num() {
+    assert_eq!(bitor_fn(&[Value::Number(-1.0), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn negative_second_arg_returns_num() {
+    assert_eq!(bitor_fn(&[Value::Number(1.0), Value::Number(-1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn exceeds_max_returns_num() {
+    let too_big = 281_474_976_710_656.0_f64;
+    assert_eq!(bitor_fn(&[Value::Number(too_big), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_numeric_returns_value() {
+    assert_eq!(bitor_fn(&[Value::Text("abc".to_string()), Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/engineering/bitor/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitor/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/bitor/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/bitor/tests/success.rs
@@ -1,0 +1,28 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn both_zero() {
+    assert_eq!(bitor_fn(&[Value::Number(0.0), Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn basic_or() {
+    assert_eq!(bitor_fn(&[Value::Number(12.0), Value::Number(10.0)]), Value::Number(14.0));
+}
+
+#[test]
+fn no_overlap() {
+    assert_eq!(bitor_fn(&[Value::Number(5.0), Value::Number(2.0)]), Value::Number(7.0));
+}
+
+#[test]
+fn same_value() {
+    assert_eq!(bitor_fn(&[Value::Number(255.0), Value::Number(255.0)]), Value::Number(255.0));
+}
+
+#[test]
+fn max_value() {
+    let max = 281_474_976_710_655.0_f64;
+    assert_eq!(bitor_fn(&[Value::Number(max), Value::Number(0.0)]), Value::Number(max));
+}

--- a/crates/core/src/eval/functions/engineering/bitrshift/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitrshift/mod.rs
@@ -1,0 +1,45 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+const MAX_BIT: u64 = 281_474_976_710_655; // 2^48 - 1
+
+pub fn bitrshift_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let number = match to_number(args[0].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let shift = match to_number(args[1].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    if number < 0.0 || number > MAX_BIT as f64 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let num = number as u64;
+    let shift_amount = shift as i64;
+    let result = if shift_amount >= 0 {
+        let s = shift_amount as u32;
+        if s >= 64 {
+            0
+        } else {
+            num >> s
+        }
+    } else {
+        let s = (-shift_amount) as u32;
+        if s >= 48 {
+            return Value::Error(ErrorKind::Num);
+        }
+        num.checked_shl(s).unwrap_or(u64::MAX)
+    };
+    if result > MAX_BIT {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/bitrshift/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/bitrshift/tests/failure.rs
@@ -1,0 +1,34 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(bitrshift_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg_returns_na() {
+    assert_eq!(bitrshift_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn negative_number_returns_num() {
+    assert_eq!(bitrshift_fn(&[Value::Number(-1.0), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn exceeds_max_input_returns_num() {
+    let too_big = 281_474_976_710_656.0_f64;
+    assert_eq!(bitrshift_fn(&[Value::Number(too_big), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn result_exceeds_max_returns_num() {
+    let max = 281_474_976_710_655.0_f64;
+    assert_eq!(bitrshift_fn(&[Value::Number(max), Value::Number(-1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_numeric_returns_value() {
+    assert_eq!(bitrshift_fn(&[Value::Text("abc".to_string()), Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/engineering/bitrshift/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitrshift/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/bitrshift/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/bitrshift/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn shift_by_zero() {
+    assert_eq!(bitrshift_fn(&[Value::Number(4.0), Value::Number(0.0)]), Value::Number(4.0));
+}
+
+#[test]
+fn shift_right_by_one() {
+    assert_eq!(bitrshift_fn(&[Value::Number(8.0), Value::Number(1.0)]), Value::Number(4.0));
+}
+
+#[test]
+fn shift_right_by_two() {
+    assert_eq!(bitrshift_fn(&[Value::Number(4.0), Value::Number(2.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn negative_shift_acts_as_left_shift() {
+    assert_eq!(bitrshift_fn(&[Value::Number(4.0), Value::Number(-1.0)]), Value::Number(8.0));
+}
+
+#[test]
+fn zero_number() {
+    assert_eq!(bitrshift_fn(&[Value::Number(0.0), Value::Number(4.0)]), Value::Number(0.0));
+}

--- a/crates/core/src/eval/functions/engineering/bitxor/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitxor/mod.rs
@@ -1,0 +1,27 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+const MAX_BIT: u64 = 281_474_976_710_655; // 2^48 - 1
+
+pub fn bitxor_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let a = match to_number(args[0].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let b = match to_number(args[1].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    if a < 0.0 || b < 0.0 || a > MAX_BIT as f64 || b > MAX_BIT as f64 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let result = (a as u64) ^ (b as u64);
+    Value::Number(result as f64)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/bitxor/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/bitxor/tests/failure.rs
@@ -1,0 +1,33 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(bitxor_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn one_arg_returns_na() {
+    assert_eq!(bitxor_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn negative_first_arg_returns_num() {
+    assert_eq!(bitxor_fn(&[Value::Number(-1.0), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn negative_second_arg_returns_num() {
+    assert_eq!(bitxor_fn(&[Value::Number(1.0), Value::Number(-1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn exceeds_max_returns_num() {
+    let too_big = 281_474_976_710_656.0_f64;
+    assert_eq!(bitxor_fn(&[Value::Number(too_big), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_numeric_returns_value() {
+    assert_eq!(bitxor_fn(&[Value::Text("abc".to_string()), Value::Number(1.0)]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/engineering/bitxor/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitxor/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/bitxor/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/bitxor/tests/success.rs
@@ -1,0 +1,28 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn both_zero() {
+    assert_eq!(bitxor_fn(&[Value::Number(0.0), Value::Number(0.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn basic_xor() {
+    assert_eq!(bitxor_fn(&[Value::Number(12.0), Value::Number(10.0)]), Value::Number(6.0));
+}
+
+#[test]
+fn same_value_is_zero() {
+    assert_eq!(bitxor_fn(&[Value::Number(255.0), Value::Number(255.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn no_overlap() {
+    assert_eq!(bitxor_fn(&[Value::Number(5.0), Value::Number(2.0)]), Value::Number(7.0));
+}
+
+#[test]
+fn max_value() {
+    let max = 281_474_976_710_655.0_f64;
+    assert_eq!(bitxor_fn(&[Value::Number(max), Value::Number(0.0)]), Value::Number(max));
+}

--- a/crates/core/src/eval/functions/engineering/delta/mod.rs
+++ b/crates/core/src/eval/functions/engineering/delta/mod.rs
@@ -1,0 +1,29 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+pub fn delta_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let a = match to_number(args[0].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let b = if args.len() == 2 {
+        match to_number(args[1].clone()) {
+            Ok(n) => n,
+            Err(e) => return e,
+        }
+    } else {
+        0.0
+    };
+    if a == b {
+        Value::Number(1.0)
+    } else {
+        Value::Number(0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/delta/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/delta/tests/failure.rs
@@ -1,0 +1,31 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(delta_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn three_args_returns_na() {
+    assert_eq!(
+        delta_fn(&[Value::Number(1.0), Value::Number(1.0), Value::Number(1.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}
+
+#[test]
+fn non_numeric_first_arg_returns_value() {
+    assert_eq!(
+        delta_fn(&[Value::Text("abc".to_string()), Value::Number(1.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn non_numeric_second_arg_returns_value() {
+    assert_eq!(
+        delta_fn(&[Value::Number(1.0), Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/engineering/delta/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/delta/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/delta/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/delta/tests/success.rs
@@ -1,0 +1,32 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn equal_values_returns_one() {
+    assert_eq!(delta_fn(&[Value::Number(5.0), Value::Number(5.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn unequal_values_returns_zero() {
+    assert_eq!(delta_fn(&[Value::Number(5.0), Value::Number(4.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn default_second_arg_zero_equal() {
+    assert_eq!(delta_fn(&[Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn default_second_arg_zero_unequal() {
+    assert_eq!(delta_fn(&[Value::Number(1.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn both_zero_returns_one() {
+    assert_eq!(delta_fn(&[Value::Number(0.0), Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn negative_equal_returns_one() {
+    assert_eq!(delta_fn(&[Value::Number(-3.0), Value::Number(-3.0)]), Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/engineering/gestep/mod.rs
+++ b/crates/core/src/eval/functions/engineering/gestep/mod.rs
@@ -1,0 +1,29 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::Value;
+
+pub fn gestep_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let number = match to_number(args[0].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let step = if args.len() == 2 {
+        match to_number(args[1].clone()) {
+            Ok(n) => n,
+            Err(e) => return e,
+        }
+    } else {
+        0.0
+    };
+    if number >= step {
+        Value::Number(1.0)
+    } else {
+        Value::Number(0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/gestep/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/gestep/tests/failure.rs
@@ -1,0 +1,31 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(gestep_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn three_args_returns_na() {
+    assert_eq!(
+        gestep_fn(&[Value::Number(1.0), Value::Number(1.0), Value::Number(1.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}
+
+#[test]
+fn non_numeric_first_arg_returns_value() {
+    assert_eq!(
+        gestep_fn(&[Value::Text("abc".to_string()), Value::Number(1.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn non_numeric_second_arg_returns_value() {
+    assert_eq!(
+        gestep_fn(&[Value::Number(1.0), Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/engineering/gestep/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/gestep/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/gestep/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/gestep/tests/success.rs
@@ -1,0 +1,37 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn greater_than_step_returns_one() {
+    assert_eq!(gestep_fn(&[Value::Number(5.0), Value::Number(4.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn equal_to_step_returns_one() {
+    assert_eq!(gestep_fn(&[Value::Number(5.0), Value::Number(5.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn less_than_step_returns_zero() {
+    assert_eq!(gestep_fn(&[Value::Number(3.0), Value::Number(5.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn default_step_zero_positive_returns_one() {
+    assert_eq!(gestep_fn(&[Value::Number(1.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn default_step_zero_equal_returns_one() {
+    assert_eq!(gestep_fn(&[Value::Number(0.0)]), Value::Number(1.0));
+}
+
+#[test]
+fn default_step_zero_negative_returns_zero() {
+    assert_eq!(gestep_fn(&[Value::Number(-1.0)]), Value::Number(0.0));
+}
+
+#[test]
+fn negative_numbers() {
+    assert_eq!(gestep_fn(&[Value::Number(-2.0), Value::Number(-3.0)]), Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/engineering/mod.rs
+++ b/crates/core/src/eval/functions/engineering/mod.rs
@@ -1,0 +1,20 @@
+use super::Registry;
+use super::FunctionMeta;
+
+pub mod bitand;
+pub mod bitor;
+pub mod bitxor;
+pub mod bitlshift;
+pub mod bitrshift;
+pub mod delta;
+pub mod gestep;
+
+pub fn register_engineering(registry: &mut Registry) {
+    registry.register_eager("BITAND",    bitand::bitand_fn,       FunctionMeta { category: "engineering", signature: "BITAND(number1, number2)",          description: "Bitwise AND of two integers" });
+    registry.register_eager("BITOR",     bitor::bitor_fn,         FunctionMeta { category: "engineering", signature: "BITOR(number1, number2)",           description: "Bitwise OR of two integers" });
+    registry.register_eager("BITXOR",    bitxor::bitxor_fn,       FunctionMeta { category: "engineering", signature: "BITXOR(number1, number2)",          description: "Bitwise XOR of two integers" });
+    registry.register_eager("BITLSHIFT", bitlshift::bitlshift_fn, FunctionMeta { category: "engineering", signature: "BITLSHIFT(number, shift_amount)",   description: "Left-shift an integer by a number of bits" });
+    registry.register_eager("BITRSHIFT", bitrshift::bitrshift_fn, FunctionMeta { category: "engineering", signature: "BITRSHIFT(number, shift_amount)",   description: "Right-shift an integer by a number of bits" });
+    registry.register_eager("DELTA",     delta::delta_fn,         FunctionMeta { category: "engineering", signature: "DELTA(number1, [number2])",         description: "Test whether two values are equal" });
+    registry.register_eager("GESTEP",    gestep::gestep_fn,       FunctionMeta { category: "engineering", signature: "GESTEP(number, [step])",            description: "Test whether a number is greater than or equal to a step value" });
+}

--- a/crates/core/src/eval/functions/mod.rs
+++ b/crates/core/src/eval/functions/mod.rs
@@ -1,4 +1,5 @@
 pub mod date;
+pub mod engineering;
 pub mod financial;
 pub mod logical;
 pub mod math;
@@ -72,6 +73,7 @@ impl Registry {
         operator::register_operator(&mut r);
         date::register_date(&mut r);
         parser::register_parser(&mut r);
+        engineering::register_engineering(&mut r);
         r
     }
 


### PR DESCRIPTION
## Summary

- Add `engineering` module under `crates/core/src/eval/functions/engineering/` with 7 functions
- Each function follows the established subdirectory pattern with `mod.rs`, `tests/mod.rs`, `tests/success.rs`, and `tests/failure.rs`
- Wire `register_engineering` into `Registry::new()` in `functions/mod.rs`

closes #225
closes #227
closes #229
closes #231
closes #233
closes #239
closes #240

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes with no issues
- [x] `cargo test -p ganit-core` passes (1963 tests, 21 ignored)
- [x] BITAND: bitwise AND, validates range [0, 2^48-1], returns #NUM! for out-of-range, #VALUE! for non-numeric
- [x] BITOR: bitwise OR, same range validation
- [x] BITXOR: bitwise XOR, same range validation
- [x] BITLSHIFT: left-shift with negative-shift-means-right-shift, result range validated
- [x] BITRSHIFT: right-shift with negative-shift-means-left-shift, result range validated
- [x] DELTA: returns 1 if equal, 0 otherwise; optional second arg defaults to 0
- [x] GESTEP: returns 1 if number >= step, 0 otherwise; optional step defaults to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)