### PR TITLE
chore: release v0.3.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "ganit-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "calamine",
  "chrono",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "ganit-mcp"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ganit-core",
  "serde",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "ganit-wasm"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ganit-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 license = "MIT"
 authors = ["tryganit"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.8...ganit-core-v0.3.9) - 2026-04-16
+
+### Added
+
+- implement BITAND, BITOR, BITXOR, BITLSHIFT, BITRSHIFT, DELTA, GESTEP
+
 ## [0.3.8](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.6...ganit-core-v0.3.8) - 2026-04-16
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `ganit-core`: 0.3.8 -> 0.3.9 (✓ API compatible changes)
* `ganit-mcp`: 0.3.8 -> 0.3.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `ganit-core`

<blockquote>

## [0.3.9](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.8...ganit-core-v0.3.9) - 2026-04-16

### Added

- implement BITAND, BITOR, BITXOR, BITLSHIFT, BITRSHIFT, DELTA, GESTEP
</blockquote>

## `ganit-mcp`

<blockquote>

## [0.3.8](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.3.7...ganit-mcp-v0.3.8) - 2026-04-16

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).