### PR TITLE
feat(ci): Google Sheets conformance badge + PR regression comment

### DIFF
--- a/.github/scripts/post-conformance-comment.sh
+++ b/.github/scripts/post-conformance-comment.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# .github/scripts/post-conformance-comment.sh
+#
+# Reads target/conformance-report.json, optionally compares to a baseline
+# (from main branch), posts a PR comment, and exits 1 on regressions.
+#
+# Usage:
+#   post-conformance-comment.sh <report.json> [baseline.json] [pr-number]
+#
+# Environment:
+#   GITHUB_REPOSITORY  — set automatically by GitHub Actions (owner/repo)
+#   GH_TOKEN           — set automatically by GitHub Actions
+
+set -euo pipefail
+
+REPORT="${1:-target/conformance-report.json}"
+BASELINE="${2:-}"
+PR_NUMBER="${3:-}"
+
+if [[ ! -f "$REPORT" ]]; then
+  echo "::warning::conformance-report.json not found at $REPORT — skipping comment"
+  exit 0
+fi
+
+# Parse JSON with pure bash (no jq dependency)
+total=$(grep '"total"'   "$REPORT" | grep -o '[0-9]*' | head -1)
+passed=$(grep '"passed"' "$REPORT" | grep -o '[0-9]*' | head -1)
+failed=$(grep '"failed"' "$REPORT" | grep -o '[0-9]*' | head -1)
+
+pct=$(awk "BEGIN { printf \"%.1f\", ($passed/$total)*100 }" 2>/dev/null || echo "?")
+
+# Build category table rows
+category_section=""
+while IFS= read -r line; do
+  if [[ "$line" =~ \"([a-z]+)\":[[:space:]]*\{[[:space:]]*\"passed\":[[:space:]]*([0-9]+),[[:space:]]*\"total\":[[:space:]]*([0-9]+) ]]; then
+    cat_name="${BASH_REMATCH[1]}"
+    cat_passed="${BASH_REMATCH[2]}"
+    cat_total="${BASH_REMATCH[3]}"
+    cat_pct=$(awk "BEGIN { printf \"%.1f\", ($cat_passed/$cat_total)*100 }" 2>/dev/null || echo "?")
+    # Capitalize first letter (compatible with bash 3.x on macOS and bash 5 on Linux)
+    cat_display=$(echo "$cat_name" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
+    suffix=""
+    if [[ "$cat_passed" -lt "$cat_total" ]]; then
+      suffix="  ← $(($cat_total - $cat_passed)) failing"
+    fi
+    category_section+="| ${cat_display} | ${cat_passed}/${cat_total} | ${cat_pct}% |${suffix}"$'\n'
+  fi
+done < "$REPORT"
+
+# Regression detection
+regressions=0
+regression_section=""
+if [[ -n "$BASELINE" && -f "$BASELINE" ]]; then
+  baseline_passed=$(grep '"passed"' "$BASELINE" | grep -o '[0-9]*' | head -1)
+  if [[ "$passed" -lt "$baseline_passed" ]]; then
+    regressions=$(($baseline_passed - $passed))
+    regression_section="⚠️ **${regressions} regression(s) detected** — this PR breaks previously passing tests vs main."
+  fi
+fi
+
+# Build comment body
+comment="## Google Sheets Conformance
+
+ganit calculations match Google Sheets — ${passed}/${total} tests passing (${pct}%)
+
+| Category | Passed | Rate |
+|----------|--------|------|
+${category_section}
+**Total: ${passed}/${total} (${pct}%)**
+"
+
+if [[ -n "$regression_section" ]]; then
+  comment+="
+${regression_section}"
+fi
+
+comment+="
+<sub>Oracle: Google Sheets · Verified on every PR</sub>"
+
+# Post comment (only on actual PRs, not pushes to main)
+if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
+  echo "$comment" | gh pr comment "$PR_NUMBER" \
+    --repo "$GITHUB_REPOSITORY" \
+    --body-file - \
+    --edit-last 2>/dev/null || \
+  echo "$comment" | gh pr comment "$PR_NUMBER" \
+    --repo "$GITHUB_REPOSITORY" \
+    --body-file -
+fi
+
+echo "Google Sheets Conformance: ${passed}/${total} (${pct}%)"
+
+# Fail CI on regressions
+if [[ "$regressions" -gt 0 ]]; then
+  echo "::error::${regressions} Google Sheets conformance regression(s) detected"
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,63 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Generate conformance report
+        run: cargo test -p ganit-core --test conformance generate_conformance_report -- --nocapture
+
+      - name: Download main-branch conformance baseline
+        run: |
+          gh run download \
+            --repo "$GITHUB_REPOSITORY" \
+            --name conformance-report \
+            --dir baseline/ \
+            2>/dev/null || echo "No baseline found (first run or main has no artifact)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        continue-on-error: true
+
+      - name: Upload conformance report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-report
+          path: target/conformance-report.json
+          retention-days: 30
+
+      - name: Post conformance PR comment
+        if: github.event_name == 'pull_request'
+        run: |
+          bash .github/scripts/post-conformance-comment.sh \
+            target/conformance-report.json \
+            baseline/conformance-report.json \
+            "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Publish conformance badge to gh-pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          total=$(grep '"total"'  target/conformance-report.json | grep -o '[0-9]*' | head -1)
+          passed=$(grep '"passed"' target/conformance-report.json | grep -o '[0-9]*' | head -1)
+          pct=$(awk "BEGIN { printf \"%.1f\", ($passed/$total)*100 }")
+          if   (( $(echo "$pct >= 99.0" | bc -l) )); then color="brightgreen"
+          elif (( $(echo "$pct >= 95.0" | bc -l) )); then color="green"
+          elif (( $(echo "$pct >= 90.0" | bc -l) )); then color="yellow"
+          else color="red"
+          fi
+          badge_json="{\"schemaVersion\":1,\"label\":\"Google Sheets Conformance\",\"message\":\"${passed}/${total} · ${pct}%\",\"color\":\"${color}\"}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages 2>/dev/null || true
+          git checkout gh-pages 2>/dev/null || git checkout --orphan gh-pages
+          echo "$badge_json" > conformance-badge.json
+          git add conformance-badge.json
+          git diff --cached --quiet || git commit -m "chore: update Google Sheets conformance badge [skip ci]"
+          git push origin gh-pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![ganit-mcp](https://img.shields.io/crates/v/ganit-mcp?label=ganit-mcp)](https://crates.io/crates/ganit-mcp)
 [![docs.rs](https://img.shields.io/docsrs/ganit-core)](https://docs.rs/ganit-core)
 [![license](https://img.shields.io/crates/l/ganit-core)](LICENSE)
+[![Google Sheets Conformance](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/tryganit/ganit-core/gh-pages/conformance-badge.json&label=Google%20Sheets%20Conformance)](https://github.com/tryganit/ganit-core/actions)
 
 WebAssembly-powered spreadsheet formula engine for JavaScript/TypeScript.
 


### PR DESCRIPTION
## Summary

- New script `.github/scripts/post-conformance-comment.sh` reads `target/conformance-report.json` and posts a `## Google Sheets Conformance` table on every PR
- Regression detection: if this PR breaks previously passing tests vs main, CI fails with a clear error message
- Conformance report is uploaded as a CI artifact on every run (used as baseline for future PRs via `gh run download`)
- On push to main: `conformance-badge.json` is published to the `gh-pages` branch in Shields.io endpoint format with label `Google Sheets Conformance`
- Google Sheets conformance badge added to README (static Shields.io endpoint pointing at gh-pages)

## Sample PR comment

```
## Google Sheets Conformance

ganit calculations match Google Sheets — 5024/5048 tests passing (99.5%)

| Category | Passed | Rate |
|----------|--------|------|
| Math | 1234/1240 | 99.5% |
| Text | 342/342 | 100.0% |
...

**Total: 5024/5048 (99.5%)**
```

## Dependencies

Requires #367, #368, #369 merged first (all merged).

closes #370