### PR TITLE
fix(ci): persist .nojekyll in gh-pages to prevent Jekyll failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,8 @@ jobs:
           git checkout gh-pages 2>/dev/null || git checkout --orphan gh-pages
           echo "$badge_json" > conformance-badge.json
           cp /tmp/conformance.html index.html
-          git add conformance-badge.json index.html
+          touch .nojekyll
+          git add conformance-badge.json index.html .nojekyll
           git diff --cached --quiet || git commit -m "chore: update Google Sheets conformance report [skip ci]"
           git push origin gh-pages
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
             $(python3 -c "
           import json, sys
           d = json.load(open('target/conformance-report.json'))
-          cats = d.get('categories', {})
+          cats = d.get('by_category', {})
           if not cats:
               print('<p>No per-category data available.</p>')
               sys.exit()


### PR DESCRIPTION
Adds `touch .nojekyll` to the gh-pages publish step so every CI push retains the file. Without it, the next CI run overwrites the branch and Jekyll breaks the Pages build again.