### PR TITLE
test: activate M2 engineering conformance tests

### DIFF
--- a/crates/core/src/eval/functions/engineering/bitand/mod.rs
+++ b/crates/core/src/eval/functions/engineering/bitand/mod.rs
@@ -16,7 +16,9 @@ pub fn bitand_fn(args: &[Value]) -> Value {
         Ok(n) => n,
         Err(e) => return e,
     };
-    if a < 0.0 || b < 0.0 || a > MAX_BIT as f64 || b > MAX_BIT as f64 {
+    if a < 0.0 || b < 0.0 || a > MAX_BIT as f64 || b > MAX_BIT as f64
+        || a.fract() != 0.0 || b.fract() != 0.0
+    {
         return Value::Error(ErrorKind::Num);
     }
     let result = (a as u64) & (b as u64);

--- a/crates/core/src/eval/functions/engineering/mod.rs
+++ b/crates/core/src/eval/functions/engineering/mod.rs
@@ -24,8 +24,12 @@ pub mod oct2hex;
 
 /// Parse a binary string (up to 10 chars of 0/1) as 10-bit two's complement → i64.
 /// Returns None if invalid chars or length > 10.
+/// Empty string is treated as "0" (Google Sheets behaviour).
 pub(crate) fn parse_bin(s: &str) -> Option<i64> {
-    if s.is_empty() || s.len() > 10 {
+    if s.is_empty() {
+        return Some(0);
+    }
+    if s.len() > 10 {
         return None;
     }
     for c in s.chars() {
@@ -45,8 +49,12 @@ pub(crate) fn parse_bin(s: &str) -> Option<i64> {
 
 /// Parse an octal string (up to 10 chars of 0–7) as 29-bit two's complement → i64.
 /// Returns None if invalid chars or length > 10.
+/// Empty string is treated as "0" (Google Sheets behaviour).
 pub(crate) fn parse_oct(s: &str) -> Option<i64> {
-    if s.is_empty() || s.len() > 10 {
+    if s.is_empty() {
+        return Some(0);
+    }
+    if s.len() > 10 {
         return None;
     }
     for c in s.chars() {
@@ -65,8 +73,12 @@ pub(crate) fn parse_oct(s: &str) -> Option<i64> {
 
 /// Parse a hex string (up to 10 chars, case-insensitive) as 40-bit two's complement → i64.
 /// Returns None if invalid chars or length > 10.
+/// Empty string is treated as "0" (Google Sheets behaviour).
 pub(crate) fn parse_hex(s: &str) -> Option<i64> {
-    if s.is_empty() || s.len() > 10 {
+    if s.is_empty() {
+        return Some(0);
+    }
+    if s.len() > 10 {
         return None;
     }
     for c in s.chars() {

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -220,7 +220,7 @@ conformance_test!(m1_operator_conformance,    "m1", "Operator.xlsx");
 conformance_test!(m1_text_conformance,        "m1", "Text.xlsx");
 
 conformance_test!(m2_date_conformance,        "m2", "Date.xlsx");
-conformance_test!(pending, m2_engineering_conformance, "m2", "Engineering.xlsx");
+conformance_test!(m2_engineering_conformance, "m2", "Engineering.xlsx");
 conformance_test!(pending, m2_info_conformance,        "m2", "Info.xlsx");
 conformance_test!(pending, m2_logical_conformance,     "m2", "Logical.xlsx");
 conformance_test!(pending, m2_lookup_conformance,      "m2", "Lookup.xlsx");


### PR DESCRIPTION
## Summary

- Activates `m2_engineering_conformance` test (removes `pending` marker)
- Fixes 10 conformance failures found in the Engineering.xlsx fixture:
  - 9 empty-string failures: `parse_bin`, `parse_oct`, `parse_hex` now return `0` for `""` to match Google Sheets behaviour (affects BIN2DEC, BIN2HEX, BIN2OCT, HEX2BIN, HEX2DEC, HEX2OCT, OCT2BIN, OCT2DEC, OCT2HEX)
  - 1 BITAND non-integer failure: `BITAND(1.5, 3)` now returns `#NUM!` as Google Sheets requires

closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)