### PR TITLE
fix(concat): always return Value::Text, remove numeric oracle workaround

### DIFF
--- a/crates/core/src/eval/functions/operator/mod.rs
+++ b/crates/core/src/eval/functions/operator/mod.rs
@@ -223,14 +223,7 @@ pub fn concat_fn(args: &[Value]) -> Value {
         Ok(s) => s,
         Err(e) => return e,
     };
-    let result = format!("{}{}", a, b);
-    // The Google Sheets xlsx oracle exports numeric-looking text results (e.g. "12") as
-    // float cells, so the conformance harness expects Number(12.0) for CONCAT(1,2).
-    // Parse-fallback mirrors that until the fixture is regenerated with explicit text cells.
-    if let Ok(n) = result.parse::<f64>() {
-        return Value::Number(n);
-    }
-    Value::Text(result)
+    Value::Text(format!("{}{}", a, b))
 }
 
 pub fn uminus_fn(args: &[Value]) -> Value {

--- a/crates/core/src/eval/functions/operator/tests/concat.rs
+++ b/crates/core/src/eval/functions/operator/tests/concat.rs
@@ -1,0 +1,53 @@
+use super::super::concat_fn;
+use crate::types::{ErrorKind, Value};
+
+// ── basic concatenation ───────────────────────────────────────────────────────
+
+#[test]
+fn two_text_args_returns_text() {
+    // CONCAT("hello", " world") → "hello world"
+    assert_eq!(
+        concat_fn(&[Value::Text("hello".into()), Value::Text(" world".into())]),
+        Value::Text("hello world".into())
+    );
+}
+
+#[test]
+fn numeric_args_returns_text_not_number() {
+    // CONCAT(1, 2) must return Text("12"), never Number(12.0)
+    assert_eq!(
+        concat_fn(&[Value::Number(1.0), Value::Number(2.0)]),
+        Value::Text("12".into())
+    );
+}
+
+#[test]
+fn mixed_number_and_text_returns_text() {
+    // CONCAT("x", 9) → "x9"
+    assert_eq!(
+        concat_fn(&[Value::Text("x".into()), Value::Number(9.0)]),
+        Value::Text("x9".into())
+    );
+}
+
+// ── arity errors ──────────────────────────────────────────────────────────────
+
+#[test]
+fn too_few_args_returns_na_error() {
+    assert_eq!(
+        concat_fn(&[Value::Text("a".into())]),
+        Value::Error(ErrorKind::NA)
+    );
+}
+
+#[test]
+fn too_many_args_returns_na_error() {
+    assert_eq!(
+        concat_fn(&[
+            Value::Text("a".into()),
+            Value::Text("b".into()),
+            Value::Text("c".into()),
+        ]),
+        Value::Error(ErrorKind::NA)
+    );
+}

--- a/crates/core/src/eval/functions/operator/tests/mod.rs
+++ b/crates/core/src/eval/functions/operator/tests/mod.rs
@@ -1,1 +1,2 @@
+mod concat;
 mod isbetween;


### PR DESCRIPTION
## Summary

- `CONCAT` is a text function and must always return `Value::Text`
- Removes the `parse::<f64>()` fallback in `concat_fn` that was returning `Value::Number` for numeric-looking results (e.g. `CONCAT(1,2)` → `Number(12.0)`)
- The conformance harness already has a `(Value::Text(s), Value::Number(b))` arm in `values_match` that handles the xlsx oracle artifact, so no fixture change is needed
- Adds unit tests covering basic concatenation, numeric args (the previously wrong case), mixed types, and arity errors

closes #69

## Test Plan
- [ ] `cargo test -p ganit-core operator::tests::concat` — 5 tests pass
- [ ] `cargo test -p ganit-core` — 2462 passed, 3 ignored
- [ ] `cargo clippy --workspace -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)