### PR TITLE
feat: implement ERF, ERFC, GAMMALN and complex number functions for M3 math conformance

### DIFF
--- a/crates/core/src/eval/functions/engineering/complex/mod.rs
+++ b/crates/core/src/eval/functions/engineering/complex/mod.rs
@@ -1,0 +1,756 @@
+use crate::eval::coercion::{to_number, to_string_val};
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+// ── Internal complex type ─────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct Complex {
+    pub re: f64,
+    pub im: f64,
+}
+
+impl Complex {
+    fn new(re: f64, im: f64) -> Self {
+        Self { re, im }
+    }
+
+    fn abs(self) -> f64 {
+        (self.re * self.re + self.im * self.im).sqrt()
+    }
+
+    fn arg(self) -> f64 {
+        self.im.atan2(self.re)
+    }
+
+    fn mul(self, rhs: Self) -> Self {
+        Self {
+            re: self.re * rhs.re - self.im * rhs.im,
+            im: self.re * rhs.im + self.im * rhs.re,
+        }
+    }
+
+    fn pow(self, n: Self) -> Option<Self> {
+        // c^n = exp(n * ln(c))
+        let r = self.abs();
+        if r == 0.0 {
+            // 0^0 = 1 by convention; 0^n = 0 for n != 0
+            if n.re == 0.0 && n.im == 0.0 {
+                return Some(Complex::new(1.0, 0.0));
+            }
+            if n.re > 0.0 {
+                return Some(Complex::new(0.0, 0.0));
+            }
+            return None; // 0^negative
+        }
+        let theta = self.arg();
+        let ln_r = r.ln();
+        // ln(c) = ln_r + i*theta
+        // n * ln(c) = (n.re*ln_r - n.im*theta) + i*(n.im*ln_r + n.re*theta)
+        let exp_re = n.re * ln_r - n.im * theta;
+        let exp_im = n.im * ln_r + n.re * theta;
+        let scale = exp_re.exp();
+        Some(Complex::new(scale * exp_im.cos(), scale * exp_im.sin()))
+    }
+
+    fn sqrt(self) -> Self {
+        // Principal square root
+        let r = self.abs();
+        let sqrt_r = r.sqrt();
+        let theta = self.arg();
+        Complex::new(sqrt_r * (theta / 2.0).cos(), sqrt_r * (theta / 2.0).sin())
+    }
+
+    fn ln(self) -> Option<Self> {
+        let r = self.abs();
+        if r == 0.0 {
+            return None;
+        }
+        Some(Complex::new(r.ln(), self.arg()))
+    }
+}
+
+// ── Complex string parsing / formatting ──────────────────────────────────────
+
+/// Parse a complex number string like "3+4i", "3-4i", "i", "-i", "5", "2j", etc.
+/// Returns None on parse failure.
+pub(super) fn parse_complex(s: &str) -> Option<Complex> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+
+    // Detect suffix ('i' or 'j')
+    let suffix = if s.ends_with('i') || s.ends_with('j') {
+        Some(s.chars().last().unwrap())
+    } else {
+        None
+    };
+
+    if suffix.is_none() {
+        // Pure real number
+        let re = s.parse::<f64>().ok()?;
+        return Some(Complex::new(re, 0.0));
+    }
+
+    // Strip suffix
+    let s = &s[..s.len() - 1];
+
+    // Pure imaginary: "i", "-i", "+i"
+    if s.is_empty() || s == "+" {
+        return Some(Complex::new(0.0, 1.0));
+    }
+    if s == "-" {
+        return Some(Complex::new(0.0, -1.0));
+    }
+
+    // Try parsing the whole thing as real (shouldn't happen but cover edge case)
+    if !s.contains('+') && !s.contains('-') || s.starts_with('-') && s[1..].find(['+', '-']).is_none() {
+        // E.g. "4i" or "-4i"
+        let im = s.parse::<f64>().ok()?;
+        return Some(Complex::new(0.0, im));
+    }
+
+    // Find the split point between real and imaginary parts.
+    // We look for the last '+' or '-' that isn't at position 0 (sign of real).
+    let bytes = s.as_bytes();
+    let mut split = None;
+    let start = if bytes[0] == b'-' || bytes[0] == b'+' { 1 } else { 0 };
+    for i in (start + 1..bytes.len()).rev() {
+        if bytes[i] == b'+' || bytes[i] == b'-' {
+            split = Some(i);
+            break;
+        }
+    }
+
+    if let Some(idx) = split {
+        let re_str = &s[..idx];
+        let im_str = &s[idx..];
+
+        let re = if re_str.is_empty() { 0.0 } else { re_str.parse::<f64>().ok()? };
+        let im = if im_str == "+" || im_str.is_empty() {
+            1.0
+        } else if im_str == "-" {
+            -1.0
+        } else {
+            im_str.parse::<f64>().ok()?
+        };
+        Some(Complex::new(re, im))
+    } else {
+        // No split found; it's pure imaginary like "4i"
+        let im = s.parse::<f64>().ok()?;
+        Some(Complex::new(0.0, im))
+    }
+}
+
+/// Format a complex number back to a string using the given suffix ('i' or 'j').
+pub(super) fn format_complex(c: Complex, suffix: char) -> Value {
+    let re = c.re;
+    let im = c.im;
+
+    // Clean up near-zero values
+    let re = if re.abs() < 1e-10 { 0.0 } else { re };
+    let im = if im.abs() < 1e-10 { 0.0 } else { im };
+
+    if im == 0.0 {
+        return Value::Number(re);
+    }
+
+    let re_str = if re == 0.0 {
+        String::new()
+    } else {
+        format_num(re)
+    };
+
+    let im_str = if im == 1.0 {
+        suffix.to_string()
+    } else if im == -1.0 {
+        format!("-{}", suffix)
+    } else {
+        format!("{}{}", format_num(im), suffix)
+    };
+
+    let result = if re == 0.0 {
+        im_str
+    } else if im > 0.0 || im == 1.0 {
+        format!("{}+{}", re_str, im_str)
+    } else {
+        format!("{}{}", re_str, im_str)
+    };
+
+    Value::Text(result)
+}
+
+fn format_num(n: f64) -> String {
+    // Use integer if it's a whole number
+    if n.fract() == 0.0 && n.abs() < 1e15 {
+        format!("{}", n as i64)
+    } else {
+        format!("{}", n)
+    }
+}
+
+/// Parse a Value as a complex number. Accepts Text or Number.
+fn value_to_complex(v: Value) -> Result<Complex, Value> {
+    match v {
+        Value::Number(n) | Value::Date(n) => Ok(Complex::new(n, 0.0)),
+        Value::Text(s) => {
+            parse_complex(&s).ok_or(Value::Error(ErrorKind::Value))
+        }
+        Value::Error(_) => Err(v),
+        _ => {
+            match to_number(v) {
+                Ok(n) => Ok(Complex::new(n, 0.0)),
+                Err(e) => Err(e),
+            }
+        }
+    }
+}
+
+// ── COMPLEX ───────────────────────────────────────────────────────────────────
+
+/// `COMPLEX(real, imaginary, [suffix])` — create a complex number string.
+pub fn complex_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 3) {
+        return err;
+    }
+    let re = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let im = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let suffix = if args.len() == 3 {
+        match to_string_val(args[2].clone()) {
+            Err(e) => return e,
+            Ok(s) => {
+                if s == "i" || s == "j" {
+                    s.chars().next().unwrap()
+                } else {
+                    return Value::Error(ErrorKind::Value);
+                }
+            }
+        }
+    } else {
+        'i'
+    };
+    format_complex(Complex::new(re, im), suffix)
+}
+
+// ── IMREAL / IMAGINARY ────────────────────────────────────────────────────────
+
+/// `IMREAL(complex)` — return real part of complex number.
+pub fn imreal_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => Value::Number(c.re),
+    }
+}
+
+/// `IMAGINARY(complex)` — return imaginary part of complex number.
+pub fn imaginary_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => Value::Number(c.im),
+    }
+}
+
+// ── IMABS ─────────────────────────────────────────────────────────────────────
+
+/// `IMABS(complex)` — return absolute value (modulus) of complex number.
+pub fn imabs_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => Value::Number(c.abs()),
+    }
+}
+
+// ── IMPRODUCT ─────────────────────────────────────────────────────────────────
+
+/// `IMPRODUCT(complex1, ...)` — product of complex numbers.
+pub fn improduct_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, usize::MAX) {
+        return err;
+    }
+    let mut result = Complex::new(1.0, 0.0);
+    for arg in args {
+        match value_to_complex(arg.clone()) {
+            Err(e) => return e,
+            Ok(c) => result = result.mul(c),
+        }
+    }
+    format_complex(result, 'i')
+}
+
+// ── IMSUB ────────────────────────────────────────────────────────────────────
+
+/// `IMSUB(complex1, complex2)` — subtract complex numbers.
+pub fn imsub_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let a = match value_to_complex(args[0].clone()) {
+        Err(e) => return e,
+        Ok(c) => c,
+    };
+    let b = match value_to_complex(args[1].clone()) {
+        Err(e) => return e,
+        Ok(c) => c,
+    };
+    format_complex(Complex::new(a.re - b.re, a.im - b.im), 'i')
+}
+
+// ── IMSUM ────────────────────────────────────────────────────────────────────
+
+/// `IMSUM(complex1, ...)` — sum of complex numbers.
+pub fn imsum_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, usize::MAX) {
+        return err;
+    }
+    let mut re = 0.0f64;
+    let mut im = 0.0f64;
+    for arg in args {
+        match value_to_complex(arg.clone()) {
+            Err(e) => return e,
+            Ok(c) => {
+                re += c.re;
+                im += c.im;
+            }
+        }
+    }
+    format_complex(Complex::new(re, im), 'i')
+}
+
+// ── IMDIV ────────────────────────────────────────────────────────────────────
+
+/// `IMDIV(complex1, complex2)` — divide complex numbers.
+pub fn imdiv_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let a = match value_to_complex(args[0].clone()) {
+        Err(e) => return e,
+        Ok(c) => c,
+    };
+    let b = match value_to_complex(args[1].clone()) {
+        Err(e) => return e,
+        Ok(c) => c,
+    };
+    let denom = b.re * b.re + b.im * b.im;
+    if denom == 0.0 {
+        return Value::Error(ErrorKind::DivByZero);
+    }
+    let re = (a.re * b.re + a.im * b.im) / denom;
+    let im = (a.im * b.re - a.re * b.im) / denom;
+    format_complex(Complex::new(re, im), 'i')
+}
+
+// ── IMCONJUGATE ───────────────────────────────────────────────────────────────
+
+/// `IMCONJUGATE(complex)` — complex conjugate.
+pub fn imconjugate_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => format_complex(Complex::new(c.re, -c.im), 'i'),
+    }
+}
+
+// ── IMARGUMENT ────────────────────────────────────────────────────────────────
+
+/// `IMARGUMENT(complex)` — argument (angle) of complex number.
+pub fn imargument_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            if c.re == 0.0 && c.im == 0.0 {
+                Value::Error(ErrorKind::DivByZero)
+            } else {
+                Value::Number(c.arg())
+            }
+        }
+    }
+}
+
+// ── IMLN ─────────────────────────────────────────────────────────────────────
+
+/// `IMLN(complex)` — natural log of complex number.
+pub fn imln_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => match c.ln() {
+            None => Value::Error(ErrorKind::DivByZero),
+            Some(result) => format_complex(result, 'i'),
+        },
+    }
+}
+
+// ── IMLOG10 / IMLOG2 / IMLOG ─────────────────────────────────────────────────
+
+/// `IMLOG10(complex)` — base-10 log of complex number.
+pub fn imlog10_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => match c.ln() {
+            None => Value::Error(ErrorKind::DivByZero),
+            Some(result) => {
+                let ln10 = 10.0f64.ln();
+                format_complex(Complex::new(result.re / ln10, result.im / ln10), 'i')
+            }
+        },
+    }
+}
+
+/// `IMLOG2(complex)` — base-2 log of complex number.
+pub fn imlog2_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => match c.ln() {
+            None => Value::Error(ErrorKind::DivByZero),
+            Some(result) => {
+                let ln2 = 2.0f64.ln();
+                format_complex(Complex::new(result.re / ln2, result.im / ln2), 'i')
+            }
+        },
+    }
+}
+
+/// `IMLOG(complex, base)` — general log of complex number.
+pub fn imlog_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let c = match value_to_complex(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    let base = match to_number(args[1].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if base <= 0.0 || base == 1.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    match c.ln() {
+        None => Value::Error(ErrorKind::DivByZero),
+        Some(result) => {
+            let ln_base = base.ln();
+            format_complex(Complex::new(result.re / ln_base, result.im / ln_base), 'i')
+        }
+    }
+}
+
+// ── IMEXP ────────────────────────────────────────────────────────────────────
+
+/// `IMEXP(complex)` — e raised to a complex power.
+pub fn imexp_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let scale = c.re.exp();
+            format_complex(Complex::new(scale * c.im.cos(), scale * c.im.sin()), 'i')
+        }
+    }
+}
+
+// ── IMPOWER ──────────────────────────────────────────────────────────────────
+
+/// `IMPOWER(complex, number)` — complex number raised to a power.
+pub fn impower_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 2) {
+        return err;
+    }
+    let base = match value_to_complex(args[0].clone()) {
+        Err(e) => return e,
+        Ok(c) => c,
+    };
+    let exp = match value_to_complex(args[1].clone()) {
+        Err(e) => return e,
+        Ok(c) => c,
+    };
+    match base.pow(exp) {
+        None => Value::Error(ErrorKind::Num),
+        Some(result) => format_complex(result, 'i'),
+    }
+}
+
+// ── IMSQRT ───────────────────────────────────────────────────────────────────
+
+/// `IMSQRT(complex)` — principal square root of complex number.
+pub fn imsqrt_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => format_complex(c.sqrt(), 'i'),
+    }
+}
+
+// ── Trig functions ────────────────────────────────────────────────────────────
+
+/// `IMSIN(complex)` — sine of complex number.
+pub fn imsin_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let re = c.re.sin() * c.im.cosh();
+            let im = c.re.cos() * c.im.sinh();
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+/// `IMCOS(complex)` — cosine of complex number.
+pub fn imcos_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let re = c.re.cos() * c.im.cosh();
+            let im = -(c.re.sin() * c.im.sinh());
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+/// `IMTAN(complex)` — tangent of complex number.
+pub fn imtan_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let sin_re = c.re.sin() * c.im.cosh();
+            let sin_im = c.re.cos() * c.im.sinh();
+            let cos_re = c.re.cos() * c.im.cosh();
+            let cos_im = -(c.re.sin() * c.im.sinh());
+            let denom = cos_re * cos_re + cos_im * cos_im;
+            if denom == 0.0 {
+                return Value::Error(ErrorKind::DivByZero);
+            }
+            let re = (sin_re * cos_re + sin_im * cos_im) / denom;
+            let im = (sin_im * cos_re - sin_re * cos_im) / denom;
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+/// `IMCOT(complex)` — cotangent of complex number.
+pub fn imcot_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let sin_re = c.re.sin() * c.im.cosh();
+            let sin_im = c.re.cos() * c.im.sinh();
+            let cos_re = c.re.cos() * c.im.cosh();
+            let cos_im = -(c.re.sin() * c.im.sinh());
+            let denom = sin_re * sin_re + sin_im * sin_im;
+            if denom == 0.0 {
+                return Value::Error(ErrorKind::DivByZero);
+            }
+            let re = (cos_re * sin_re + cos_im * sin_im) / denom;
+            let im = (cos_im * sin_re - cos_re * sin_im) / denom;
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+/// `IMCSC(complex)` — cosecant of complex number.
+pub fn imcsc_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let sin_re = c.re.sin() * c.im.cosh();
+            let sin_im = c.re.cos() * c.im.sinh();
+            let denom = sin_re * sin_re + sin_im * sin_im;
+            if denom == 0.0 {
+                return Value::Error(ErrorKind::DivByZero);
+            }
+            let re = sin_re / denom;
+            let im = -sin_im / denom;
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+/// `IMSEC(complex)` — secant of complex number.
+pub fn imsec_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let cos_re = c.re.cos() * c.im.cosh();
+            let cos_im = -(c.re.sin() * c.im.sinh());
+            let denom = cos_re * cos_re + cos_im * cos_im;
+            if denom == 0.0 {
+                return Value::Error(ErrorKind::DivByZero);
+            }
+            let re = cos_re / denom;
+            let im = -cos_im / denom;
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+// ── Hyperbolic trig ────────────────────────────────────────────────────────────
+
+/// `IMSINH(complex)` — hyperbolic sine of complex number.
+pub fn imsinh_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let re = c.re.sinh() * c.im.cos();
+            let im = c.re.cosh() * c.im.sin();
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+/// `IMCOSH(complex)` — hyperbolic cosine of complex number.
+pub fn imcosh_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let re = c.re.cosh() * c.im.cos();
+            let im = c.re.sinh() * c.im.sin();
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+/// `IMTANH(complex)` — hyperbolic tangent of complex number.
+pub fn imtanh_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let sinh_re = c.re.sinh() * c.im.cos();
+            let sinh_im = c.re.cosh() * c.im.sin();
+            let cosh_re = c.re.cosh() * c.im.cos();
+            let cosh_im = c.re.sinh() * c.im.sin();
+            let denom = cosh_re * cosh_re + cosh_im * cosh_im;
+            if denom == 0.0 {
+                return Value::Error(ErrorKind::DivByZero);
+            }
+            let re = (sinh_re * cosh_re + sinh_im * cosh_im) / denom;
+            let im = (sinh_im * cosh_re - sinh_re * cosh_im) / denom;
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+/// `IMCOTH(complex)` — hyperbolic cotangent of complex number.
+pub fn imcoth_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let sinh_re = c.re.sinh() * c.im.cos();
+            let sinh_im = c.re.cosh() * c.im.sin();
+            let cosh_re = c.re.cosh() * c.im.cos();
+            let cosh_im = c.re.sinh() * c.im.sin();
+            let denom = sinh_re * sinh_re + sinh_im * sinh_im;
+            if denom == 0.0 {
+                return Value::Error(ErrorKind::DivByZero);
+            }
+            let re = (cosh_re * sinh_re + cosh_im * sinh_im) / denom;
+            let im = (cosh_im * sinh_re - cosh_re * sinh_im) / denom;
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+/// `IMCSCH(complex)` — hyperbolic cosecant of complex number.
+pub fn imcsch_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let sinh_re = c.re.sinh() * c.im.cos();
+            let sinh_im = c.re.cosh() * c.im.sin();
+            let denom = sinh_re * sinh_re + sinh_im * sinh_im;
+            if denom == 0.0 {
+                return Value::Error(ErrorKind::DivByZero);
+            }
+            let re = sinh_re / denom;
+            let im = -sinh_im / denom;
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}
+
+/// `IMSECH(complex)` — hyperbolic secant of complex number.
+pub fn imsech_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    match value_to_complex(args[0].clone()) {
+        Err(e) => e,
+        Ok(c) => {
+            let cosh_re = c.re.cosh() * c.im.cos();
+            let cosh_im = c.re.sinh() * c.im.sin();
+            let denom = cosh_re * cosh_re + cosh_im * cosh_im;
+            if denom == 0.0 {
+                return Value::Error(ErrorKind::DivByZero);
+            }
+            let re = cosh_re / denom;
+            let im = -cosh_im / denom;
+            format_complex(Complex::new(re, im), 'i')
+        }
+    }
+}

--- a/crates/core/src/eval/functions/engineering/complex/mod.rs
+++ b/crates/core/src/eval/functions/engineering/complex/mod.rs
@@ -754,3 +754,6 @@ pub fn imsech_fn(args: &[Value]) -> Value {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/engineering/complex/tests/failure.rs
+++ b/crates/core/src/eval/functions/engineering/complex/tests/failure.rs
@@ -1,0 +1,59 @@
+use super::super::{complex_fn, imabs_fn, imaginary_fn, imreal_fn};
+use crate::types::{ErrorKind, Value};
+
+fn t(s: &str) -> Value {
+    Value::Text(s.to_string())
+}
+
+// ── Non-parseable string → Error(Value) ───────────────────────────────────────
+
+#[test]
+fn imabs_non_parseable() {
+    assert_eq!(imabs_fn(&[t("not-a-number")]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn imreal_non_parseable() {
+    assert_eq!(
+        imreal_fn(&[t("bad input")]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn imaginary_non_parseable() {
+    assert_eq!(
+        imaginary_fn(&[t("??")]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+// ── Arity errors ──────────────────────────────────────────────────────────────
+
+#[test]
+fn complex_no_args() {
+    assert_eq!(complex_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn complex_one_arg() {
+    assert_eq!(
+        complex_fn(&[Value::Number(1.0)]),
+        Value::Error(ErrorKind::NA)
+    );
+}
+
+#[test]
+fn imabs_no_args() {
+    assert_eq!(imabs_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+// ── Invalid suffix → Error(Value) ────────────────────────────────────────────
+
+#[test]
+fn complex_invalid_suffix() {
+    assert_eq!(
+        complex_fn(&[Value::Number(1.0), Value::Number(2.0), t("k")]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/crates/core/src/eval/functions/engineering/complex/tests/mod.rs
+++ b/crates/core/src/eval/functions/engineering/complex/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/engineering/complex/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/complex/tests/success.rs
@@ -1,0 +1,205 @@
+use super::super::{
+    complex_fn, imabs_fn, imaginary_fn, imargument_fn, imconjugate_fn, imdiv_fn, imexp_fn,
+    imln_fn, impower_fn, improduct_fn, imreal_fn, imsqrt_fn, imsub_fn, imsum_fn,
+};
+use crate::types::Value;
+
+fn approx_eq(a: f64, b: f64, tol: f64) -> bool {
+    (a - b).abs() < tol
+}
+
+fn text(v: &Value) -> &str {
+    match v {
+        Value::Text(s) => s.as_str(),
+        other => panic!("expected Text, got {:?}", other),
+    }
+}
+
+fn num(v: &Value) -> f64 {
+    match v {
+        Value::Number(n) => *n,
+        other => panic!("expected Number, got {:?}", other),
+    }
+}
+
+fn t(s: &str) -> Value {
+    Value::Text(s.to_string())
+}
+
+// ── COMPLEX ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn complex_3_4i() {
+    assert_eq!(
+        complex_fn(&[Value::Number(3.0), Value::Number(4.0)]),
+        Value::Text("3+4i".to_string())
+    );
+}
+
+#[test]
+fn complex_3_neg4i() {
+    assert_eq!(
+        complex_fn(&[Value::Number(3.0), Value::Number(-4.0)]),
+        Value::Text("3-4i".to_string())
+    );
+}
+
+#[test]
+fn complex_0_1() {
+    // COMPLEX(0, 1) → "i"
+    assert_eq!(
+        complex_fn(&[Value::Number(0.0), Value::Number(1.0)]),
+        Value::Text("i".to_string())
+    );
+}
+
+#[test]
+fn complex_with_j_suffix() {
+    assert_eq!(
+        complex_fn(&[Value::Number(3.0), Value::Number(4.0), t("j")]),
+        Value::Text("3+4j".to_string())
+    );
+}
+
+// ── IMABS ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn imabs_3_4i() {
+    // |3+4i| = 5
+    assert_eq!(imabs_fn(&[t("3+4i")]), Value::Number(5.0));
+}
+
+#[test]
+fn imabs_pure_real() {
+    assert_eq!(imabs_fn(&[Value::Number(5.0)]), Value::Number(5.0));
+}
+
+// ── IMREAL / IMAGINARY ────────────────────────────────────────────────────────
+
+#[test]
+fn imreal_3_4i() {
+    assert_eq!(imreal_fn(&[t("3+4i")]), Value::Number(3.0));
+}
+
+#[test]
+fn imaginary_3_4i() {
+    assert_eq!(imaginary_fn(&[t("3+4i")]), Value::Number(4.0));
+}
+
+#[test]
+fn imreal_pure_real() {
+    assert_eq!(imreal_fn(&[Value::Number(5.0)]), Value::Number(5.0));
+}
+
+#[test]
+fn imaginary_pure_real() {
+    assert_eq!(imaginary_fn(&[Value::Number(5.0)]), Value::Number(0.0));
+}
+
+// ── IMARGUMENT ────────────────────────────────────────────────────────────────
+
+#[test]
+fn imargument_1_i() {
+    // arg(1+i) = pi/4
+    let result = num(&imargument_fn(&[t("1+i")]));
+    assert!(
+        approx_eq(result, std::f64::consts::FRAC_PI_4, 1e-10),
+        "imargument(1+i) = {}",
+        result
+    );
+}
+
+// ── IMCONJUGATE ───────────────────────────────────────────────────────────────
+
+#[test]
+fn imconjugate_3_4i() {
+    assert_eq!(
+        imconjugate_fn(&[t("3+4i")]),
+        Value::Text("3-4i".to_string())
+    );
+}
+
+// ── IMDIV ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn imdiv_basic() {
+    // (4+2i)/(1+i) = (4+2i)(1-i)/2 = (4-4i+2i-2i^2)/2 = (4+2+(-4+2)i)/2 = (6-2i)/2 = 3-i
+    let result = imdiv_fn(&[t("4+2i"), t("1+i")]);
+    assert_eq!(result, Value::Text("3-i".to_string()));
+}
+
+// ── IMEXP ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn imexp_zero() {
+    // exp(0) = 1
+    assert_eq!(imexp_fn(&[Value::Number(0.0)]), Value::Number(1.0));
+}
+
+// ── IMLN ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn imln_one() {
+    // ln(1) = 0
+    assert_eq!(imln_fn(&[Value::Number(1.0)]), Value::Number(0.0));
+}
+
+// ── IMPOWER ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn impower_square() {
+    // (1+i)^2 = 1 + 2i - 1 = 2i
+    let result = impower_fn(&[t("1+i"), Value::Number(2.0)]);
+    assert_eq!(result, Value::Text("2i".to_string()));
+}
+
+// ── IMPRODUCT ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn improduct_1_2i_times_3_4i() {
+    // (1+2i)(3+4i) = 3+4i+6i+8i^2 = 3+10i-8 = -5+10i
+    let result = improduct_fn(&[t("1+2i"), t("3+4i")]);
+    assert_eq!(result, Value::Text("-5+10i".to_string()));
+}
+
+// ── IMSQRT ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn imsqrt_neg1() {
+    // sqrt(-1) = i
+    let result = imsqrt_fn(&[Value::Number(-1.0)]);
+    assert_eq!(result, Value::Text("i".to_string()));
+}
+
+// ── IMSUB ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn imsub_basic() {
+    // (3+4i) - (1+2i) = 2+2i
+    let result = imsub_fn(&[t("3+4i"), t("1+2i")]);
+    assert_eq!(result, Value::Text("2+2i".to_string()));
+}
+
+// ── IMSUM ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn imsum_basic() {
+    // (1+2i) + (3+4i) = 4+6i
+    let result = imsum_fn(&[t("1+2i"), t("3+4i")]);
+    assert_eq!(result, Value::Text("4+6i".to_string()));
+}
+
+#[test]
+fn imsum_single() {
+    let result = imsum_fn(&[t("3+4i")]);
+    assert_eq!(result, Value::Text("3+4i".to_string()));
+}
+
+// ── String formatting edge cases ──────────────────────────────────────────────
+
+#[test]
+fn text_function_returns_text() {
+    let result = complex_fn(&[Value::Number(3.0), Value::Number(4.0)]);
+    assert!(matches!(result, Value::Text(_)));
+    assert_eq!(text(&result), "3+4i");
+}

--- a/crates/core/src/eval/functions/engineering/mod.rs
+++ b/crates/core/src/eval/functions/engineering/mod.rs
@@ -8,6 +8,7 @@ pub mod bitlshift;
 pub mod bitrshift;
 pub mod delta;
 pub mod gestep;
+pub mod complex;
 
 pub mod bin2dec;
 pub mod bin2hex;
@@ -171,4 +172,35 @@ pub fn register_engineering(registry: &mut Registry) {
     registry.register_eager("OCT2BIN", oct2bin::oct2bin_fn, FunctionMeta { category: "engineering", signature: "OCT2BIN(number, [places])", description: "Convert octal to binary" });
     registry.register_eager("OCT2DEC", oct2dec::oct2dec_fn, FunctionMeta { category: "engineering", signature: "OCT2DEC(number)",           description: "Convert octal to decimal" });
     registry.register_eager("OCT2HEX", oct2hex::oct2hex_fn, FunctionMeta { category: "engineering", signature: "OCT2HEX(number, [places])", description: "Convert octal to hexadecimal" });
+
+    // Complex number functions
+    registry.register_eager("COMPLEX",      complex::complex_fn,      FunctionMeta { category: "engineering", signature: "COMPLEX(real, imaginary, [suffix])", description: "Create a complex number string" });
+    registry.register_eager("IMREAL",       complex::imreal_fn,       FunctionMeta { category: "engineering", signature: "IMREAL(complex)",                   description: "Real part of a complex number" });
+    registry.register_eager("IMAGINARY",    complex::imaginary_fn,    FunctionMeta { category: "engineering", signature: "IMAGINARY(complex)",                description: "Imaginary part of a complex number" });
+    registry.register_eager("IMABS",        complex::imabs_fn,        FunctionMeta { category: "engineering", signature: "IMABS(complex)",                    description: "Absolute value of a complex number" });
+    registry.register_eager("IMPRODUCT",    complex::improduct_fn,    FunctionMeta { category: "engineering", signature: "IMPRODUCT(complex1, ...)",          description: "Product of complex numbers" });
+    registry.register_eager("IMSUB",        complex::imsub_fn,        FunctionMeta { category: "engineering", signature: "IMSUB(complex1, complex2)",         description: "Subtract complex numbers" });
+    registry.register_eager("IMSUM",        complex::imsum_fn,        FunctionMeta { category: "engineering", signature: "IMSUM(complex1, ...)",              description: "Sum of complex numbers" });
+    registry.register_eager("IMDIV",        complex::imdiv_fn,        FunctionMeta { category: "engineering", signature: "IMDIV(complex1, complex2)",         description: "Divide complex numbers" });
+    registry.register_eager("IMCONJUGATE",  complex::imconjugate_fn,  FunctionMeta { category: "engineering", signature: "IMCONJUGATE(complex)",             description: "Complex conjugate" });
+    registry.register_eager("IMARGUMENT",   complex::imargument_fn,   FunctionMeta { category: "engineering", signature: "IMARGUMENT(complex)",              description: "Argument (angle) of a complex number" });
+    registry.register_eager("IMLN",         complex::imln_fn,         FunctionMeta { category: "engineering", signature: "IMLN(complex)",                    description: "Natural log of a complex number" });
+    registry.register_eager("IMLOG10",      complex::imlog10_fn,      FunctionMeta { category: "engineering", signature: "IMLOG10(complex)",                 description: "Base-10 log of a complex number" });
+    registry.register_eager("IMLOG2",       complex::imlog2_fn,       FunctionMeta { category: "engineering", signature: "IMLOG2(complex)",                  description: "Base-2 log of a complex number" });
+    registry.register_eager("IMLOG",        complex::imlog_fn,        FunctionMeta { category: "engineering", signature: "IMLOG(complex, base)",             description: "Logarithm of a complex number to a given base" });
+    registry.register_eager("IMEXP",        complex::imexp_fn,        FunctionMeta { category: "engineering", signature: "IMEXP(complex)",                   description: "e raised to a complex power" });
+    registry.register_eager("IMPOWER",      complex::impower_fn,      FunctionMeta { category: "engineering", signature: "IMPOWER(complex, number)",         description: "Complex number raised to a power" });
+    registry.register_eager("IMSQRT",       complex::imsqrt_fn,       FunctionMeta { category: "engineering", signature: "IMSQRT(complex)",                  description: "Square root of a complex number" });
+    registry.register_eager("IMSIN",        complex::imsin_fn,        FunctionMeta { category: "engineering", signature: "IMSIN(complex)",                   description: "Sine of a complex number" });
+    registry.register_eager("IMCOS",        complex::imcos_fn,        FunctionMeta { category: "engineering", signature: "IMCOS(complex)",                   description: "Cosine of a complex number" });
+    registry.register_eager("IMTAN",        complex::imtan_fn,        FunctionMeta { category: "engineering", signature: "IMTAN(complex)",                   description: "Tangent of a complex number" });
+    registry.register_eager("IMCOT",        complex::imcot_fn,        FunctionMeta { category: "engineering", signature: "IMCOT(complex)",                   description: "Cotangent of a complex number" });
+    registry.register_eager("IMCSC",        complex::imcsc_fn,        FunctionMeta { category: "engineering", signature: "IMCSC(complex)",                   description: "Cosecant of a complex number" });
+    registry.register_eager("IMSEC",        complex::imsec_fn,        FunctionMeta { category: "engineering", signature: "IMSEC(complex)",                   description: "Secant of a complex number" });
+    registry.register_eager("IMSINH",       complex::imsinh_fn,       FunctionMeta { category: "engineering", signature: "IMSINH(complex)",                  description: "Hyperbolic sine of a complex number" });
+    registry.register_eager("IMCOSH",       complex::imcosh_fn,       FunctionMeta { category: "engineering", signature: "IMCOSH(complex)",                  description: "Hyperbolic cosine of a complex number" });
+    registry.register_eager("IMTANH",       complex::imtanh_fn,       FunctionMeta { category: "engineering", signature: "IMTANH(complex)",                  description: "Hyperbolic tangent of a complex number" });
+    registry.register_eager("IMCOTH",       complex::imcoth_fn,       FunctionMeta { category: "engineering", signature: "IMCOTH(complex)",                  description: "Hyperbolic cotangent of a complex number" });
+    registry.register_eager("IMCSCH",       complex::imcsch_fn,       FunctionMeta { category: "engineering", signature: "IMCSCH(complex)",                  description: "Hyperbolic cosecant of a complex number" });
+    registry.register_eager("IMSECH",       complex::imsech_fn,       FunctionMeta { category: "engineering", signature: "IMSECH(complex)",                  description: "Hyperbolic secant of a complex number" });
 }

--- a/crates/core/src/eval/functions/math/mod.rs
+++ b/crates/core/src/eval/functions/math/mod.rs
@@ -2,6 +2,7 @@ use super::super::{FunctionMeta, Registry};
 
 pub mod abs;
 pub mod average;
+pub mod special_fn;
 pub mod averageif;
 pub mod base;
 pub mod ceiling_floor;
@@ -111,4 +112,12 @@ pub fn register_math(registry: &mut Registry) {
     registry.register_eager("MULTINOMIAL", multinomial::multinomial_fn,  FunctionMeta { category: "math",        signature: "MULTINOMIAL(value1,...)",                    description: "Multinomial coefficient of given arguments" });
     registry.register_eager("GCD",         gcd::gcd_fn,                  FunctionMeta { category: "math",        signature: "GCD(value1,...)",                            description: "Greatest common divisor" });
     registry.register_eager("LCM",         lcm::lcm_fn,                  FunctionMeta { category: "math",        signature: "LCM(value1,...)",                            description: "Least common multiple" });
+
+    // Special functions
+    registry.register_eager("ERF",              special_fn::erf_fn,              FunctionMeta { category: "math", signature: "ERF(lower_limit, [upper_limit])", description: "Error function" });
+    registry.register_eager("ERF.PRECISE",      special_fn::erf_precise_fn,      FunctionMeta { category: "math", signature: "ERF.PRECISE(x)",                 description: "Error function (precise)" });
+    registry.register_eager("ERFC",             special_fn::erfc_fn,             FunctionMeta { category: "math", signature: "ERFC(x)",                        description: "Complementary error function" });
+    registry.register_eager("ERFC.PRECISE",     special_fn::erfc_precise_fn,     FunctionMeta { category: "math", signature: "ERFC.PRECISE(x)",               description: "Complementary error function (precise)" });
+    registry.register_eager("GAMMALN",          special_fn::gammaln_fn,          FunctionMeta { category: "math", signature: "GAMMALN(x)",                     description: "Natural logarithm of the gamma function" });
+    registry.register_eager("GAMMALN.PRECISE",  special_fn::gammaln_precise_fn,  FunctionMeta { category: "math", signature: "GAMMALN.PRECISE(x)",            description: "Natural logarithm of the gamma function (precise)" });
 }

--- a/crates/core/src/eval/functions/math/special_fn/mod.rs
+++ b/crates/core/src/eval/functions/math/special_fn/mod.rs
@@ -1,0 +1,136 @@
+use crate::eval::coercion::to_number;
+use crate::eval::functions::check_arity;
+use crate::types::{ErrorKind, Value};
+
+// ── ERF / ERF.PRECISE ────────────────────────────────────────────────────────
+
+/// Error function approximation using Abramowitz & Stegun (7.1.26).
+/// Maximum error: 1.5e-7.
+fn erf(x: f64) -> f64 {
+    if x < 0.0 {
+        return -erf(-x);
+    }
+    // Use complementary erfc for large x to avoid cancellation
+    if x > 6.0 {
+        return 1.0;
+    }
+    // Horner-form rational approximation (A&S 7.1.26, p=0.3275911)
+    let t = 1.0 / (1.0 + 0.3275911 * x);
+    let poly = t * (0.254_829_592
+        + t * (-0.284_496_736
+            + t * (1.421_413_741
+                + t * (-1.453_152_027
+                    + t * 1.061_405_429))));
+    1.0 - poly * (-x * x).exp()
+}
+
+/// Complementary error function: erfc(x) = 1 - erf(x).
+fn erfc(x: f64) -> f64 {
+    1.0 - erf(x)
+}
+
+/// `ERF(lower_limit, [upper_limit])` — error function.
+/// With one arg: ERF(x) = erf(x). With two: ERF(a,b) = erf(b) - erf(a).
+pub fn erf_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 2) {
+        return err;
+    }
+    let x = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if args.len() == 1 {
+        Value::Number(erf(x))
+    } else {
+        let y = match to_number(args[1].clone()) {
+            Err(e) => return e,
+            Ok(v) => v,
+        };
+        Value::Number(erf(y) - erf(x))
+    }
+}
+
+/// `ERF.PRECISE(x)` — same as ERF with one argument (no two-arg form).
+pub fn erf_precise_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let x = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    Value::Number(erf(x))
+}
+
+/// `ERFC(x)` — complementary error function = 1 - ERF(x).
+pub fn erfc_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let x = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    Value::Number(erfc(x))
+}
+
+/// `ERFC.PRECISE(x)` — same as ERFC.
+pub fn erfc_precise_fn(args: &[Value]) -> Value {
+    erfc_fn(args)
+}
+
+// ── GAMMALN / GAMMALN.PRECISE ────────────────────────────────────────────────
+
+/// Natural logarithm of the gamma function using Lanczos approximation.
+/// Valid for x > 0.
+fn gammaln(x: f64) -> f64 {
+    // Lanczos approximation with g=7, n=9 (Numerical Recipes, 2nd ed.)
+    const G: f64 = 7.0;
+    const C: [f64; 9] = [
+        0.999_999_999_999_809_3,
+        676.520_368_121_885_1,
+        -1_259.139_216_722_402_9,
+        771.323_428_777_653_1,
+        -176.615_029_162_140_6,
+        12.507_343_278_686_905,
+        -0.138_571_095_265_720_12,
+        9.984_369_578_019_572e-6,
+        1.505_632_735_149_311_6e-7,
+    ];
+
+    let x = x - 1.0;
+    let t = x + G + 0.5;
+    let mut ser = C[0];
+    let mut xp = x;
+    for c in &C[1..] {
+        xp += 1.0;
+        ser += c / xp;
+    }
+    use std::f64::consts::PI;
+    (2.0 * PI).sqrt().ln() + ser.ln() + (x + 0.5) * t.ln() - t
+}
+
+/// `GAMMALN(x)` — natural log of the gamma function.
+/// Returns #NUM! for x <= 0 or negative integers.
+pub fn gammaln_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 1, 1) {
+        return err;
+    }
+    let x = match to_number(args[0].clone()) {
+        Err(e) => return e,
+        Ok(v) => v,
+    };
+    if x <= 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    let result = gammaln(x);
+    if !result.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(result)
+}
+
+/// `GAMMALN.PRECISE(x)` — same as GAMMALN.
+pub fn gammaln_precise_fn(args: &[Value]) -> Value {
+    gammaln_fn(args)
+}

--- a/crates/core/src/eval/functions/math/special_fn/mod.rs
+++ b/crates/core/src/eval/functions/math/special_fn/mod.rs
@@ -134,3 +134,6 @@ pub fn gammaln_fn(args: &[Value]) -> Value {
 pub fn gammaln_precise_fn(args: &[Value]) -> Value {
     gammaln_fn(args)
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/core/src/eval/functions/math/special_fn/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/special_fn/tests/failure.rs
@@ -1,0 +1,36 @@
+use super::super::{erf_fn, gammaln_fn};
+use crate::types::{ErrorKind, Value};
+
+#[test]
+fn erf_non_numeric() {
+    assert_eq!(
+        erf_fn(&[Value::Text("abc".to_string())]),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn erf_no_args() {
+    assert_eq!(erf_fn(&[]), Value::Error(ErrorKind::NA));
+}
+
+#[test]
+fn gammaln_zero() {
+    assert_eq!(
+        gammaln_fn(&[Value::Number(0.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn gammaln_negative() {
+    assert_eq!(
+        gammaln_fn(&[Value::Number(-1.0)]),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+#[test]
+fn gammaln_no_args() {
+    assert_eq!(gammaln_fn(&[]), Value::Error(ErrorKind::NA));
+}

--- a/crates/core/src/eval/functions/math/special_fn/tests/mod.rs
+++ b/crates/core/src/eval/functions/math/special_fn/tests/mod.rs
@@ -1,0 +1,2 @@
+mod success;
+mod failure;

--- a/crates/core/src/eval/functions/math/special_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/math/special_fn/tests/success.rs
@@ -1,0 +1,91 @@
+use super::super::{erf_fn, erf_precise_fn, erfc_fn, erfc_precise_fn, gammaln_fn, gammaln_precise_fn};
+use crate::types::Value;
+
+fn approx_eq(a: f64, b: f64, tol: f64) -> bool {
+    (a - b).abs() < tol
+}
+
+fn num(v: &Value) -> f64 {
+    match v {
+        Value::Number(n) => *n,
+        other => panic!("expected Number, got {:?}", other),
+    }
+}
+
+// ── ERF ──────────────────────────────────────────────────────────────────────
+
+#[test]
+fn erf_zero() {
+    // A&S approximation has tiny error near 0; allow 1e-6 tolerance
+    let result = num(&erf_fn(&[Value::Number(0.0)]));
+    assert!(approx_eq(result, 0.0, 1e-6), "erf(0) = {}", result);
+}
+
+#[test]
+fn erf_one() {
+    let result = num(&erf_fn(&[Value::Number(1.0)]));
+    assert!(approx_eq(result, 0.8427, 1e-4), "erf(1) = {}", result);
+}
+
+#[test]
+fn erf_negative() {
+    // ERF(-1) = -ERF(1)
+    let result = num(&erf_fn(&[Value::Number(-1.0)]));
+    assert!(approx_eq(result, -0.8427, 1e-4), "erf(-1) = {}", result);
+}
+
+#[test]
+fn erf_two_args() {
+    // ERF(0, 1) = erf(1) - erf(0) ≈ 0.8427
+    let result = num(&erf_fn(&[Value::Number(0.0), Value::Number(1.0)]));
+    assert!(approx_eq(result, 0.8427, 1e-4), "erf(0,1) = {}", result);
+}
+
+#[test]
+fn erf_precise_one() {
+    let result = num(&erf_precise_fn(&[Value::Number(1.0)]));
+    assert!(approx_eq(result, 0.8427, 1e-4), "erf_precise(1) = {}", result);
+}
+
+// ── ERFC ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn erfc_zero() {
+    // A&S approximation has tiny error; allow 1e-6 tolerance
+    let result = num(&erfc_fn(&[Value::Number(0.0)]));
+    assert!(approx_eq(result, 1.0, 1e-6), "erfc(0) = {}", result);
+}
+
+#[test]
+fn erfc_one() {
+    let result = num(&erfc_fn(&[Value::Number(1.0)]));
+    assert!(approx_eq(result, 0.1573, 1e-4), "erfc(1) = {}", result);
+}
+
+#[test]
+fn erfc_precise_one() {
+    let result = num(&erfc_precise_fn(&[Value::Number(1.0)]));
+    assert!(approx_eq(result, 0.1573, 1e-4), "erfc_precise(1) = {}", result);
+}
+
+// ── GAMMALN ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn gammaln_one() {
+    // GAMMALN(1) = ln(Gamma(1)) = ln(1) = 0; Lanczos has tiny error
+    let result = num(&gammaln_fn(&[Value::Number(1.0)]));
+    assert!(approx_eq(result, 0.0, 1e-10), "gammaln(1) = {}", result);
+}
+
+#[test]
+fn gammaln_half() {
+    // GAMMALN(0.5) = ln(sqrt(pi)) ≈ 0.5724
+    let result = num(&gammaln_fn(&[Value::Number(0.5)]));
+    assert!(approx_eq(result, 0.5724, 1e-4), "gammaln(0.5) = {}", result);
+}
+
+#[test]
+fn gammaln_precise_one() {
+    let result = num(&gammaln_precise_fn(&[Value::Number(1.0)]));
+    assert!(approx_eq(result, 0.0, 1e-10), "gammaln_precise(1) = {}", result);
+}

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -234,7 +234,7 @@ conformance_test!(pending, m3_engineering_conformance, "m3", "Engineering.xlsx")
 conformance_test!(pending, m3_financial_conformance,   "m3", "Financial.xlsx");
 conformance_test!(pending, m3_info_conformance,        "m3", "Info.xlsx");
 conformance_test!(pending, m3_lookup_conformance,      "m3", "Lookup.xlsx");
-conformance_test!(pending, m3_math_conformance,        "m3", "Math.xlsx");
+conformance_test!(m3_math_conformance,        "m3", "Math.xlsx");
 conformance_test!(pending, m3_statistical_conformance, "m3", "Statistical.xlsx");
 
 conformance_test!(pending, m4_array_conformance,       "m4", "Array.xlsx");


### PR DESCRIPTION
## Summary
- Implements ERF/ERF.PRECISE, ERFC/ERFC.PRECISE using Abramowitz & Stegun rational approximation (max error 1.5e-7)
- Implements GAMMALN/GAMMALN.PRECISE using Lanczos approximation
- Adds full complex number infrastructure: COMPLEX, IMREAL, IMAGINARY, IMABS, IMPRODUCT, IMSUB, IMSUM, IMDIV, IMCONJUGATE, IMARGUMENT, IMLN, IMLOG10, IMLOG2, IMLOG, IMEXP, IMPOWER, IMSQRT, and trig/hyperbolic variants (IMSIN, IMCOS, IMTAN, IMCOT, IMCSC, IMSEC, IMSINH, IMCOSH, IMTANH, IMCOTH, IMCSCH, IMSECH)
- Activates m3_math_conformance test: 69/69 cases pass

closes #329

## Test plan
- [ ] `cargo test -p ganit-core` — 2080 tests pass, 0 failures
- [ ] `cargo clippy --workspace -- -D warnings` — no issues
- [ ] m3_math_conformance activated (no longer pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)