### PR TITLE
docs(mcp): add ganit-core badge and use --force for install

### DIFF
--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -1,6 +1,7 @@
 # ganit-mcp
 
-[![crates.io](https://img.shields.io/crates/v/ganit-mcp)](https://crates.io/crates/ganit-mcp)
+[![ganit-core](https://img.shields.io/crates/v/ganit-core?label=ganit-core)](https://crates.io/crates/ganit-core)
+[![ganit-mcp](https://img.shields.io/crates/v/ganit-mcp?label=ganit-mcp)](https://crates.io/crates/ganit-mcp)
 [![license](https://img.shields.io/crates/l/ganit-mcp)](LICENSE)
 
 MCP server that exposes [ganit](https://crates.io/crates/ganit-core) spreadsheet formula evaluation as tools for AI assistants.
@@ -10,7 +11,7 @@ Plug it into Claude Desktop (or any MCP-compatible client) and your AI can evalu
 ## Install
 
 ```sh
-cargo install ganit-mcp
+cargo install ganit-mcp --force
 ```
 
 ## Claude Desktop setup


### PR DESCRIPTION
## Summary

- Add `ganit-core` crates.io badge alongside the existing `ganit-mcp` badge so both are visible in the MCP README
- Update `cargo install` command to use `--force` so users always get the latest published version

## Test plan

- [ ] Verify both badges render correctly on crates.io / GitHub
- [ ] Verify the install command reads `cargo install ganit-mcp --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)