### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "ganit-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "calamine",
  "chrono",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "ganit-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ganit-core",
  "serde",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "ganit-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ganit-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 authors = ["tryganit"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.4.0...ganit-core-v0.4.1) - 2026-04-17
+
+### Fixed
+
+- *(concat)* always return Value::Text, remove numeric oracle workaround
+
 ## [0.4.0](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.12...ganit-core-v0.4.0) - 2026-04-17
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `ganit-core`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `ganit-mcp`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `ganit-core`

<blockquote>

## [0.4.1](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.4.0...ganit-core-v0.4.1) - 2026-04-17

### Fixed

- *(concat)* always return Value::Text, remove numeric oracle workaround
</blockquote>

## `ganit-mcp`

<blockquote>

## [0.3.12](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.3.11...ganit-mcp-v0.3.12) - 2026-04-16

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).