### PR TITLE
feat: implement BIN2DEC/HEX/OCT, DEC2BIN/HEX/OCT, HEX2BIN/DEC/OCT, OCT2BIN/DEC/HEX

### DIFF
--- a/crates/core/src/eval/functions/engineering/bin2dec/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bin2dec/mod.rs
@@ -1,0 +1,21 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::parse_bin;
+use crate::types::{ErrorKind, Value};
+
+pub fn bin2dec_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let s = match to_string_val(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    match parse_bin(&s) {
+        Some(n) => Value::Number(n as f64),
+        None => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/bin2dec/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/bin2dec/tests/failure.rs
@@ -1,0 +1,22 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(bin2dec_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_char_returns_num() {
+    assert_eq!(bin2dec_fn(&[Value::Text("2".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn too_long_returns_num() {
+    assert_eq!(bin2dec_fn(&[Value::Text("11111111111".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn non_binary_string_returns_num() {
+    assert_eq!(bin2dec_fn(&[Value::Text("ABC".to_string())]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/bin2dec/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bin2dec/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/bin2dec/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/bin2dec/tests/success.rs
@@ -1,0 +1,37 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn all_ones_is_minus_one() {
+    assert_eq!(bin2dec_fn(&[Value::Text("1111111111".to_string())]), Value::Number(-1.0));
+}
+
+#[test]
+fn sign_bit_only_is_minus_512() {
+    assert_eq!(bin2dec_fn(&[Value::Text("1000000000".to_string())]), Value::Number(-512.0));
+}
+
+#[test]
+fn one_is_one() {
+    assert_eq!(bin2dec_fn(&[Value::Text("1".to_string())]), Value::Number(1.0));
+}
+
+#[test]
+fn zero_padded_one() {
+    assert_eq!(bin2dec_fn(&[Value::Text("0000000001".to_string())]), Value::Number(1.0));
+}
+
+#[test]
+fn max_positive() {
+    assert_eq!(bin2dec_fn(&[Value::Text("111111111".to_string())]), Value::Number(511.0));
+}
+
+#[test]
+fn zero() {
+    assert_eq!(bin2dec_fn(&[Value::Text("0".to_string())]), Value::Number(0.0));
+}
+
+#[test]
+fn numeric_input_coerced() {
+    assert_eq!(bin2dec_fn(&[Value::Number(1.0)]), Value::Number(1.0));
+}

--- a/crates/core/src/eval/functions/engineering/bin2hex/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bin2hex/mod.rs
@@ -1,0 +1,29 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::{format_hex, get_places, parse_bin};
+use crate::types::{ErrorKind, Value};
+
+pub fn bin2hex_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let places = match get_places(args) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let s = match to_string_val(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let n = match parse_bin(&s) {
+        Some(v) => v,
+        None => return Value::Error(ErrorKind::Num),
+    };
+    match format_hex(n, places) {
+        Ok(result) => Value::Text(result),
+        Err(()) => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/bin2hex/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/bin2hex/tests/failure.rs
@@ -1,0 +1,22 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(bin2hex_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_char_returns_num() {
+    assert_eq!(bin2hex_fn(&[Value::Text("2".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_too_small_returns_num() {
+    assert_eq!(bin2hex_fn(&[Value::Text("11111011".to_string()), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_zero_returns_num() {
+    assert_eq!(bin2hex_fn(&[Value::Text("1".to_string()), Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/bin2hex/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bin2hex/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/bin2hex/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/bin2hex/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn all_ones_to_hex() {
+    assert_eq!(bin2hex_fn(&[Value::Text("1111111111".to_string())]), Value::Text("FFFFFFFFFF".to_string()));
+}
+
+#[test]
+fn fb() {
+    assert_eq!(bin2hex_fn(&[Value::Text("11111011".to_string())]), Value::Text("FB".to_string()));
+}
+
+#[test]
+fn one_to_hex() {
+    assert_eq!(bin2hex_fn(&[Value::Text("1".to_string())]), Value::Text("1".to_string()));
+}
+
+#[test]
+fn with_places() {
+    assert_eq!(bin2hex_fn(&[Value::Text("1111011".to_string()), Value::Number(4.0)]), Value::Text("007B".to_string()));
+}
+
+#[test]
+fn zero_to_hex() {
+    assert_eq!(bin2hex_fn(&[Value::Text("0".to_string())]), Value::Text("0".to_string()));
+}

--- a/crates/core/src/eval/functions/engineering/bin2oct/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bin2oct/mod.rs
@@ -1,0 +1,29 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::{format_oct, get_places, parse_bin};
+use crate::types::{ErrorKind, Value};
+
+pub fn bin2oct_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let places = match get_places(args) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let s = match to_string_val(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let n = match parse_bin(&s) {
+        Some(v) => v,
+        None => return Value::Error(ErrorKind::Num),
+    };
+    match format_oct(n, places) {
+        Ok(result) => Value::Text(result),
+        Err(()) => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/bin2oct/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/bin2oct/tests/failure.rs
@@ -1,0 +1,22 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(bin2oct_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_char_returns_num() {
+    assert_eq!(bin2oct_fn(&[Value::Text("2".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_too_small_returns_num() {
+    assert_eq!(bin2oct_fn(&[Value::Text("1111111111".to_string()), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_zero_returns_num() {
+    assert_eq!(bin2oct_fn(&[Value::Text("1".to_string()), Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/bin2oct/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bin2oct/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/bin2oct/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/bin2oct/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn all_ones_to_oct() {
+    assert_eq!(bin2oct_fn(&[Value::Text("1111111111".to_string())]), Value::Text("7777777777".to_string()));
+}
+
+#[test]
+fn one_to_oct() {
+    assert_eq!(bin2oct_fn(&[Value::Text("1".to_string())]), Value::Text("1".to_string()));
+}
+
+#[test]
+fn zero_to_oct() {
+    assert_eq!(bin2oct_fn(&[Value::Text("0".to_string())]), Value::Text("0".to_string()));
+}
+
+#[test]
+fn with_places() {
+    assert_eq!(bin2oct_fn(&[Value::Text("1000".to_string()), Value::Number(4.0)]), Value::Text("0010".to_string()));
+}
+
+#[test]
+fn eight_to_oct() {
+    assert_eq!(bin2oct_fn(&[Value::Text("1000".to_string())]), Value::Text("10".to_string()));
+}

--- a/crates/core/src/eval/functions/engineering/dec2bin/mod.rs
+++ b/crates/core/src/eval/functions/engineering/dec2bin/mod.rs
@@ -1,0 +1,29 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::{format_bin, get_places};
+use crate::types::{ErrorKind, Value};
+
+pub fn dec2bin_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let places = match get_places(args) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let n = match to_number(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let n = n.trunc() as i64;
+    if !(-512..=511).contains(&n) {
+        return Value::Error(ErrorKind::Num);
+    }
+    match format_bin(n, places) {
+        Ok(result) => Value::Text(result),
+        Err(()) => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/dec2bin/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/dec2bin/tests/failure.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(dec2bin_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn out_of_range_high_returns_num() {
+    assert_eq!(dec2bin_fn(&[Value::Number(512.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn out_of_range_low_returns_num() {
+    assert_eq!(dec2bin_fn(&[Value::Number(-513.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_too_small_returns_num() {
+    assert_eq!(dec2bin_fn(&[Value::Number(511.0), Value::Number(2.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_zero_returns_num() {
+    assert_eq!(dec2bin_fn(&[Value::Number(1.0), Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/dec2bin/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/dec2bin/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/dec2bin/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/dec2bin/tests/success.rs
@@ -1,0 +1,37 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn minus_one_to_bin() {
+    assert_eq!(dec2bin_fn(&[Value::Number(-1.0)]), Value::Text("1111111111".to_string()));
+}
+
+#[test]
+fn max_positive() {
+    assert_eq!(dec2bin_fn(&[Value::Number(511.0)]), Value::Text("111111111".to_string()));
+}
+
+#[test]
+fn min_negative() {
+    assert_eq!(dec2bin_fn(&[Value::Number(-512.0)]), Value::Text("1000000000".to_string()));
+}
+
+#[test]
+fn one_to_bin() {
+    assert_eq!(dec2bin_fn(&[Value::Number(1.0)]), Value::Text("1".to_string()));
+}
+
+#[test]
+fn zero_to_bin() {
+    assert_eq!(dec2bin_fn(&[Value::Number(0.0)]), Value::Text("0".to_string()));
+}
+
+#[test]
+fn with_places() {
+    assert_eq!(dec2bin_fn(&[Value::Number(9.0), Value::Number(4.0)]), Value::Text("1001".to_string()));
+}
+
+#[test]
+fn truncates_decimal() {
+    assert_eq!(dec2bin_fn(&[Value::Number(9.9)]), Value::Text("1001".to_string()));
+}

--- a/crates/core/src/eval/functions/engineering/dec2hex/mod.rs
+++ b/crates/core/src/eval/functions/engineering/dec2hex/mod.rs
@@ -1,0 +1,32 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::{format_hex, get_places};
+use crate::types::{ErrorKind, Value};
+
+const MIN_DEC: i64 = -549_755_813_888; // -2^39
+const MAX_DEC: i64 =  549_755_813_887; //  2^39 - 1
+
+pub fn dec2hex_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let places = match get_places(args) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let n = match to_number(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let n = n.trunc() as i64;
+    if !(MIN_DEC..=MAX_DEC).contains(&n) {
+        return Value::Error(ErrorKind::Num);
+    }
+    match format_hex(n, places) {
+        Ok(result) => Value::Text(result),
+        Err(()) => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/dec2hex/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/dec2hex/tests/failure.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(dec2hex_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn out_of_range_high_returns_num() {
+    assert_eq!(dec2hex_fn(&[Value::Number(549_755_813_888.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn out_of_range_low_returns_num() {
+    assert_eq!(dec2hex_fn(&[Value::Number(-549_755_813_889.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_too_small_returns_num() {
+    assert_eq!(dec2hex_fn(&[Value::Number(255.0), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_zero_returns_num() {
+    assert_eq!(dec2hex_fn(&[Value::Number(1.0), Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/dec2hex/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/dec2hex/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/dec2hex/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/dec2hex/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn minus_one_to_hex() {
+    assert_eq!(dec2hex_fn(&[Value::Number(-1.0)]), Value::Text("FFFFFFFFFF".to_string()));
+}
+
+#[test]
+fn two_fifty_five() {
+    assert_eq!(dec2hex_fn(&[Value::Number(255.0)]), Value::Text("FF".to_string()));
+}
+
+#[test]
+fn zero_to_hex() {
+    assert_eq!(dec2hex_fn(&[Value::Number(0.0)]), Value::Text("0".to_string()));
+}
+
+#[test]
+fn with_places() {
+    assert_eq!(dec2hex_fn(&[Value::Number(255.0), Value::Number(4.0)]), Value::Text("00FF".to_string()));
+}
+
+#[test]
+fn max_positive() {
+    assert_eq!(dec2hex_fn(&[Value::Number(549_755_813_887.0)]), Value::Text("7FFFFFFFFF".to_string()));
+}

--- a/crates/core/src/eval/functions/engineering/dec2oct/mod.rs
+++ b/crates/core/src/eval/functions/engineering/dec2oct/mod.rs
@@ -1,0 +1,32 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::{format_oct, get_places};
+use crate::types::{ErrorKind, Value};
+
+const MIN_DEC: i64 = -536_870_912; // -2^29
+const MAX_DEC: i64 =  536_870_911; //  2^29 - 1
+
+pub fn dec2oct_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let places = match get_places(args) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let n = match to_number(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let n = n.trunc() as i64;
+    if !(MIN_DEC..=MAX_DEC).contains(&n) {
+        return Value::Error(ErrorKind::Num);
+    }
+    match format_oct(n, places) {
+        Ok(result) => Value::Text(result),
+        Err(()) => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/dec2oct/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/dec2oct/tests/failure.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(dec2oct_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn out_of_range_high_returns_num() {
+    assert_eq!(dec2oct_fn(&[Value::Number(536_870_912.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn out_of_range_low_returns_num() {
+    assert_eq!(dec2oct_fn(&[Value::Number(-536_870_913.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_too_small_returns_num() {
+    assert_eq!(dec2oct_fn(&[Value::Number(536_870_911.0), Value::Number(2.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_zero_returns_num() {
+    assert_eq!(dec2oct_fn(&[Value::Number(1.0), Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/dec2oct/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/dec2oct/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/dec2oct/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/dec2oct/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn minus_one_to_oct() {
+    assert_eq!(dec2oct_fn(&[Value::Number(-1.0)]), Value::Text("7777777777".to_string()));
+}
+
+#[test]
+fn eight_to_oct() {
+    assert_eq!(dec2oct_fn(&[Value::Number(8.0)]), Value::Text("10".to_string()));
+}
+
+#[test]
+fn zero_to_oct() {
+    assert_eq!(dec2oct_fn(&[Value::Number(0.0)]), Value::Text("0".to_string()));
+}
+
+#[test]
+fn with_places() {
+    assert_eq!(dec2oct_fn(&[Value::Number(8.0), Value::Number(4.0)]), Value::Text("0010".to_string()));
+}
+
+#[test]
+fn max_positive() {
+    assert_eq!(dec2oct_fn(&[Value::Number(536_870_911.0)]), Value::Text("3777777777".to_string()));
+}

--- a/crates/core/src/eval/functions/engineering/hex2bin/mod.rs
+++ b/crates/core/src/eval/functions/engineering/hex2bin/mod.rs
@@ -1,0 +1,33 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::{format_bin, get_places, parse_hex};
+use crate::types::{ErrorKind, Value};
+
+pub fn hex2bin_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let places = match get_places(args) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let s = match to_string_val(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let n = match parse_hex(&s) {
+        Some(v) => v,
+        None => return Value::Error(ErrorKind::Num),
+    };
+    // Result must fit in 10-bit signed range (-512 to 511)
+    if !(-512..=511).contains(&n) {
+        return Value::Error(ErrorKind::Num);
+    }
+    match format_bin(n, places) {
+        Ok(result) => Value::Text(result),
+        Err(()) => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/hex2bin/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/hex2bin/tests/failure.rs
@@ -1,0 +1,28 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(hex2bin_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_char_returns_num() {
+    assert_eq!(hex2bin_fn(&[Value::Text("G".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn out_of_bin_range_returns_num() {
+    // 0x200 = 512, which is out of 10-bit signed range
+    assert_eq!(hex2bin_fn(&[Value::Text("200".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_zero_returns_num() {
+    assert_eq!(hex2bin_fn(&[Value::Text("1".to_string()), Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn too_long_returns_num() {
+    assert_eq!(hex2bin_fn(&[Value::Text("FFFFFFFFFFF".to_string())]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/hex2bin/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/hex2bin/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/hex2bin/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/hex2bin/tests/success.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn f_to_bin() {
+    assert_eq!(hex2bin_fn(&[Value::Text("F".to_string())]), Value::Text("1111".to_string()));
+}
+
+#[test]
+fn all_f_to_bin() {
+    assert_eq!(hex2bin_fn(&[Value::Text("FFFFFFFFFF".to_string())]), Value::Text("1111111111".to_string()));
+}
+
+#[test]
+fn one_to_bin() {
+    assert_eq!(hex2bin_fn(&[Value::Text("1".to_string())]), Value::Text("1".to_string()));
+}
+
+#[test]
+fn lowercase_hex() {
+    assert_eq!(hex2bin_fn(&[Value::Text("ff".to_string())]), Value::Text("11111111".to_string()));
+}
+
+#[test]
+fn with_places() {
+    assert_eq!(hex2bin_fn(&[Value::Text("1".to_string()), Value::Number(4.0)]), Value::Text("0001".to_string()));
+}

--- a/crates/core/src/eval/functions/engineering/hex2dec/mod.rs
+++ b/crates/core/src/eval/functions/engineering/hex2dec/mod.rs
@@ -1,0 +1,21 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::parse_hex;
+use crate::types::{ErrorKind, Value};
+
+pub fn hex2dec_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let s = match to_string_val(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    match parse_hex(&s) {
+        Some(n) => Value::Number(n as f64),
+        None => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/hex2dec/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/hex2dec/tests/failure.rs
@@ -1,0 +1,17 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(hex2dec_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_char_returns_num() {
+    assert_eq!(hex2dec_fn(&[Value::Text("G".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn too_long_returns_num() {
+    assert_eq!(hex2dec_fn(&[Value::Text("FFFFFFFFFFF".to_string())]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/hex2dec/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/hex2dec/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/hex2dec/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/hex2dec/tests/success.rs
@@ -1,0 +1,32 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn all_f_is_minus_one() {
+    assert_eq!(hex2dec_fn(&[Value::Text("FFFFFFFFFF".to_string())]), Value::Number(-1.0));
+}
+
+#[test]
+fn a5_is_165() {
+    assert_eq!(hex2dec_fn(&[Value::Text("A5".to_string())]), Value::Number(165.0));
+}
+
+#[test]
+fn one_is_one() {
+    assert_eq!(hex2dec_fn(&[Value::Text("1".to_string())]), Value::Number(1.0));
+}
+
+#[test]
+fn zero_is_zero() {
+    assert_eq!(hex2dec_fn(&[Value::Text("0".to_string())]), Value::Number(0.0));
+}
+
+#[test]
+fn lowercase_accepted() {
+    assert_eq!(hex2dec_fn(&[Value::Text("a5".to_string())]), Value::Number(165.0));
+}
+
+#[test]
+fn max_positive() {
+    assert_eq!(hex2dec_fn(&[Value::Text("7FFFFFFFFF".to_string())]), Value::Number(549_755_813_887.0));
+}

--- a/crates/core/src/eval/functions/engineering/hex2oct/mod.rs
+++ b/crates/core/src/eval/functions/engineering/hex2oct/mod.rs
@@ -1,0 +1,33 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::{format_oct, get_places, parse_hex};
+use crate::types::{ErrorKind, Value};
+
+pub fn hex2oct_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let places = match get_places(args) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let s = match to_string_val(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let n = match parse_hex(&s) {
+        Some(v) => v,
+        None => return Value::Error(ErrorKind::Num),
+    };
+    // Result must fit in 29-bit signed range (-536870912 to 536870911)
+    if !(-536_870_912..=536_870_911).contains(&n) {
+        return Value::Error(ErrorKind::Num);
+    }
+    match format_oct(n, places) {
+        Ok(result) => Value::Text(result),
+        Err(()) => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/hex2oct/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/hex2oct/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(hex2oct_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_char_returns_num() {
+    assert_eq!(hex2oct_fn(&[Value::Text("G".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn out_of_oct_range_returns_num() {
+    // 0x2000_0000 = 536870912, out of 29-bit signed range
+    assert_eq!(hex2oct_fn(&[Value::Text("20000000".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_zero_returns_num() {
+    assert_eq!(hex2oct_fn(&[Value::Text("1".to_string()), Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/hex2oct/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/hex2oct/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/hex2oct/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/hex2oct/tests/success.rs
@@ -1,0 +1,28 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn f_to_oct() {
+    assert_eq!(hex2oct_fn(&[Value::Text("F".to_string())]), Value::Text("17".to_string()));
+}
+
+#[test]
+fn one_to_oct() {
+    assert_eq!(hex2oct_fn(&[Value::Text("1".to_string())]), Value::Text("1".to_string()));
+}
+
+#[test]
+fn zero_to_oct() {
+    assert_eq!(hex2oct_fn(&[Value::Text("0".to_string())]), Value::Text("0".to_string()));
+}
+
+#[test]
+fn all_f_to_oct() {
+    // FFFFFFFFFF = -1 in 40-bit; -1 in 29-bit = 7777777777 octal
+    assert_eq!(hex2oct_fn(&[Value::Text("FFFFFFFFFF".to_string())]), Value::Text("7777777777".to_string()));
+}
+
+#[test]
+fn with_places() {
+    assert_eq!(hex2oct_fn(&[Value::Text("1".to_string()), Value::Number(4.0)]), Value::Text("0001".to_string()));
+}

--- a/crates/core/src/eval/functions/engineering/mod.rs
+++ b/crates/core/src/eval/functions/engineering/mod.rs
@@ -9,6 +9,148 @@ pub mod bitrshift;
 pub mod delta;
 pub mod gestep;
 
+pub mod bin2dec;
+pub mod bin2hex;
+pub mod bin2oct;
+pub mod dec2bin;
+pub mod dec2hex;
+pub mod dec2oct;
+pub mod hex2bin;
+pub mod hex2dec;
+pub mod hex2oct;
+pub mod oct2bin;
+pub mod oct2dec;
+pub mod oct2hex;
+
+/// Parse a binary string (up to 10 chars of 0/1) as 10-bit two's complement → i64.
+/// Returns None if invalid chars or length > 10.
+pub(crate) fn parse_bin(s: &str) -> Option<i64> {
+    if s.is_empty() || s.len() > 10 {
+        return None;
+    }
+    for c in s.chars() {
+        if c != '0' && c != '1' {
+            return None;
+        }
+    }
+    let bits = u64::from_str_radix(s, 2).ok()?;
+    // 10-bit two's complement: bit 9 is sign bit
+    if bits & 0b10_0000_0000 != 0 {
+        // negative: extend sign
+        Some(bits as i64 - 1024)
+    } else {
+        Some(bits as i64)
+    }
+}
+
+/// Parse an octal string (up to 10 chars of 0–7) as 29-bit two's complement → i64.
+/// Returns None if invalid chars or length > 10.
+pub(crate) fn parse_oct(s: &str) -> Option<i64> {
+    if s.is_empty() || s.len() > 10 {
+        return None;
+    }
+    for c in s.chars() {
+        if !('0'..='7').contains(&c) {
+            return None;
+        }
+    }
+    let bits = u64::from_str_radix(s, 8).ok()?;
+    // 29-bit two's complement: bit 29 sign (value 2^29 = 536870912)
+    if bits & 0x2000_0000 != 0 {
+        Some(bits as i64 - 0x4000_0000) // subtract 2^30
+    } else {
+        Some(bits as i64)
+    }
+}
+
+/// Parse a hex string (up to 10 chars, case-insensitive) as 40-bit two's complement → i64.
+/// Returns None if invalid chars or length > 10.
+pub(crate) fn parse_hex(s: &str) -> Option<i64> {
+    if s.is_empty() || s.len() > 10 {
+        return None;
+    }
+    for c in s.chars() {
+        if !c.is_ascii_hexdigit() {
+            return None;
+        }
+    }
+    let bits = u64::from_str_radix(s, 16).ok()?;
+    // 40-bit two's complement: bit 39 is sign (value 2^39 = 549755813888)
+    if bits & 0x80_0000_0000 != 0 {
+        Some(bits as i64 - 0x100_0000_0000i64) // subtract 2^40
+    } else {
+        Some(bits as i64)
+    }
+}
+
+/// Format i64 as binary string using 10-bit two's complement for negatives.
+/// Returns Err(()) if places is invalid or result won't fit.
+pub(crate) fn format_bin(n: i64, places: Option<usize>) -> Result<String, ()> {
+    let bits: u64 = if n < 0 {
+        // 10-bit two's complement
+        (n + 1024) as u64
+    } else {
+        n as u64
+    };
+    let s = format!("{:b}", bits);
+    apply_places(s, places, 10)
+}
+
+/// Format i64 as octal string using 10-digit two's complement for negatives.
+/// Returns Err(()) if places is invalid or result won't fit.
+pub(crate) fn format_oct(n: i64, places: Option<usize>) -> Result<String, ()> {
+    let bits: u64 = if n < 0 {
+        // 29-bit two's complement stored in 30 bits
+        (n + 0x4000_0000) as u64
+    } else {
+        n as u64
+    };
+    let s = format!("{:o}", bits);
+    apply_places(s, places, 10)
+}
+
+/// Format i64 as uppercase hex string using 10-digit two's complement for negatives.
+/// Returns Err(()) if places is invalid or result won't fit.
+pub(crate) fn format_hex(n: i64, places: Option<usize>) -> Result<String, ()> {
+    let bits: u64 = if n < 0 {
+        // 40-bit two's complement
+        (n + 0x100_0000_0000i64) as u64
+    } else {
+        n as u64
+    };
+    let s = format!("{:X}", bits);
+    apply_places(s, places, 10)
+}
+
+fn apply_places(s: String, places: Option<usize>, max_len: usize) -> Result<String, ()> {
+    match places {
+        None => Ok(s),
+        Some(p) => {
+            if p == 0 || s.len() > p || p > max_len {
+                Err(())
+            } else {
+                Ok(format!("{:0>width$}", s, width = p))
+            }
+        }
+    }
+}
+
+/// Extract optional places argument (2nd arg) from args slice.
+/// Returns Ok(None) if not provided, Ok(Some(n)) if valid positive integer, Err(Value) on error.
+pub(crate) fn get_places(args: &[crate::types::Value]) -> Result<Option<usize>, crate::types::Value> {
+    use crate::eval::coercion::to_number;
+    use crate::types::{ErrorKind, Value};
+    if args.len() < 2 {
+        return Ok(None);
+    }
+    let n = to_number(args[1].clone())?;
+    let p = n.trunc() as i64;
+    if p <= 0 {
+        return Err(Value::Error(ErrorKind::Num));
+    }
+    Ok(Some(p as usize))
+}
+
 pub fn register_engineering(registry: &mut Registry) {
     registry.register_eager("BITAND",    bitand::bitand_fn,       FunctionMeta { category: "engineering", signature: "BITAND(number1, number2)",          description: "Bitwise AND of two integers" });
     registry.register_eager("BITOR",     bitor::bitor_fn,         FunctionMeta { category: "engineering", signature: "BITOR(number1, number2)",           description: "Bitwise OR of two integers" });
@@ -17,4 +159,16 @@ pub fn register_engineering(registry: &mut Registry) {
     registry.register_eager("BITRSHIFT", bitrshift::bitrshift_fn, FunctionMeta { category: "engineering", signature: "BITRSHIFT(number, shift_amount)",   description: "Right-shift an integer by a number of bits" });
     registry.register_eager("DELTA",     delta::delta_fn,         FunctionMeta { category: "engineering", signature: "DELTA(number1, [number2])",         description: "Test whether two values are equal" });
     registry.register_eager("GESTEP",    gestep::gestep_fn,       FunctionMeta { category: "engineering", signature: "GESTEP(number, [step])",            description: "Test whether a number is greater than or equal to a step value" });
+    registry.register_eager("BIN2DEC", bin2dec::bin2dec_fn, FunctionMeta { category: "engineering", signature: "BIN2DEC(number)",           description: "Convert binary to decimal" });
+    registry.register_eager("BIN2HEX", bin2hex::bin2hex_fn, FunctionMeta { category: "engineering", signature: "BIN2HEX(number, [places])", description: "Convert binary to hexadecimal" });
+    registry.register_eager("BIN2OCT", bin2oct::bin2oct_fn, FunctionMeta { category: "engineering", signature: "BIN2OCT(number, [places])", description: "Convert binary to octal" });
+    registry.register_eager("DEC2BIN", dec2bin::dec2bin_fn, FunctionMeta { category: "engineering", signature: "DEC2BIN(number, [places])", description: "Convert decimal to binary" });
+    registry.register_eager("DEC2HEX", dec2hex::dec2hex_fn, FunctionMeta { category: "engineering", signature: "DEC2HEX(number, [places])", description: "Convert decimal to hexadecimal" });
+    registry.register_eager("DEC2OCT", dec2oct::dec2oct_fn, FunctionMeta { category: "engineering", signature: "DEC2OCT(number, [places])", description: "Convert decimal to octal" });
+    registry.register_eager("HEX2BIN", hex2bin::hex2bin_fn, FunctionMeta { category: "engineering", signature: "HEX2BIN(number, [places])", description: "Convert hexadecimal to binary" });
+    registry.register_eager("HEX2DEC", hex2dec::hex2dec_fn, FunctionMeta { category: "engineering", signature: "HEX2DEC(number)",           description: "Convert hexadecimal to decimal" });
+    registry.register_eager("HEX2OCT", hex2oct::hex2oct_fn, FunctionMeta { category: "engineering", signature: "HEX2OCT(number, [places])", description: "Convert hexadecimal to octal" });
+    registry.register_eager("OCT2BIN", oct2bin::oct2bin_fn, FunctionMeta { category: "engineering", signature: "OCT2BIN(number, [places])", description: "Convert octal to binary" });
+    registry.register_eager("OCT2DEC", oct2dec::oct2dec_fn, FunctionMeta { category: "engineering", signature: "OCT2DEC(number)",           description: "Convert octal to decimal" });
+    registry.register_eager("OCT2HEX", oct2hex::oct2hex_fn, FunctionMeta { category: "engineering", signature: "OCT2HEX(number, [places])", description: "Convert octal to hexadecimal" });
 }

--- a/crates/core/src/eval/functions/engineering/oct2bin/mod.rs
+++ b/crates/core/src/eval/functions/engineering/oct2bin/mod.rs
@@ -1,0 +1,33 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::{format_bin, get_places, parse_oct};
+use crate::types::{ErrorKind, Value};
+
+pub fn oct2bin_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let places = match get_places(args) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let s = match to_string_val(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let n = match parse_oct(&s) {
+        Some(v) => v,
+        None => return Value::Error(ErrorKind::Num),
+    };
+    // Result must fit in 10-bit signed range (-512 to 511)
+    if !(-512..=511).contains(&n) {
+        return Value::Error(ErrorKind::Num);
+    }
+    match format_bin(n, places) {
+        Ok(result) => Value::Text(result),
+        Err(()) => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/oct2bin/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/oct2bin/tests/failure.rs
@@ -1,0 +1,23 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(oct2bin_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_char_returns_num() {
+    assert_eq!(oct2bin_fn(&[Value::Text("8".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn out_of_bin_range_returns_num() {
+    // 1000 octal = 512 decimal, out of 10-bit signed range
+    assert_eq!(oct2bin_fn(&[Value::Text("1000".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_zero_returns_num() {
+    assert_eq!(oct2bin_fn(&[Value::Text("1".to_string()), Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/oct2bin/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/oct2bin/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/oct2bin/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/oct2bin/tests/success.rs
@@ -1,0 +1,28 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn seven_to_bin() {
+    assert_eq!(oct2bin_fn(&[Value::Text("7".to_string())]), Value::Text("111".to_string()));
+}
+
+#[test]
+fn one_to_bin() {
+    assert_eq!(oct2bin_fn(&[Value::Text("1".to_string())]), Value::Text("1".to_string()));
+}
+
+#[test]
+fn zero_to_bin() {
+    assert_eq!(oct2bin_fn(&[Value::Text("0".to_string())]), Value::Text("0".to_string()));
+}
+
+#[test]
+fn all_sevens_to_bin() {
+    // 7777777777 octal = -1 (29-bit two's complement), which gives 1111111111 in binary
+    assert_eq!(oct2bin_fn(&[Value::Text("7777777777".to_string())]), Value::Text("1111111111".to_string()));
+}
+
+#[test]
+fn with_places() {
+    assert_eq!(oct2bin_fn(&[Value::Text("3".to_string()), Value::Number(4.0)]), Value::Text("0011".to_string()));
+}

--- a/crates/core/src/eval/functions/engineering/oct2dec/mod.rs
+++ b/crates/core/src/eval/functions/engineering/oct2dec/mod.rs
@@ -1,0 +1,21 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::parse_oct;
+use crate::types::{ErrorKind, Value};
+
+pub fn oct2dec_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let s = match to_string_val(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    match parse_oct(&s) {
+        Some(n) => Value::Number(n as f64),
+        None => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/oct2dec/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/oct2dec/tests/failure.rs
@@ -1,0 +1,17 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(oct2dec_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_char_returns_num() {
+    assert_eq!(oct2dec_fn(&[Value::Text("8".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn too_long_returns_num() {
+    assert_eq!(oct2dec_fn(&[Value::Text("77777777777".to_string())]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/oct2dec/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/oct2dec/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/oct2dec/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/oct2dec/tests/success.rs
@@ -1,0 +1,32 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn all_sevens_is_minus_one() {
+    assert_eq!(oct2dec_fn(&[Value::Text("7777777777".to_string())]), Value::Number(-1.0));
+}
+
+#[test]
+fn seven_is_seven() {
+    assert_eq!(oct2dec_fn(&[Value::Text("7".to_string())]), Value::Number(7.0));
+}
+
+#[test]
+fn zero_is_zero() {
+    assert_eq!(oct2dec_fn(&[Value::Text("0".to_string())]), Value::Number(0.0));
+}
+
+#[test]
+fn ten_octal_is_eight() {
+    assert_eq!(oct2dec_fn(&[Value::Text("10".to_string())]), Value::Number(8.0));
+}
+
+#[test]
+fn max_positive() {
+    assert_eq!(oct2dec_fn(&[Value::Text("3777777777".to_string())]), Value::Number(536_870_911.0));
+}
+
+#[test]
+fn min_negative() {
+    assert_eq!(oct2dec_fn(&[Value::Text("4000000000".to_string())]), Value::Number(-536_870_912.0));
+}

--- a/crates/core/src/eval/functions/engineering/oct2hex/mod.rs
+++ b/crates/core/src/eval/functions/engineering/oct2hex/mod.rs
@@ -1,0 +1,29 @@
+use crate::eval::coercion::to_string_val;
+use crate::eval::functions::check_arity;
+use crate::eval::functions::engineering::{format_hex, get_places, parse_oct};
+use crate::types::{ErrorKind, Value};
+
+pub fn oct2hex_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let places = match get_places(args) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let s = match to_string_val(args[0].clone()) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    let n = match parse_oct(&s) {
+        Some(v) => v,
+        None => return Value::Error(ErrorKind::Num),
+    };
+    match format_hex(n, places) {
+        Ok(result) => Value::Text(result),
+        Err(()) => Value::Error(ErrorKind::Num),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/oct2hex/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/oct2hex/tests/failure.rs
@@ -1,0 +1,22 @@
+use super::super::*;
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn no_args_returns_na() {
+    assert_eq!(oct2hex_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn invalid_char_returns_num() {
+    assert_eq!(oct2hex_fn(&[Value::Text("8".to_string())]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_zero_returns_num() {
+    assert_eq!(oct2hex_fn(&[Value::Text("7".to_string()), Value::Number(0.0)]), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn places_too_small_returns_num() {
+    assert_eq!(oct2hex_fn(&[Value::Text("3777777777".to_string()), Value::Number(1.0)]), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/engineering/oct2hex/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/oct2hex/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/oct2hex/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/oct2hex/tests/success.rs
@@ -1,0 +1,28 @@
+use super::super::*;
+use crate::types::Value;
+
+#[test]
+fn seven_to_hex() {
+    assert_eq!(oct2hex_fn(&[Value::Text("7".to_string())]), Value::Text("7".to_string()));
+}
+
+#[test]
+fn ten_octal_to_hex() {
+    assert_eq!(oct2hex_fn(&[Value::Text("10".to_string())]), Value::Text("8".to_string()));
+}
+
+#[test]
+fn all_sevens_to_hex() {
+    // 7777777777 = -1, which is FFFFFFFFFF in hex
+    assert_eq!(oct2hex_fn(&[Value::Text("7777777777".to_string())]), Value::Text("FFFFFFFFFF".to_string()));
+}
+
+#[test]
+fn with_places() {
+    assert_eq!(oct2hex_fn(&[Value::Text("7".to_string()), Value::Number(2.0)]), Value::Text("07".to_string()));
+}
+
+#[test]
+fn zero_to_hex() {
+    assert_eq!(oct2hex_fn(&[Value::Text("0".to_string())]), Value::Text("0".to_string()));
+}


### PR DESCRIPTION
## Summary
- Add 12 base-conversion engineering functions with shared two's complement helpers
- BIN2DEC, BIN2HEX, BIN2OCT: parse 10-bit signed binary strings
- DEC2BIN, DEC2HEX, DEC2OCT: format integers as binary/hex/octal with two's complement
- HEX2BIN, HEX2DEC, HEX2OCT: parse 40-bit signed hex strings
- OCT2BIN, OCT2DEC, OCT2HEX: parse 29-bit signed octal strings

## Test plan
- [ ] All 116 engineering unit tests pass (`cargo test -p ganit-core --lib -- eval::functions::engineering`)
- [ ] Clippy clean (`cargo clippy --workspace -- -D warnings`)
- [ ] Positive values, negative two's complement, boundary values, invalid chars, arity errors covered

closes #219
closes #221
closes #223
closes #235
closes #237
closes #238
closes #241
closes #242
closes #244
closes #246
closes #248
closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)