### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "ganit-core"
-version = "0.3.12"
+version = "0.4.0"
 dependencies = [
  "calamine",
  "chrono",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "ganit-mcp"
-version = "0.3.12"
+version = "0.4.0"
 dependencies = [
  "ganit-core",
  "serde",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "ganit-wasm"
-version = "0.3.12"
+version = "0.4.0"
 dependencies = [
  "ganit-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.12"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 authors = ["tryganit"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.12...ganit-core-v0.4.0) - 2026-04-17
+
+### Added
+
+- implement M2/M3 lookup functions
+- implement statistical distribution functions for M3 conformance
+
+### Other
+
+- Merge pull request #352 from tryganit/feat/334-m4-logical-lambda-impl
+- Merge remote-tracking branch 'origin/main' into feat/334-m4-logical-lambda-impl
+- Merge pull request #348 from tryganit/feat/325-m3-engineering-complex
+- Merge pull request #347 from tryganit/feat/332-m4-filter
+- resolve merge conflicts with origin/main in count/mod.rs and eval/mod.rs
+- activate M2 text conformance
+- resolve merge conflicts with main; fix SPLIT to return Value::Empty for empty parts
+- re-trigger CI
+- *(test)* convert split_fn/tests.rs to tests/success/failure/edge pattern
+- add unit tests for SPLIT, TEXT, VALUE, COUNTA fixes
+- activate M2 text conformance
+
 ## [0.3.12](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.10...ganit-core-v0.3.12) - 2026-04-16
 
 ### Other

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -12,6 +12,6 @@ name = "ganit-mcp"
 path = "src/main.rs"
 
 [dependencies]
-ganit-core = { path = "../core", version = "0.3" }
+ganit-core = { path = "../core", version = "0.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION



## 🤖 New release

* `ganit-core`: 0.3.12 -> 0.4.0 (⚠ API breaking changes)
* `ganit-mcp`: 0.3.12 -> 0.4.0

### ⚠ `ganit-core` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Expr:Apply in /tmp/.tmparjDWN/ganit-core/crates/core/src/parser/ast.rs:52
  variant Expr:Apply in /tmp/.tmparjDWN/ganit-core/crates/core/src/parser/ast.rs:52
  variant Expr:Apply in /tmp/.tmparjDWN/ganit-core/crates/core/src/parser/ast.rs:52

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  ganit_core::eval::functions::math::sumifs::sumifs_fn now takes 2 parameters instead of 1, in /tmp/.tmparjDWN/ganit-core/crates/core/src/eval/functions/math/sumifs/mod.rs:12
  ganit_core::eval::functions::math::sumif::sumif_fn now takes 2 parameters instead of 1, in /tmp/.tmparjDWN/ganit-core/crates/core/src/eval/functions/math/sumif/mod.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `ganit-core`

<blockquote>

## [0.4.0](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.12...ganit-core-v0.4.0) - 2026-04-17

### Added

- implement M2/M3 lookup functions
- implement statistical distribution functions for M3 conformance

### Other

- Merge pull request #352 from tryganit/feat/334-m4-logical-lambda-impl
- Merge remote-tracking branch 'origin/main' into feat/334-m4-logical-lambda-impl
- Merge pull request #348 from tryganit/feat/325-m3-engineering-complex
- Merge pull request #347 from tryganit/feat/332-m4-filter
- resolve merge conflicts with origin/main in count/mod.rs and eval/mod.rs
- activate M2 text conformance
- resolve merge conflicts with main; fix SPLIT to return Value::Empty for empty parts
- re-trigger CI
- *(test)* convert split_fn/tests.rs to tests/success/failure/edge pattern
- add unit tests for SPLIT, TEXT, VALUE, COUNTA fixes
- activate M2 text conformance
</blockquote>

## `ganit-mcp`

<blockquote>

## [0.3.12](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.3.11...ganit-mcp-v0.3.12) - 2026-04-16

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).