### PR TITLE
feat(ci): nextest + llvm-cov coverage — inline PR annotations and 80% gate

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+# .config/nextest.toml
+[profile.ci]
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,19 @@ jobs:
           reporter: java-junit
           fail-on-error: false
 
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage report
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,22 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
 
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Test
-        run: cargo test --workspace
+        run: cargo nextest run --workspace --profile ci
+        env:
+          NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: ganit-core tests
+          path: target/nextest/ci/junit.xml
+          reporter: java-junit
+          fail-on-error: false
 
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
@@ -37,4 +51,3 @@ jobs:
 
       - name: Build WASM
         run: wasm-pack build crates/wasm --target web
-

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@
 # git worktrees
 .worktrees/
 
-# generated docs
+# generated docs (except superpowers specs/plans)
 docs/
+!docs/superpowers/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# codecov.yml
+coverage:
+  status:
+    patch:
+      default:
+        target: 80%
+        only_pulls: true
+        informational: false
+    project:
+      ganit-core:
+        target: 80%
+        paths:
+          - crates/core/

--- a/docs/superpowers/plans/2026-04-18-ci-infrastructure-367-368.md
+++ b/docs/superpowers/plans/2026-04-18-ci-infrastructure-367-368.md
@@ -1,0 +1,245 @@
+# CI Infrastructure: nextest + Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `cargo test` with `cargo-nextest` for richer test output and inline PR annotations (#367), then add `cargo-llvm-cov` + codecov for per-PR coverage delta comments with an 80% gate on `ganit-core` (#368).
+
+**Architecture:** Two CI steps replace/extend the existing "Test" step. nextest runs first and writes JUnit XML; a separate coverage step runs llvm-cov and uploads LCOV to codecov.io. Both changes live entirely in `.github/workflows/ci.yml` and new config files.
+
+**Tech Stack:** cargo-nextest, cargo-llvm-cov, dorny/test-reporter GitHub Action, codecov/codecov-action
+
+**GitHub issues:** Closes #367 and #368 (sub-issues of epic #366)
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `.config/nextest.toml` | nextest CI profile — JUnit XML output path |
+| Modify | `.github/workflows/ci.yml` | Replace `cargo test`, add nextest + test-reporter + llvm-cov + codecov steps |
+| Create | `codecov.yml` | Coverage gate: 80% patch minimum on `ganit-core` |
+
+---
+
+## Task 1: Add nextest config file
+
+**Files:**
+- Create: `.config/nextest.toml`
+
+- [ ] **Step 1: Create the nextest config**
+
+```toml
+# .config/nextest.toml
+[profile.ci]
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"
+```
+
+- [ ] **Step 2: Verify nextest is installed locally and config is valid**
+
+```bash
+cargo install cargo-nextest --locked 2>/dev/null || true
+cargo nextest run --workspace --profile ci --no-run 2>&1 | head -5
+```
+
+Expected: something like `Compiling ...` or `Finished test` — no error about invalid config.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .config/nextest.toml
+git commit -m "chore: add nextest CI profile with JUnit XML output"
+```
+
+---
+
+## Task 2: Update CI to use nextest + test-reporter
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+Current "Test" step (lines 22-23):
+```yaml
+      - name: Test
+        run: cargo test --workspace
+```
+
+- [ ] **Step 1: Replace the Test step and add test-reporter**
+
+Replace the entire `Test` step with:
+
+```yaml
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Test
+        run: cargo nextest run --workspace --profile ci
+        env:
+          NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: ganit-core tests
+          path: target/nextest/ci/junit.xml
+          reporter: java-junit
+          fail-on-error: false
+```
+
+- [ ] **Step 2: Verify the full updated ci.yml is valid YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML valid"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 3: Run nextest locally to confirm all tests still pass**
+
+```bash
+cargo nextest run --workspace --profile ci 2>&1 | tail -5
+```
+
+Expected output ends with something like:
+```
+    Summary [  X.Xs] 2461 tests run: 2461 passed, 0 skipped
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "feat(ci): switch to cargo-nextest with JUnit XML and PR test annotations
+
+Closes #367"
+```
+
+---
+
+## Task 3: Add codecov.yml coverage gate
+
+**Files:**
+- Create: `codecov.yml`
+
+- [ ] **Step 1: Create the codecov config**
+
+```yaml
+# codecov.yml
+coverage:
+  status:
+    patch:
+      default:
+        target: 80%
+        only_pulls: true
+        informational: false
+    project:
+      ganit-core:
+        target: 80%
+        paths:
+          - crates/core/
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add codecov.yml
+git commit -m "chore: add codecov config with 80% coverage gate on ganit-core"
+```
+
+---
+
+## Task 4: Add llvm-cov + codecov steps to CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add llvm-cov install and coverage steps after the Test step**
+
+After the `Publish test results` step, add:
+
+```yaml
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage report
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+```
+
+- [ ] **Step 2: Verify YAML is still valid**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML valid"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 3: Run llvm-cov locally to verify it produces output**
+
+```bash
+cargo llvm-cov --workspace --lcov --output-path lcov.info 2>&1 | tail -3
+ls -lh lcov.info
+```
+
+Expected: `lcov.info` exists and is non-empty (several KB at minimum).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "feat(ci): add llvm-cov coverage measurement and codecov upload
+
+Closes #368"
+```
+
+---
+
+## Task 5: Open PR
+
+- [ ] **Step 1: Push branch and open PR**
+
+```bash
+gh pr create \
+  --repo tryganit/ganit-core \
+  --title "feat(ci): nextest + llvm-cov coverage — inline PR annotations and 80% gate" \
+  --assignee hhimanshu \
+  --body "$(cat <<'EOF'
+## Summary
+- Replaces `cargo test` with `cargo-nextest` for per-test timing and inline PR failure annotations (via JUnit XML + dorny/test-reporter)
+- Adds `cargo-llvm-cov` + codecov integration with an 80% coverage gate on `ganit-core`
+
+## What a failing test looks like in a PR now
+The `dorny/test-reporter` action parses JUnit XML and posts inline annotations on the PR diff showing exactly which file/line failed and what the expected vs actual values were.
+
+## Coverage PR comment
+codecov will comment on every PR with a per-crate coverage delta table.
+
+closes #367
+closes #368
+EOF
+)"
+gh pr edit --add-assignee hhimanshu
+```
+
+- [ ] **Step 2: Monitor CI**
+
+```bash
+gh run list --repo tryganit/ganit-core --limit 3
+```
+
+Wait for the run triggered by the PR push. If it fails:
+```bash
+gh run view <run-id> --log-failed --repo tryganit/ganit-core
+```
+
+Fix the root cause and push a new commit (do not amend).

--- a/docs/superpowers/plans/2026-04-18-conformance-badge-370.md
+++ b/docs/superpowers/plans/2026-04-18-conformance-badge-370.md
@@ -1,0 +1,303 @@
+# Conformance Badge + PR Comment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After every CI run, post a Google Sheets conformance table as a PR comment (with regression detection) and add a live badge to the README.
+
+**Architecture:** CI reads `target/conformance-report.json` (produced by issue #369), computes deltas against the main branch report, posts a PR comment via `gh pr comment`, and updates a Shields.io endpoint-based badge in `README.md`. Regressions (tests that passed on main but fail on the PR) cause CI to exit non-zero.
+
+**Tech Stack:** Bash CI script, `gh` CLI, Shields.io endpoint badges, GitHub Actions
+
+**GitHub issue:** Closes #370 (sub-issue of epic #366)
+
+**Prerequisites:** Issues #367 (nextest), #368 (coverage), #369 (conformance reporter) must be merged before this plan is implemented.
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `.github/scripts/post-conformance-comment.sh` | Read JSON, compute delta, post PR comment, fail on regression |
+| Modify | `.github/workflows/ci.yml` | Add steps: run reporter, download main baseline, call script |
+| Modify | `README.md` | Add conformance badge |
+
+---
+
+## Task 1: Write the comment script
+
+**Files:**
+- Create: `.github/scripts/post-conformance-comment.sh`
+
+- [ ] **Step 1: Create the scripts directory and write the script**
+
+```bash
+mkdir -p .github/scripts
+```
+
+```bash
+#!/usr/bin/env bash
+# .github/scripts/post-conformance-comment.sh
+#
+# Reads target/conformance-report.json, optionally compares to a baseline
+# (from main branch), posts a PR comment, and exits 1 on regressions.
+#
+# Usage:
+#   post-conformance-comment.sh <report.json> [baseline.json] [pr-number]
+#
+# Environment:
+#   GITHUB_REPOSITORY  — set automatically by GitHub Actions (owner/repo)
+#   GH_TOKEN           — set automatically by GitHub Actions
+
+set -euo pipefail
+
+REPORT="${1:-target/conformance-report.json}"
+BASELINE="${2:-}"
+PR_NUMBER="${3:-}"
+
+if [[ ! -f "$REPORT" ]]; then
+  echo "::warning::conformance-report.json not found at $REPORT — skipping comment"
+  exit 0
+fi
+
+# Parse JSON with pure bash (no jq dependency)
+total=$(grep '"total"'   "$REPORT" | grep -o '[0-9]*' | head -1)
+passed=$(grep '"passed"' "$REPORT" | grep -o '[0-9]*' | head -1)
+failed=$(grep '"failed"' "$REPORT" | grep -o '[0-9]*' | head -1)
+
+pct=$(awk "BEGIN { printf \"%.1f\", ($passed/$total)*100 }" 2>/dev/null || echo "?")
+
+# Build category table
+category_section=""
+while IFS= read -r line; do
+  if [[ "$line" =~ \"([a-z]+)\":[[:space:]]*\{[[:space:]]*\"passed\":[[:space:]]*([0-9]+),[[:space:]]*\"total\":[[:space:]]*([0-9]+) ]]; then
+    cat_name="${BASH_REMATCH[1]}"
+    cat_passed="${BASH_REMATCH[2]}"
+    cat_total="${BASH_REMATCH[3]}"
+    cat_pct=$(awk "BEGIN { printf \"%.1f\", ($cat_passed/$cat_total)*100 }" 2>/dev/null || echo "?")
+    suffix=""
+    if [[ "$cat_passed" -lt "$cat_total" ]]; then
+      suffix="  ← $(($cat_total - $cat_passed)) failing"
+    fi
+    category_section+="| ${cat_name^} | ${cat_passed}/${cat_total} | ${cat_pct}% |${suffix}"$'\n'
+  fi
+done < "$REPORT"
+
+# Regression detection
+regressions=0
+regression_section=""
+if [[ -n "$BASELINE" && -f "$BASELINE" ]]; then
+  baseline_passed=$(grep '"passed"' "$BASELINE" | grep -o '[0-9]*' | head -1)
+  if [[ "$passed" -lt "$baseline_passed" ]]; then
+    regressions=$(($baseline_passed - $passed))
+    regression_section="⚠️ **${regressions} regression(s) detected** — this PR breaks previously passing tests vs main."
+  fi
+fi
+
+# Build comment body
+comment="## Google Sheets Conformance
+
+ganit calculations match Google Sheets — ${passed}/${total} tests passing (${pct}%)
+
+| Category | Passed | Rate |
+|----------|--------|------|
+${category_section}
+
+**Total: ${passed}/${total} (${pct}%)**
+"
+
+if [[ -n "$regression_section" ]]; then
+  comment+="
+${regression_section}"
+fi
+
+comment+="
+<sub>Oracle: Google Sheets · Verified on every PR</sub>"
+
+# Post comment (only on actual PRs, not pushes to main)
+if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
+  echo "$comment" | gh pr comment "$PR_NUMBER" \
+    --repo "$GITHUB_REPOSITORY" \
+    --body-file - \
+    --edit-last 2>/dev/null || \
+  echo "$comment" | gh pr comment "$PR_NUMBER" \
+    --repo "$GITHUB_REPOSITORY" \
+    --body-file -
+fi
+
+echo "Conformance: ${passed}/${total} (${pct}%)"
+
+# Fail CI on regressions
+if [[ "$regressions" -gt 0 ]]; then
+  echo "::error::${regressions} Google Sheets conformance regression(s) detected"
+  exit 1
+fi
+```
+
+- [ ] **Step 2: Make it executable**
+
+```bash
+chmod +x .github/scripts/post-conformance-comment.sh
+```
+
+- [ ] **Step 3: Test locally (dry run — no PR comment posted)**
+
+```bash
+# First generate a report
+cargo test -p ganit-core --test conformance generate_conformance_report -- --nocapture 2>/dev/null
+
+# Run the script without a PR number (skips posting)
+bash .github/scripts/post-conformance-comment.sh target/conformance-report.json "" ""
+```
+
+Expected output: `Conformance: XXXX/XXXX (XX.X%)`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/scripts/post-conformance-comment.sh
+git commit -m "chore: add conformance comment script — posts GS match table to PRs, fails on regressions"
+```
+
+---
+
+## Task 2: Add CI steps for conformance reporting
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add conformance report steps to `ci.yml`**
+
+After the existing test step (nextest), add:
+
+```yaml
+      - name: Generate conformance report
+        run: cargo test -p ganit-core --test conformance generate_conformance_report -- --nocapture
+
+      - name: Download main-branch conformance baseline
+        run: |
+          gh run download \
+            --repo ${{ github.repository }} \
+            --name conformance-report \
+            --dir baseline/ \
+            2>/dev/null || echo "No baseline found (first run or main has no artifact)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Upload conformance report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-report
+          path: target/conformance-report.json
+          retention-days: 30
+
+      - name: Post conformance PR comment
+        if: github.event_name == 'pull_request'
+        run: |
+          bash .github/scripts/post-conformance-comment.sh \
+            target/conformance-report.json \
+            baseline/conformance-report.json \
+            ${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML valid"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "feat(ci): post Google Sheets conformance table on PRs with regression detection
+
+Closes #370"
+```
+
+---
+
+## Task 3: Add conformance badge to README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Read the current top of README.md to find where badges live**
+
+```bash
+head -10 README.md
+```
+
+- [ ] **Step 2: Add the conformance badge after existing badges**
+
+Find the line with existing badges (likely shields.io img tags or markdown badge syntax). After the last existing badge, add:
+
+```markdown
+[![Google Sheets Conformance](https://img.shields.io/badge/Google%20Sheets%20conformance-passing-brightgreen)](https://github.com/tryganit/ganit-core/actions)
+```
+
+Note: This is a static badge initially. It will show "passing" — the exact count can be made dynamic in a follow-up using a Shields.io endpoint badge once a public endpoint is set up. For now the static badge communicates the intent clearly.
+
+- [ ] **Step 3: Verify README renders correctly**
+
+```bash
+head -15 README.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add Google Sheets conformance badge to README"
+```
+
+---
+
+## Task 4: Open PR
+
+- [ ] **Step 1: Push and create PR**
+
+```bash
+gh pr create \
+  --repo tryganit/ganit-core \
+  --title "feat(ci): Google Sheets conformance badge + PR regression comment" \
+  --assignee hhimanshu \
+  --body "$(cat <<'EOF'
+## Summary
+- New script `.github/scripts/post-conformance-comment.sh` reads `target/conformance-report.json` and posts a conformance table on every PR
+- Regression detection: if this PR breaks previously passing tests vs main, CI fails with a clear error
+- Conformance report is uploaded as a CI artifact on every run (used as baseline for future PRs)
+- Google Sheets conformance badge added to README
+
+## Sample PR comment
+```
+## Google Sheets Conformance
+ganit calculations match Google Sheets — 2430/2461 tests passing (98.7%)
+
+| Category | Passed | Rate |
+|----------|--------|------|
+| Math | 418/420 | 99.5% |
+| Text | 342/342 | 100.0% |
+| ...
+```
+
+## Dependencies
+Requires #367, #368, #369 merged first.
+
+closes #370
+EOF
+)"
+gh pr edit --add-assignee hhimanshu
+```
+
+- [ ] **Step 2: Monitor CI**
+
+```bash
+gh run list --repo tryganit/ganit-core --limit 3
+```
+
+On failure: `gh run view <run-id> --log-failed --repo tryganit/ganit-core`

--- a/docs/superpowers/plans/2026-04-18-conformance-property-tests-373.md
+++ b/docs/superpowers/plans/2026-04-18-conformance-property-tests-373.md
@@ -1,0 +1,300 @@
+# Conformance-Driven Property Tests
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add property tests that verify `ganit(formula) ≈ Google Sheets oracle` across *generated* inputs for each function category — not just the fixed fixture rows. This catches regressions in functions that have oracle fixtures but limited hand-written edge cases.
+
+**Architecture:** A new `property_conformance.rs` integration test file. For each function category (math, text, logical, financial), proptest generates valid inputs and evaluates the formula through ganit, then asserts the result matches the *mathematical property* that the Google Sheets oracle implies (e.g. ABS always non-negative, ROUND precision, IF branching). This is not a live GS call — the properties are derived from the oracle behavior we've already confirmed in conformance tests.
+
+**Tech Stack:** proptest 1.x, ganit_core (evaluate, Value, ErrorKind)
+
+**GitHub issue:** Closes #373 (sub-issue of epic #366)
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `crates/core/tests/property_conformance.rs` | Conformance-driven property tests per milestone |
+
+---
+
+## Task 1: Create `property_conformance.rs`
+
+**Files:**
+- Create: `crates/core/tests/property_conformance.rs`
+
+- [ ] **Step 1: Write the file**
+
+```rust
+// crates/core/tests/property_conformance.rs
+//
+// Conformance-driven property tests: for each function confirmed by Google Sheets
+// oracle fixtures, verify that the mathematical property holds across generated inputs.
+//
+// These tests complement the fixed-row conformance tests in conformance.rs.
+// They catch regressions for inputs that don't appear in the fixture files.
+
+use ganit_core::{evaluate, Value};
+use proptest::prelude::*;
+use std::collections::HashMap;
+
+fn run(formula: &str) -> Value {
+    evaluate(formula, &HashMap::new())
+}
+
+fn run_n(formula: &str, var: &str, n: f64) -> Value {
+    let mut m = HashMap::new();
+    m.insert(var.to_string(), Value::Number(n));
+    evaluate(formula, &m)
+}
+
+fn run_s(formula: &str, var: &str, s: &str) -> Value {
+    let mut m = HashMap::new();
+    m.insert(var.to_string(), Value::Text(s.to_string()));
+    evaluate(formula, &m)
+}
+
+fn run_two(formula: &str, a: (&str, f64), b: (&str, f64)) -> Value {
+    let mut m = HashMap::new();
+    m.insert(a.0.to_string(), Value::Number(a.1));
+    m.insert(b.0.to_string(), Value::Number(b.1));
+    evaluate(formula, &m)
+}
+
+fn small_f64() -> impl Strategy<Value = f64> { -1e6f64..1e6f64 }
+fn pos_f64()   -> impl Strategy<Value = f64> { 1e-6f64..1e6f64 }
+fn ascii_str() -> impl Strategy<Value = String> { "[a-z]{0,20}" }
+
+// ─── M1: Math ────────────────────────────────────────────────────────────────
+
+proptest! {
+    // ABS: confirmed by m1/Math.xlsx — result is always >= 0
+    #[test]
+    fn m1_abs_non_negative(x in small_f64()) {
+        let r = run_n("=ABS(x)", "x", x);
+        if let Value::Number(n) = r {
+            prop_assert!(n >= 0.0, "ABS({}) = {} is negative", x, n);
+        }
+    }
+
+    // ROUND(x, n): confirmed by m1/Math.xlsx — result differs from x by less than 10^(-n)
+    #[test]
+    fn m1_round_precision(x in small_f64(), digits in 0i32..=5) {
+        let formula = format!("=ROUND(x, {})", digits);
+        let r = run_n(&formula, "x", x);
+        if let Value::Number(n) = r {
+            let tolerance = 10f64.powi(-digits) / 2.0 + 1e-9;
+            prop_assert!((n - x).abs() <= tolerance,
+                "ROUND({}, {}) = {} differs by {}", x, digits, n, (n-x).abs());
+        }
+    }
+
+    // SQRT(x): x >= 0 → result >= 0 and result^2 ≈ x
+    #[test]
+    fn m1_sqrt_inverse_square(x in pos_f64()) {
+        let r = run_n("=SQRT(x)", "x", x);
+        if let Value::Number(n) = r {
+            prop_assert!(n >= 0.0, "SQRT({}) = {} is negative", x, n);
+            prop_assert!((n * n - x).abs() / x.max(1.0) < 1e-9,
+                "SQRT({})^2 = {} (expected {})", x, n*n, x);
+        }
+    }
+
+    // MOD(a, b): result has same sign as b and |result| < |b|
+    #[test]
+    fn m1_mod_remainder_bounds(a in small_f64(), b in pos_f64()) {
+        let formula = format!("=MOD(x, {})", b);
+        let r = run_n(&formula, "x", a);
+        if let Value::Number(n) = r {
+            prop_assert!(n >= 0.0, "MOD({},{}) = {} is negative", a, b, n);
+            prop_assert!(n < b + 1e-9, "MOD({},{}) = {} >= b", a, b, n);
+        }
+    }
+
+    // POWER(x, 2) == x * x for small positive x
+    #[test]
+    fn m1_power_two_equals_square(x in 0.0f64..1000.0f64) {
+        let r = run_n("=POWER(x, 2)", "x", x);
+        if let Value::Number(n) = r {
+            prop_assert!((n - x * x).abs() < 1e-6,
+                "POWER({}, 2) = {} but x*x = {}", x, n, x*x);
+        }
+    }
+}
+
+// ─── M1: Text ────────────────────────────────────────────────────────────────
+
+proptest! {
+    // LEN: confirmed by m1/Text.xlsx — always >= 0
+    #[test]
+    fn m1_len_non_negative(s in ascii_str()) {
+        let r = run_s("=LEN(x)", "x", &s);
+        if let Value::Number(n) = r {
+            prop_assert!(n >= 0.0, "LEN({:?}) = {} is negative", s, n);
+        }
+    }
+
+    // LEN(s) == number of characters in s
+    #[test]
+    fn m1_len_equals_char_count(s in ascii_str()) {
+        let r = run_s("=LEN(x)", "x", &s);
+        if let Value::Number(n) = r {
+            prop_assert_eq!(n as usize, s.chars().count(),
+                "LEN({:?}) = {} but char count = {}", s, n, s.chars().count());
+        }
+    }
+
+    // LOWER: result is always lowercase
+    #[test]
+    fn m1_lower_result_is_lowercase(s in ascii_str()) {
+        let r = run_s("=LOWER(x)", "x", &s);
+        if let Value::Text(t) = r {
+            prop_assert_eq!(t, t.to_lowercase(),
+                "LOWER({:?}) = {:?} is not lowercase", s, t);
+        }
+    }
+
+    // UPPER: result is always uppercase
+    #[test]
+    fn m1_upper_result_is_uppercase(s in ascii_str()) {
+        let r = run_s("=UPPER(x)", "x", &s);
+        if let Value::Text(t) = r {
+            prop_assert_eq!(t, t.to_uppercase(),
+                "UPPER({:?}) = {:?} is not uppercase", s, t);
+        }
+    }
+}
+
+// ─── M1: Logical ─────────────────────────────────────────────────────────────
+
+proptest! {
+    // IF(TRUE, a, b) == a
+    #[test]
+    fn m1_if_true_picks_first(a in small_f64(), b in small_f64()) {
+        let formula = format!("=IF(TRUE, {}, {})", a, b);
+        let r = run(&formula);
+        if let Value::Number(n) = r {
+            prop_assert!((n - a).abs() < 1e-12,
+                "IF(TRUE,{},{}) = {} (expected {})", a, b, n, a);
+        }
+    }
+
+    // IF(FALSE, a, b) == b
+    #[test]
+    fn m1_if_false_picks_second(a in small_f64(), b in small_f64()) {
+        let formula = format!("=IF(FALSE, {}, {})", a, b);
+        let r = run(&formula);
+        if let Value::Number(n) = r {
+            prop_assert!((n - b).abs() < 1e-12,
+                "IF(FALSE,{},{}) = {} (expected {})", a, b, n, b);
+        }
+    }
+
+    // AND(TRUE, TRUE) == TRUE; AND(TRUE, FALSE) == FALSE
+    #[test]
+    fn m1_and_both_true(x in proptest::bool::ANY, y in proptest::bool::ANY) {
+        let tx = if x { "TRUE" } else { "FALSE" };
+        let ty = if y { "TRUE" } else { "FALSE" };
+        let formula = format!("=AND({},{})", tx, ty);
+        let r = run(&formula);
+        if let Value::Bool(b) = r {
+            prop_assert_eq!(b, x && y, "AND({},{}) = {} (expected {})", x, y, b, x&&y);
+        }
+    }
+
+    // OR(x, y) == x || y
+    #[test]
+    fn m1_or_semantics(x in proptest::bool::ANY, y in proptest::bool::ANY) {
+        let tx = if x { "TRUE" } else { "FALSE" };
+        let ty = if y { "TRUE" } else { "FALSE" };
+        let formula = format!("=OR({},{})", tx, ty);
+        let r = run(&formula);
+        if let Value::Bool(b) = r {
+            prop_assert_eq!(b, x || y, "OR({},{}) = {} (expected {})", x, y, b, x||y);
+        }
+    }
+}
+
+// ─── M2: Math ────────────────────────────────────────────────────────────────
+
+proptest! {
+    // SUMPRODUCT([a],[b]) == a*b for single-element arrays
+    // Approximated as: =a*b via operator
+    #[test]
+    fn m2_multiplication_commutative(a in small_f64(), b in small_f64()) {
+        let ab = run_two("=x*y", ("x", a), ("y", b));
+        let ba = run_two("=x*y", ("x", b), ("y", a));
+        prop_assert_eq!(ab, ba, "{}*{} != {}*{}", a, b, b, a);
+    }
+}
+```
+
+- [ ] **Step 2: Run all conformance-driven property tests**
+
+```bash
+cargo test -p ganit-core --test property_conformance -- --nocapture 2>&1 | tail -15
+```
+
+Expected: all tests pass. If any fail, the output shows the exact input and formula — investigate the evaluator for that function.
+
+- [ ] **Step 3: Check test count**
+
+```bash
+cargo test -p ganit-core --test property_conformance -- --list 2>&1 | grep "test$" | wc -l
+```
+
+Expected: at least 15 tests listed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/core/tests/property_conformance.rs
+git commit -m "test(proptest): conformance-driven property tests across m1-m2 functions
+
+For each function confirmed by Google Sheets oracle fixtures, verify the
+mathematical property holds across proptest-generated inputs:
+- Math: ABS non-negative, ROUND precision, SQRT inverse, MOD bounds, POWER
+- Text: LEN count, LOWER/UPPER case invariants
+- Logical: IF branching, AND/OR semantics
+- M2: multiplication commutativity
+
+Closes #373"
+```
+
+---
+
+## Task 2: Open PR
+
+- [ ] **Step 1: Push and create PR**
+
+```bash
+gh pr create \
+  --repo tryganit/ganit-core \
+  --title "test(proptest): conformance-driven property tests — ganit ≈ Google Sheets across generated inputs" \
+  --assignee hhimanshu \
+  --body "$(cat <<'EOF'
+## Summary
+Adds `property_conformance.rs` with property tests derived from what Google Sheets oracle fixtures confirm:
+
+- **M1 Math**: ABS non-negative, ROUND precision, SQRT inverse, MOD bounds, POWER correctness
+- **M1 Text**: LEN exact char count, LOWER/UPPER case invariants
+- **M1 Logical**: IF branching semantics, AND/OR truth table
+- **M2 Math**: multiplication commutativity
+
+These complement the fixed-row conformance tests by generating varied inputs that don't appear in the fixture files, catching regressions more broadly.
+
+closes #373
+EOF
+)"
+gh pr edit --add-assignee hhimanshu
+```
+
+- [ ] **Step 2: Monitor CI**
+
+```bash
+gh run list --repo tryganit/ganit-core --limit 3
+```
+
+On failure: `gh run view <run-id> --log-failed --repo tryganit/ganit-core`

--- a/docs/superpowers/plans/2026-04-18-conformance-reporter-369.md
+++ b/docs/superpowers/plans/2026-04-18-conformance-reporter-369.md
@@ -1,0 +1,366 @@
+# Conformance Reporter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the Google Sheets oracle conformance tests to emit a machine-readable JSON summary (`target/conformance-report.json`) after each run, enabling the badge and PR comment in issue #370.
+
+**Architecture:** Add a `collect_fixture_results` function alongside the existing `run_fixture` (which panics on failure). A new test `#[test] fn generate_conformance_report()` calls `collect_fixture_results` for every fixture file, aggregates into a `ConformanceReport` struct, and serializes to JSON. Known deviations (`#[ignore]`-tagged tests) are tracked via a separate `KNOWN_DEVIATIONS` slice. No new dependencies — JSON is hand-serialized.
+
+**Tech Stack:** Rust std, existing `calamine` + `ganit_core` dev-deps
+
+**GitHub issue:** Closes #369 (sub-issue of epic #366)
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `crates/core/tests/conformance_reporter.rs` | `collect_fixture_results`, `ConformanceReport`, JSON serializer, known-deviation list |
+| Modify | `crates/core/tests/conformance.rs` | Add `mod conformance_reporter;` and the `generate_conformance_report` test |
+
+---
+
+## Task 1: Create `conformance_reporter.rs`
+
+**Files:**
+- Create: `crates/core/tests/conformance_reporter.rs`
+
+- [ ] **Step 1: Write the reporter module**
+
+```rust
+// crates/core/tests/conformance_reporter.rs
+//
+// Collects pass/fail counts per fixture and writes target/conformance-report.json.
+// Called by the generate_conformance_report test in conformance.rs.
+
+use calamine::{open_workbook, Data, Reader, Xlsx};
+use ganit_core::{evaluate, ErrorKind, Value};
+use std::collections::HashMap;
+use std::path::Path;
+
+// Re-use the oracle helpers from the parent module via super::
+// (parse_error_string, oracle_to_value, values_match, is_volatile_formula
+//  are defined in conformance.rs and visible here through the test module tree)
+
+#[derive(Default, Debug)]
+pub struct CategoryResult {
+    pub passed: usize,
+    pub total: usize,
+    pub failures: Vec<String>,
+}
+
+#[derive(Default, Debug)]
+pub struct ConformanceReport {
+    pub by_category: HashMap<String, CategoryResult>,
+    pub known_deviations: Vec<KnownDeviation>,
+}
+
+#[derive(Debug)]
+pub struct KnownDeviation {
+    pub formula: &'static str,
+    pub reason: &'static str,
+}
+
+impl ConformanceReport {
+    pub fn total_passed(&self) -> usize {
+        self.by_category.values().map(|r| r.passed).sum()
+    }
+    pub fn total_tests(&self) -> usize {
+        self.by_category.values().map(|r| r.total).sum()
+    }
+    pub fn total_failed(&self) -> usize {
+        self.total_tests() - self.total_passed()
+    }
+
+    pub fn to_json(&self) -> String {
+        let mut s = String::new();
+        s.push_str("{\n");
+        s.push_str(&format!("  \"total\": {},\n", self.total_tests()));
+        s.push_str(&format!("  \"passed\": {},\n", self.total_passed()));
+        s.push_str(&format!("  \"failed\": {},\n", self.total_failed()));
+        s.push_str("  \"by_category\": {\n");
+        let mut cats: Vec<(&String, &CategoryResult)> = self.by_category.iter().collect();
+        cats.sort_by_key(|(k, _)| k.as_str());
+        for (i, (cat, result)) in cats.iter().enumerate() {
+            let comma = if i + 1 < cats.len() { "," } else { "" };
+            s.push_str(&format!(
+                "    \"{}\": {{ \"passed\": {}, \"total\": {} }}{}\n",
+                cat, result.passed, result.total, comma
+            ));
+        }
+        s.push_str("  },\n");
+        s.push_str("  \"known_deviations\": [\n");
+        for (i, dev) in self.known_deviations.iter().enumerate() {
+            let comma = if i + 1 < self.known_deviations.len() { "," } else { "" };
+            s.push_str(&format!(
+                "    {{ \"formula\": \"{}\", \"reason\": \"{}\" }}{}\n",
+                dev.formula.replace('"', "\\\""),
+                dev.reason.replace('"', "\\\""),
+                comma
+            ));
+        }
+        s.push_str("  ]\n");
+        s.push_str("}\n");
+        s
+    }
+}
+
+/// Known deviations: cases where ganit intentionally differs from Google Sheets.
+/// These are excluded from failure counts but documented in the report.
+pub const KNOWN_DEVIATIONS: &[KnownDeviation] = &[
+    // Add entries here as they are discovered. Format:
+    // KnownDeviation { formula: "=RATE(4*12,-200,8000)", reason: "floating-point iteration limit differs" },
+];
+
+/// Collect pass/fail for a single fixture file. Returns results without panicking.
+/// `category` is the logical name used in the JSON (e.g. "math", "text").
+pub fn collect_fixture_results(
+    path: &Path,
+    category: &str,
+    report: &mut ConformanceReport,
+) {
+    if !path.exists() {
+        return;
+    }
+
+    let mut workbook: Xlsx<_> = match open_workbook(path) {
+        Ok(w) => w,
+        Err(_) => return,
+    };
+
+    let sheet_names: Vec<String> = workbook.sheet_names().to_vec();
+    let vars: HashMap<String, Value> = HashMap::new();
+    let entry = report.by_category.entry(category.to_string()).or_default();
+
+    for sheet_name in &sheet_names {
+        let range = match workbook.worksheet_range(sheet_name) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+
+        for (row_idx, row) in range.rows().enumerate().skip(1) {
+            if row.len() < 3 {
+                continue;
+            }
+            let formula = match &row[1] {
+                Data::String(s) => s.as_str(),
+                _ => continue,
+            };
+            let expected = match super::oracle_to_value(&row[2]) {
+                Some(v) => v,
+                None => continue,
+            };
+            if super::is_volatile_formula(formula) {
+                continue;
+            }
+
+            entry.total += 1;
+            let actual = evaluate(formula, &vars);
+            if super::values_match(&actual, &expected) {
+                entry.passed += 1;
+            } else {
+                let desc = match &row[0] { Data::String(s) => s.clone(), _ => String::new() };
+                entry.failures.push(format!(
+                    "[{}] row {} {}: formula={} expected={:?} got={:?}",
+                    sheet_name, row_idx + 2, desc, formula, expected, actual
+                ));
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles (it won't yet — `super::` references need the module wired in first; skip compile check, proceed to Task 2)**
+
+---
+
+## Task 2: Wire the reporter into `conformance.rs`
+
+**Files:**
+- Modify: `crates/core/tests/conformance.rs`
+
+- [ ] **Step 1: Add module declaration after the existing imports at the top of `conformance.rs`**
+
+After the `use` statements (around line 15), add:
+
+```rust
+mod conformance_reporter;
+use conformance_reporter::{collect_fixture_results, ConformanceReport, KNOWN_DEVIATIONS};
+```
+
+- [ ] **Step 2: Add the `generate_conformance_report` test at the bottom of `conformance.rs`**
+
+After the last `conformance_test!` macro call (after line 261), add:
+
+```rust
+// ---------------------------------------------------------------------------
+// Conformance report generator — writes target/conformance-report.json
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generate_conformance_report() {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let mut report = ConformanceReport::default();
+    report.known_deviations = KNOWN_DEVIATIONS.to_vec();
+
+    // m1 fixtures
+    collect_fixture_results(&fixture("m1", "Math.xlsx"),        "math",        &mut report);
+    collect_fixture_results(&fixture("m1", "Logical.xlsx"),     "logical",     &mut report);
+    collect_fixture_results(&fixture("m1", "Info.xlsx"),        "info",        &mut report);
+    collect_fixture_results(&fixture("m1", "Statistical.xlsx"), "statistical", &mut report);
+    collect_fixture_results(&fixture("m1", "Operator.xlsx"),    "operator",    &mut report);
+    collect_fixture_results(&fixture("m1", "Text.xlsx"),        "text",        &mut report);
+
+    // m2 fixtures
+    collect_fixture_results(&fixture("m2", "Date.xlsx"),        "date",        &mut report);
+    collect_fixture_results(&fixture("m2", "Engineering.xlsx"), "engineering", &mut report);
+    collect_fixture_results(&fixture("m2", "Info.xlsx"),        "info",        &mut report);
+    collect_fixture_results(&fixture("m2", "Logical.xlsx"),     "logical",     &mut report);
+    collect_fixture_results(&fixture("m2", "Lookup.xlsx"),      "lookup",      &mut report);
+    collect_fixture_results(&fixture("m2", "Math.xlsx"),        "math",        &mut report);
+    collect_fixture_results(&fixture("m2", "Statistical.xlsx"), "statistical", &mut report);
+    collect_fixture_results(&fixture("m2", "Text.xlsx"),        "text",        &mut report);
+
+    // m3 fixtures
+    collect_fixture_results(&fixture("m3", "Database.xlsx"),    "database",    &mut report);
+    collect_fixture_results(&fixture("m3", "Engineering.xlsx"), "engineering", &mut report);
+    collect_fixture_results(&fixture("m3", "Financial.xlsx"),   "financial",   &mut report);
+    collect_fixture_results(&fixture("m3", "Info.xlsx"),        "info",        &mut report);
+    collect_fixture_results(&fixture("m3", "Lookup.xlsx"),      "lookup",      &mut report);
+    collect_fixture_results(&fixture("m3", "Math.xlsx"),        "math",        &mut report);
+    collect_fixture_results(&fixture("m3", "Statistical.xlsx"), "statistical", &mut report);
+
+    // m4 fixtures
+    collect_fixture_results(&fixture("m4", "Array.xlsx"),       "array",       &mut report);
+    collect_fixture_results(&fixture("m4", "Filter.xlsx"),      "filter",      &mut report);
+    collect_fixture_results(&fixture("m4", "Info.xlsx"),        "info",        &mut report);
+    collect_fixture_results(&fixture("m4", "Logical.xlsx"),     "logical",     &mut report);
+    collect_fixture_results(&fixture("m4", "Lookup.xlsx"),      "lookup",      &mut report);
+    collect_fixture_results(&fixture("m4", "Math.xlsx"),        "math",        &mut report);
+    collect_fixture_results(&fixture("m4", "Operator.xlsx"),    "operator",    &mut report);
+
+    // Write JSON to target/
+    let out_dir = manifest.join("../../target");
+    std::fs::create_dir_all(&out_dir).ok();
+    let out_path = out_dir.join("conformance-report.json");
+    std::fs::write(&out_path, report.to_json())
+        .expect("failed to write conformance-report.json");
+
+    println!("conformance-report.json written to {}", out_path.display());
+    println!(
+        "Total: {}/{} passed ({} failed)",
+        report.total_passed(),
+        report.total_tests(),
+        report.total_failed(),
+    );
+}
+```
+
+Note: `KNOWN_DEVIATIONS.to_vec()` requires `KnownDeviation` to implement `Clone`. Add `#[derive(Clone)]` to `KnownDeviation` in `conformance_reporter.rs`.
+
+- [ ] **Step 3: Add `#[derive(Clone)]` to `KnownDeviation` in `conformance_reporter.rs`**
+
+Change:
+```rust
+#[derive(Debug)]
+pub struct KnownDeviation {
+```
+to:
+```rust
+#[derive(Debug, Clone)]
+pub struct KnownDeviation {
+```
+
+- [ ] **Step 4: Compile-check**
+
+```bash
+cargo test -p ganit-core --test conformance generate_conformance_report --no-run 2>&1 | tail -10
+```
+
+Expected: `Compiling ganit-core` then `Finished` — no errors.
+
+- [ ] **Step 5: Run the report generator**
+
+```bash
+cargo test -p ganit-core --test conformance generate_conformance_report -- --nocapture 2>&1 | tail -5
+```
+
+Expected output ends with:
+```
+conformance-report.json written to .../target/conformance-report.json
+Total: XXXX/XXXX passed (X failed)
+```
+
+- [ ] **Step 6: Inspect the JSON output**
+
+```bash
+cat target/conformance-report.json
+```
+
+Verify it is valid JSON with `total`, `passed`, `failed`, `by_category`, and `known_deviations` keys.
+
+- [ ] **Step 7: Run existing conformance tests to confirm nothing regressed**
+
+```bash
+cargo test -p ganit-core --test conformance 2>&1 | tail -5
+```
+
+Expected: all existing tests pass (same count as before this change).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/core/tests/conformance_reporter.rs crates/core/tests/conformance.rs
+git commit -m "feat(conformance): emit JSON summary report per-category vs Google Sheets
+
+Adds generate_conformance_report test that writes target/conformance-report.json
+with per-category pass/fail counts and known deviations list.
+
+Closes #369"
+```
+
+---
+
+## Task 3: Open PR
+
+- [ ] **Step 1: Push and create PR**
+
+```bash
+gh pr create \
+  --repo tryganit/ganit-core \
+  --title "feat(conformance): emit structured JSON summary — per-category pass/fail vs Google Sheets" \
+  --assignee hhimanshu \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds `conformance_reporter.rs` with `collect_fixture_results` and `ConformanceReport`
+- New `generate_conformance_report` test writes `target/conformance-report.json` after running all 30 fixture files
+- JSON format: total, passed, failed, by_category breakdown, known_deviations list
+- Known deviations are tracked separately and do not count as failures
+
+## Sample output
+\`\`\`json
+{
+  "total": 2461, "passed": 2430, "failed": 8,
+  "by_category": {
+    "math": { "passed": 418, "total": 420 },
+    ...
+  },
+  "known_deviations": []
+}
+\`\`\`
+
+closes #369
+EOF
+)"
+gh pr edit --add-assignee hhimanshu
+```
+
+- [ ] **Step 2: Monitor CI**
+
+```bash
+gh run list --repo tryganit/ganit-core --limit 3
+```
+
+On failure: `gh run view <run-id> --log-failed --repo tryganit/ganit-core`

--- a/docs/superpowers/plans/2026-04-18-proptest-expansion-371.md
+++ b/docs/superpowers/plans/2026-04-18-proptest-expansion-371.md
@@ -1,0 +1,340 @@
+# Proptest Expansion: Idempotency, Round-trips, Error Propagation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three new *classes* of property-based tests: idempotency (applying a function twice gives the same result as once), round-trips (composing inverse functions returns the original value), and error propagation (errors passed to non-error-handling functions always produce errors). These properties are mathematical invariants — any violation is a bug, independent of the specific input.
+
+**Architecture:** Expand `property_text.rs` and `property_math.rs` with new proptest blocks. Create `property_error_propagation.rs` for the error class. All tests use the existing `proptest` + `ganit_core` dev-dependencies. Error values are injected as variables using `evaluate(formula, &vars)` where `vars` contains a `Value::Error(ErrorKind::...)` entry.
+
+**Tech Stack:** proptest 1.x, ganit_core (evaluate, Value, ErrorKind)
+
+**GitHub issue:** Closes #371 (sub-issue of epic #366)
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Modify | `crates/core/tests/property_text.rs` | Add idempotency properties for text functions |
+| Modify | `crates/core/tests/property_math.rs` | Add idempotency and monotonicity properties |
+| Create | `crates/core/tests/property_error_propagation.rs` | Error propagation across all function categories |
+| Modify | `crates/core/tests/conformance.rs` | Add `mod property_error_propagation;` (if needed by test harness — check if it auto-discovers) |
+
+Note: Rust's test harness auto-discovers `.rs` files in `tests/` only if they are separate integration test files (not `mod` declarations). Since `property_error_propagation.rs` is a new top-level file in `tests/`, it is discovered automatically — no `mod` declaration needed.
+
+---
+
+## Task 1: Add idempotency tests to `property_text.rs`
+
+**Files:**
+- Modify: `crates/core/tests/property_text.rs`
+
+- [ ] **Step 1: Write the failing tests first**
+
+Read the current end of `crates/core/tests/property_text.rs` to find the closing `}` of the `proptest!` block, then add these properties inside that block (before the closing `}`):
+
+```rust
+    // Idempotency: LOWER(LOWER(s)) == LOWER(s)
+    #[test]
+    fn lower_idempotent(s in ascii_string()) {
+        let vars: HashMap<String, Value> = [(
+            "s".to_string(), Value::Text(s.clone()),
+        )].into_iter().collect();
+        let once = evaluate("=LOWER(s)", &vars);
+        if let Value::Text(t) = &once {
+            let vars2: HashMap<String, Value> = [(
+                "s".to_string(), Value::Text(t.clone()),
+            )].into_iter().collect();
+            let twice = evaluate("=LOWER(s)", &vars2);
+            prop_assert_eq!(once, twice, "LOWER not idempotent on {:?}", s);
+        }
+    }
+
+    // Idempotency: UPPER(UPPER(s)) == UPPER(s)
+    #[test]
+    fn upper_idempotent(s in ascii_string()) {
+        let vars: HashMap<String, Value> = [(
+            "s".to_string(), Value::Text(s.clone()),
+        )].into_iter().collect();
+        let once = evaluate("=UPPER(s)", &vars);
+        if let Value::Text(t) = &once {
+            let vars2: HashMap<String, Value> = [(
+                "s".to_string(), Value::Text(t.clone()),
+            )].into_iter().collect();
+            let twice = evaluate("=UPPER(s)", &vars2);
+            prop_assert_eq!(once, twice, "UPPER not idempotent on {:?}", s);
+        }
+    }
+
+    // LEN is non-negative for any string
+    #[test]
+    fn len_non_negative(s in ascii_string()) {
+        let vars: HashMap<String, Value> = [(
+            "s".to_string(), Value::Text(s.clone()),
+        )].into_iter().collect();
+        let result = evaluate("=LEN(s)", &vars);
+        if let Value::Number(n) = result {
+            prop_assert!(n >= 0.0, "LEN returned negative for {:?}", s);
+        }
+    }
+
+    // CONCATENATE length: LEN(CONCATENATE(a, b)) == LEN(a) + LEN(b)
+    // (Already tested but add explicit assertion message)
+    #[test]
+    fn concatenate_preserves_total_length(a in ascii_string(), b in ascii_string()) {
+        let vars: HashMap<String, Value> = [
+            ("a".to_string(), Value::Text(a.clone())),
+            ("b".to_string(), Value::Text(b.clone())),
+        ].into_iter().collect();
+        let ab_len = evaluate("=LEN(CONCATENATE(a,b))", &vars);
+        let a_len  = evaluate("=LEN(a)", &vars);
+        let b_len  = evaluate("=LEN(b)", &vars);
+        if let (Value::Number(total), Value::Number(la), Value::Number(lb)) = (ab_len, a_len, b_len) {
+            prop_assert_eq!(total, la + lb,
+                "LEN(CONCATENATE({:?},{:?})) != LEN(a)+LEN(b)", a, b);
+        }
+    }
+```
+
+- [ ] **Step 2: Run to verify tests pass**
+
+```bash
+cargo test -p ganit-core --test property_text 2>&1 | tail -8
+```
+
+Expected: all tests pass including new ones.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/core/tests/property_text.rs
+git commit -m "test(proptest): add idempotency and length properties for text functions"
+```
+
+---
+
+## Task 2: Add idempotency and monotonicity to `property_math.rs`
+
+**Files:**
+- Modify: `crates/core/tests/property_math.rs`
+
+- [ ] **Step 1: Add new properties inside the existing `proptest!` block**
+
+Append before the closing `}` of the `proptest!` block:
+
+```rust
+    // Idempotency: ABS(ABS(x)) == ABS(x)
+    #[test]
+    fn abs_idempotent(x in finite_f64()) {
+        let once  = run_vars("=ABS(x)", vec![("x", x)]);
+        let twice = run_vars("=ABS(ABS(x))", vec![("x", x)]);
+        prop_assert_eq!(once.clone(), twice,
+            "ABS not idempotent on {}", x);
+    }
+
+    // Monotonicity: MAX(a,b) >= a and MAX(a,b) >= b
+    #[test]
+    fn max_dominates_both(a in small_f64(), b in small_f64()) {
+        let max = run_vars("=MAX(x, y)", vec![("x", a), ("y", b)]);
+        if let Value::Number(m) = max {
+            prop_assert!(m >= a - 1e-12, "MAX({},{}) = {} < a", a, b, m);
+            prop_assert!(m >= b - 1e-12, "MAX({},{}) = {} < b", a, b, m);
+        }
+    }
+
+    // Monotonicity: MIN(a,b) <= a and MIN(a,b) <= b
+    #[test]
+    fn min_dominated_by_both(a in small_f64(), b in small_f64()) {
+        let min = run_vars("=MIN(x, y)", vec![("x", a), ("y", b)]);
+        if let Value::Number(m) = min {
+            prop_assert!(m <= a + 1e-12, "MIN({},{}) = {} > a", a, b, m);
+            prop_assert!(m <= b + 1e-12, "MIN({},{}) = {} > b", a, b, m);
+        }
+    }
+
+    // Round-trip: EXP(LN(x)) ≈ x for x > 0
+    #[test]
+    fn exp_ln_roundtrip(x in 1e-6f64..1e6f64) {
+        let result = run_vars("=EXP(LN(x))", vec![("x", x)]);
+        if let Value::Number(n) = result {
+            prop_assert!((n - x).abs() / x.abs().max(1.0) < 1e-9,
+                "EXP(LN({})) = {} (delta {})", x, n, (n-x).abs());
+        }
+    }
+
+    // ABS is always >= 0
+    #[test]
+    fn abs_always_non_negative(x in finite_f64()) {
+        let result = run_vars("=ABS(x)", vec![("x", x)]);
+        if let Value::Number(n) = result {
+            prop_assert!(n >= 0.0, "ABS({}) returned {}", x, n);
+        }
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cargo test -p ganit-core --test property_math 2>&1 | tail -8
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/core/tests/property_math.rs
+git commit -m "test(proptest): add idempotency, monotonicity, and round-trip properties for math functions"
+```
+
+---
+
+## Task 3: Create `property_error_propagation.rs`
+
+**Files:**
+- Create: `crates/core/tests/property_error_propagation.rs`
+
+Error propagation rule: for any non-error-handling function `f`, if an input is an error value, the output should also be an error value. We inject errors as variables.
+
+- [ ] **Step 1: Write the file**
+
+```rust
+// crates/core/tests/property_error_propagation.rs
+//
+// Verifies that non-error-handling functions propagate error values rather
+// than silently resolving them. This is a correctness invariant derived from
+// Google Sheets behavior: errors are contagious.
+
+use ganit_core::{evaluate, ErrorKind, Value};
+use proptest::prelude::*;
+use std::collections::HashMap;
+
+fn error_value() -> impl Strategy<Value = Value> {
+    prop_oneof![
+        Just(Value::Error(ErrorKind::Value)),
+        Just(Value::Error(ErrorKind::NA)),
+        Just(Value::Error(ErrorKind::DivByZero)),
+        Just(Value::Error(ErrorKind::Num)),
+    ]
+}
+
+fn run_with_error(formula: &str, var: &str, err: Value) -> Value {
+    let mut vars = HashMap::new();
+    vars.insert(var.to_string(), err);
+    evaluate(formula, &vars)
+}
+
+fn is_error(v: &Value) -> bool {
+    matches!(v, Value::Error(_))
+}
+
+proptest! {
+    // Math functions propagate errors
+    #[test]
+    fn abs_propagates_error(e in error_value()) {
+        let result = run_with_error("=ABS(x)", "x", e);
+        prop_assert!(is_error(&result), "ABS did not propagate error, got {:?}", result);
+    }
+
+    #[test]
+    fn sqrt_propagates_error(e in error_value()) {
+        let result = run_with_error("=SQRT(x)", "x", e);
+        prop_assert!(is_error(&result), "SQRT did not propagate error, got {:?}", result);
+    }
+
+    #[test]
+    fn ln_propagates_error(e in error_value()) {
+        let result = run_with_error("=LN(x)", "x", e);
+        prop_assert!(is_error(&result), "LN did not propagate error, got {:?}", result);
+    }
+
+    #[test]
+    fn exp_propagates_error(e in error_value()) {
+        let result = run_with_error("=EXP(x)", "x", e);
+        prop_assert!(is_error(&result), "EXP did not propagate error, got {:?}", result);
+    }
+
+    #[test]
+    fn round_propagates_error(e in error_value()) {
+        let result = run_with_error("=ROUND(x, 2)", "x", e);
+        prop_assert!(is_error(&result), "ROUND did not propagate error, got {:?}", result);
+    }
+
+    // Text functions propagate errors
+    #[test]
+    fn len_propagates_error(e in error_value()) {
+        let result = run_with_error("=LEN(x)", "x", e);
+        prop_assert!(is_error(&result), "LEN did not propagate error, got {:?}", result);
+    }
+
+    #[test]
+    fn upper_propagates_error(e in error_value()) {
+        let result = run_with_error("=UPPER(x)", "x", e);
+        prop_assert!(is_error(&result), "UPPER did not propagate error, got {:?}", result);
+    }
+
+    #[test]
+    fn lower_propagates_error(e in error_value()) {
+        let result = run_with_error("=LOWER(x)", "x", e);
+        prop_assert!(is_error(&result), "LOWER did not propagate error, got {:?}", result);
+    }
+
+    #[test]
+    fn trim_propagates_error(e in error_value()) {
+        let result = run_with_error("=TRIM(x)", "x", e);
+        prop_assert!(is_error(&result), "TRIM did not propagate error, got {:?}", result);
+    }
+}
+```
+
+- [ ] **Step 2: Run to see if they pass or reveal bugs**
+
+```bash
+cargo test -p ganit-core --test property_error_propagation -- --nocapture 2>&1 | tail -15
+```
+
+Expected: all 9 tests pass. If any fail, the failure output will show the exact error variant and function — investigate the evaluator for that function and fix the propagation before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/core/tests/property_error_propagation.rs
+git commit -m "test(proptest): add error propagation property tests for math and text functions
+
+Verifies that ABS, SQRT, LN, EXP, ROUND, LEN, UPPER, LOWER, TRIM propagate
+error values instead of silently resolving them. Matches Google Sheets behavior.
+
+Closes #371"
+```
+
+---
+
+## Task 4: Open PR
+
+- [ ] **Step 1: Push and create PR**
+
+```bash
+gh pr create \
+  --repo tryganit/ganit-core \
+  --title "test(proptest): idempotency, round-trips, and error propagation properties" \
+  --assignee hhimanshu \
+  --body "$(cat <<'EOF'
+## Summary
+- `property_text.rs`: idempotency for LOWER/UPPER, LEN non-negative, CONCATENATE length preservation
+- `property_math.rs`: ABS idempotency, MAX/MIN monotonicity, EXP(LN(x)) ≈ x round-trip
+- `property_error_propagation.rs` (new): verifies ABS, SQRT, LN, EXP, ROUND, LEN, UPPER, LOWER, TRIM all propagate error values — matches Google Sheets behavior where errors are contagious
+
+closes #371
+EOF
+)"
+gh pr edit --add-assignee hhimanshu
+```
+
+- [ ] **Step 2: Monitor CI**
+
+```bash
+gh run list --repo tryganit/ganit-core --limit 3
+```
+
+On failure: `gh run view <run-id> --log-failed --repo tryganit/ganit-core`

--- a/docs/superpowers/plans/2026-04-18-proptest-new-categories-372.md
+++ b/docs/superpowers/plans/2026-04-18-proptest-new-categories-372.md
@@ -1,0 +1,370 @@
+# Proptest New Categories: Date, Lookup, Array
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add property-based tests for date, lookup, and array functions — three categories currently not covered by any property tests. These tests verify mathematical invariants that hold independently of specific input values.
+
+**Architecture:** Three new integration test files, one per category, each following the existing pattern in `property_math.rs` (a `run` helper + `proptest!` block). No new dependencies — `proptest` and `ganit_core` are already dev-dependencies.
+
+**Tech Stack:** proptest 1.x, ganit_core (evaluate, Value, ErrorKind), chrono (for understanding valid date ranges)
+
+**GitHub issue:** Closes #372 (sub-issue of epic #366)
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `crates/core/tests/property_date.rs` | Date arithmetic invariants |
+| Create | `crates/core/tests/property_lookup.rs` | Lookup range invariants |
+| Create | `crates/core/tests/property_array.rs` | Array length and element-wise invariants |
+
+All three files are auto-discovered by Rust's test harness as integration test files — no `mod` declarations needed.
+
+---
+
+## Task 1: Create `property_date.rs`
+
+**Files:**
+- Create: `crates/core/tests/property_date.rs`
+
+Before writing, check what date functions are available:
+```bash
+ls /path/to/crates/core/src/eval/functions/date/ 2>/dev/null || \
+  grep -r "fn date\|fn year\|fn month\|fn day\|fn datedif\|fn today\|fn now" \
+    crates/core/src/ --include="*.rs" -l
+```
+
+- [ ] **Step 1: Write `property_date.rs`**
+
+```rust
+// crates/core/tests/property_date.rs
+//
+// Property-based tests for date functions.
+// Verifies mathematical invariants that hold for any valid date input.
+
+use ganit_core::{evaluate, Value};
+use proptest::prelude::*;
+use std::collections::HashMap;
+
+fn run(formula: &str) -> Value {
+    evaluate(formula, &HashMap::new())
+}
+
+fn run_num(formula: &str, var: &str, n: f64) -> Value {
+    let mut vars = HashMap::new();
+    vars.insert(var.to_string(), Value::Number(n));
+    evaluate(formula, &vars)
+}
+
+// Valid Gregorian years in a reasonable range (1900-2100)
+fn valid_year() -> impl Strategy<Value = i32> {
+    1900i32..=2100
+}
+
+// Valid months 1-12
+fn valid_month() -> impl Strategy<Value = i32> {
+    1i32..=12
+}
+
+// Valid days 1-28 (safe for all months including February)
+fn valid_day() -> impl Strategy<Value = i32> {
+    1i32..=28
+}
+
+proptest! {
+    // DATE(y,m,d): YEAR of the result equals y, MONTH equals m, DAY equals d
+    // (for unambiguous inputs: day 1-28, month 1-12, year 1900-2100)
+    #[test]
+    fn date_year_month_day_roundtrip(
+        y in valid_year(),
+        m in valid_month(),
+        d in valid_day(),
+    ) {
+        let formula = format!("=DATE({},{},{})", y, m, d);
+        let date_result = run(&formula);
+        // DATE returns a Value::Date or Value::Number (serial date)
+        // We verify by extracting YEAR, MONTH, DAY from the result
+        match date_result {
+            Value::Date(serial) | Value::Number(serial) => {
+                let year_f  = run(&format!("=YEAR(DATE({},{},{}))", y, m, d));
+                let month_f = run(&format!("=MONTH(DATE({},{},{}))", y, m, d));
+                let day_f   = run(&format!("=DAY(DATE({},{},{}))", y, m, d));
+                if let (Value::Number(yr), Value::Number(mo), Value::Number(dy)) =
+                    (year_f, month_f, day_f)
+                {
+                    prop_assert_eq!(yr as i32, y, "YEAR(DATE({},{},{})) mismatch", y, m, d);
+                    prop_assert_eq!(mo as i32, m, "MONTH(DATE({},{},{})) mismatch", y, m, d);
+                    prop_assert_eq!(dy as i32, d, "DAY(DATE({},{},{})) mismatch", y, m, d);
+                }
+            }
+            _ => {} // if DATE errors on some inputs, skip — don't fail the property
+        }
+    }
+
+    // DATEDIF(start, end, "D") >= 0 when end >= start
+    #[test]
+    fn datedif_days_non_negative(
+        y1 in valid_year(),
+        m1 in valid_month(),
+        d1 in valid_day(),
+        delta in 0i32..=365,
+    ) {
+        // end = start + delta days (guaranteed end >= start)
+        let start = format!("DATE({},{},{})", y1, m1, d1);
+        let end   = format!("DATE({},{},{}) + {}", y1, m1, d1, delta);
+        let formula = format!("=DATEDIF({}, {}, \"D\")", start, end);
+        let result = run(&formula);
+        if let Value::Number(n) = result {
+            prop_assert!(n >= 0.0,
+                "DATEDIF returned {} for delta={}", n, delta);
+            prop_assert!((n - delta as f64).abs() < 1.0,
+                "DATEDIF days={} but expected delta={}", n, delta);
+        }
+    }
+
+    // YEAR extracts a value in [1900, 2100] for valid dates in that range
+    #[test]
+    fn year_within_range(y in valid_year(), m in valid_month(), d in valid_day()) {
+        let result = run(&format!("=YEAR(DATE({},{},{}))", y, m, d));
+        if let Value::Number(n) = result {
+            prop_assert!(n >= 1900.0 && n <= 2100.0,
+                "YEAR={} out of expected range for DATE({},{},{})", n, y, m, d);
+        }
+    }
+
+    // MONTH always in [1, 12]
+    #[test]
+    fn month_in_valid_range(y in valid_year(), m in valid_month(), d in valid_day()) {
+        let result = run(&format!("=MONTH(DATE({},{},{}))", y, m, d));
+        if let Value::Number(n) = result {
+            prop_assert!(n >= 1.0 && n <= 12.0,
+                "MONTH={} out of [1,12] for DATE({},{},{})", n, y, m, d);
+        }
+    }
+
+    // DAY always in [1, 31]
+    #[test]
+    fn day_in_valid_range(y in valid_year(), m in valid_month(), d in valid_day()) {
+        let result = run(&format!("=DAY(DATE({},{},{}))", y, m, d));
+        if let Value::Number(n) = result {
+            prop_assert!(n >= 1.0 && n <= 31.0,
+                "DAY={} out of [1,31] for DATE({},{},{})", n, y, m, d);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify**
+
+```bash
+cargo test -p ganit-core --test property_date -- --nocapture 2>&1 | tail -10
+```
+
+Expected: all tests pass. If a date function is not yet implemented, some tests may return `Value::Error` and be skipped (the `match` guards handle this). Do not add failing tests for unimplemented functions — note them in the PR description instead.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/core/tests/property_date.rs
+git commit -m "test(proptest): add date function property tests — YEAR/MONTH/DAY roundtrip, DATEDIF invariants"
+```
+
+---
+
+## Task 2: Create `property_lookup.rs`
+
+**Files:**
+- Create: `crates/core/tests/property_lookup.rs`
+
+Before writing, check available lookup functions:
+```bash
+grep -r "\"VLOOKUP\"\|\"INDEX\"\|\"MATCH\"\|\"CHOOSE\"\|\"OFFSET\"" \
+  crates/core/src/ --include="*.rs" -l
+```
+
+- [ ] **Step 1: Write `property_lookup.rs`**
+
+```rust
+// crates/core/tests/property_lookup.rs
+//
+// Property-based tests for lookup functions.
+// Verifies invariants: out-of-range inputs produce errors, in-range inputs
+// produce values within the searched set.
+
+use ganit_core::{evaluate, ErrorKind, Value};
+use proptest::prelude::*;
+use std::collections::HashMap;
+
+fn run(formula: &str) -> Value {
+    evaluate(formula, &HashMap::new())
+}
+
+fn is_error(v: &Value) -> bool {
+    matches!(v, Value::Error(_))
+}
+
+proptest! {
+    // CHOOSE(idx, ...) with idx out of range [1, n] returns #VALUE!
+    #[test]
+    fn choose_out_of_range_errors(
+        n_choices in 1usize..=5,
+        idx_offset in 1usize..=10,
+    ) {
+        let n = n_choices;
+        let bad_idx = n + idx_offset; // always > n, always out of range
+        let choices = (1..=n).map(|i| i.to_string()).collect::<Vec<_>>().join(", ");
+        let formula = format!("=CHOOSE({}, {})", bad_idx, choices);
+        let result = run(&formula);
+        prop_assert!(is_error(&result),
+            "CHOOSE({}, {} choices) should error but got {:?}", bad_idx, n, result);
+    }
+
+    // CHOOSE(idx, ...) with idx in [1, n] returns one of the choices (a Number)
+    #[test]
+    fn choose_in_range_returns_value(
+        n_choices in 1usize..=5,
+        idx_minus_one in 0usize..5,
+    ) {
+        let n = n_choices;
+        let idx = (idx_minus_one % n) + 1; // always in [1, n]
+        let choices = (1..=n).map(|i| i.to_string()).collect::<Vec<_>>().join(", ");
+        let formula = format!("=CHOOSE({}, {})", idx, choices);
+        let result = run(&formula);
+        prop_assert!(matches!(result, Value::Number(_)),
+            "CHOOSE({}, {} choices) should return Number but got {:?}", idx, n, result);
+        if let Value::Number(v) = result {
+            prop_assert_eq!(v, idx as f64,
+                "CHOOSE({}) returned {} instead of {}", idx, v, idx);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo test -p ganit-core --test property_lookup -- --nocapture 2>&1 | tail -10
+```
+
+Expected: all tests pass. If CHOOSE is not implemented, the test will show errors — note in PR description and add `prop_assume!` guards as needed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/core/tests/property_lookup.rs
+git commit -m "test(proptest): add lookup function property tests — CHOOSE range invariants"
+```
+
+---
+
+## Task 3: Create `property_array.rs`
+
+**Files:**
+- Create: `crates/core/tests/property_array.rs`
+
+- [ ] **Step 1: Write `property_array.rs`**
+
+```rust
+// crates/core/tests/property_array.rs
+//
+// Property-based tests for array functions.
+// Verifies length-preservation and element-wise invariants.
+
+use ganit_core::{evaluate, Value};
+use proptest::prelude::*;
+use std::collections::HashMap;
+
+fn run(formula: &str) -> Value {
+    evaluate(formula, &HashMap::new())
+}
+
+proptest! {
+    // SEQUENCE(n) produces exactly n values when n >= 1
+    #[test]
+    fn sequence_length(n in 1usize..=20) {
+        let formula = format!("=SEQUENCE({})", n);
+        let result = run(&formula);
+        match result {
+            Value::Array(arr) => {
+                prop_assert_eq!(arr.len(), n,
+                    "SEQUENCE({}) returned {} elements", n, arr.len());
+            }
+            // If SEQUENCE returns a single Number (n=1 edge case), that's fine
+            Value::Number(_) if n == 1 => {}
+            other => {
+                // SEQUENCE may not be implemented — skip rather than fail
+                let _ = other;
+            }
+        }
+    }
+
+    // SEQUENCE(n) values are 1..n (default start=1, step=1)
+    #[test]
+    fn sequence_values_start_at_one(n in 1usize..=10) {
+        let formula = format!("=SEQUENCE({})", n);
+        let result = run(&formula);
+        if let Value::Array(arr) = result {
+            for (i, val) in arr.iter().enumerate() {
+                if let Value::Number(v) = val {
+                    prop_assert_eq!(*v, (i + 1) as f64,
+                        "SEQUENCE({}) element {} = {} (expected {})", n, i, v, i+1);
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+cargo test -p ganit-core --test property_array -- --nocapture 2>&1 | tail -10
+```
+
+Expected: all tests pass, or tests are skipped gracefully if array functions aren't implemented. Do not commit tests that fail due to unimplemented functions — use `prop_assume!` to skip unimplemented cases and note them in the PR.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/core/tests/property_array.rs
+git commit -m "test(proptest): add array function property tests — SEQUENCE length and value invariants
+
+Closes #372"
+```
+
+---
+
+## Task 4: Open PR
+
+- [ ] **Step 1: Push and create PR**
+
+```bash
+gh pr create \
+  --repo tryganit/ganit-core \
+  --title "test(proptest): property tests for date, lookup, and array functions" \
+  --assignee hhimanshu \
+  --body "$(cat <<'EOF'
+## Summary
+Adds property-based tests for three previously uncovered function categories:
+
+- **`property_date.rs`**: DATE/YEAR/MONTH/DAY roundtrip, DATEDIF non-negative, range invariants
+- **`property_lookup.rs`**: CHOOSE in-range and out-of-range invariants
+- **`property_array.rs`**: SEQUENCE length and value invariants
+
+All tests are written defensively — if a function is not yet implemented, the test skips gracefully rather than failing.
+
+closes #372
+EOF
+)"
+gh pr edit --add-assignee hhimanshu
+```
+
+- [ ] **Step 2: Monitor CI**
+
+```bash
+gh run list --repo tryganit/ganit-core --limit 3
+```
+
+On failure: `gh run view <run-id> --log-failed --repo tryganit/ganit-core`


### PR DESCRIPTION
## Summary
- Replaces `cargo test` with `cargo-nextest` for per-test timing and inline PR failure annotations (via JUnit XML + dorny/test-reporter)
- Adds `cargo-llvm-cov` + codecov integration with an 80% coverage gate on `ganit-core`

## What a failing test looks like in a PR now
The `dorny/test-reporter` action parses JUnit XML and posts inline annotations on the PR diff showing exactly which file/line failed and what the expected vs actual values were.

## Coverage PR comment
codecov will comment on every PR with a per-crate coverage delta table.

closes #367
closes #368