### PR TITLE
feat(ci): per-category test coverage table in PR comments

### DIFF
--- a/.github/scripts/generate-pages-html.py
+++ b/.github/scripts/generate-pages-html.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Generates index.html for gh-pages with Google Sheets Conformance + Test Coverage by Category.
+# Usage: generate-pages-html.py <junit.xml> <conformance.json> <run_url> <hex> <passed> <total> <pct>
+
+import sys
+import json
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from datetime import datetime, timezone
+
+junit_path, conf_path, run_url, hex_color, passed, total, pct = sys.argv[1:8]
+
+# ── Unit tests per category ───────────────────────────────────────────────────
+tree = ET.parse(junit_path)
+root = tree.getroot()
+unit_counts = defaultdict(int)
+for suite in root.findall('testsuite'):
+    if suite.get('name') == 'ganit-core':
+        for tc in suite.findall('testcase'):
+            parts = tc.get('name', '').split('::')
+            cat = 'core'
+            if 'functions' in parts:
+                idx = parts.index('functions')
+                if idx + 1 < len(parts) and parts[idx + 1] != 'tests':
+                    cat = parts[idx + 1]
+            unit_counts[cat] += 1
+
+# ── Proptest suites per category ──────────────────────────────────────────────
+SKIP = {'error_propagation', 'conformance'}
+CASES = 500
+prop_fns = defaultdict(int)
+for suite in root.findall('testsuite'):
+    sname = suite.get('name', '')
+    if sname.startswith('ganit-core::property_'):
+        cat = sname[len('ganit-core::property_'):]
+        if cat not in SKIP:
+            prop_fns[cat] += int(suite.get('tests', 0))
+
+# ── Conformance data ──────────────────────────────────────────────────────────
+conf = json.load(open(conf_path))
+cats_conf = conf.get('by_category', {})
+
+all_cats = sorted(
+    (set(unit_counts.keys()) | set(prop_fns.keys()) | set(cats_conf.keys())) - {'core'}
+)
+
+# ── Build table rows ──────────────────────────────────────────────────────────
+rows_html = []
+tot_unit = tot_prop = tot_grand = 0
+
+for cat in all_cats:
+    unit = unit_counts.get(cat, 0)
+    fn_c = prop_fns.get(cat, 0)
+    cd = cats_conf.get(cat)
+    cp = cd['passed'] if cd else 0
+    ct = cd['total'] if cd else 0
+
+    if cd:
+        cls = 'pass' if cp == ct else 'fail'
+        mark = '✓' if cp == ct else '⚠'
+        conf_cell = f'<span class="{cls}">{cp:,}/{ct:,} {mark}</span>'
+    else:
+        conf_cell = '—'
+
+    if fn_c:
+        prop_cases = fn_c * CASES
+        prop_cell = f'{prop_cases:,} ({fn_c}×{CASES:,})'
+    else:
+        prop_cases = 0
+        prop_cell = '—'
+
+    row_total = unit + ct + prop_cases
+    display = cat.replace('_', ' ').title()
+    rows_html.append(
+        f'<tr><td>{display}</td><td>{unit:,}</td>'
+        f'<td>{conf_cell}</td><td>{prop_cell}</td><td>{row_total:,}</td></tr>'
+    )
+    tot_unit += unit
+    tot_prop += prop_cases
+    tot_grand += unit + ct + prop_cases
+
+core_unit = unit_counts.get('core', 0)
+tot_unit += core_unit
+tot_grand += core_unit
+tot_prop_fns = sum(prop_fns.values())
+
+updated = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
+
+print(f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Google Sheets Conformance — ganit</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; max-width: 900px; margin: 40px auto; padding: 0 20px; color: #24292f; }}
+    h1 {{ font-size: 1.5rem; }}
+    h2 {{ font-size: 1.1rem; margin-top: 2rem; color: #57606a; }}
+    .badge {{ display: inline-block; background: {hex_color}; color: #fff; padding: 4px 12px; border-radius: 4px; font-size: 1.1rem; font-weight: bold; margin: 8px 0 24px; }}
+    table {{ border-collapse: collapse; width: 100%; margin-top: 8px; }}
+    th, td {{ border: 1px solid #d0d7de; padding: 8px 12px; text-align: left; }}
+    th {{ background: #f6f8fa; }}
+    tfoot td {{ font-weight: bold; background: #f6f8fa; }}
+    .pass {{ color: #1a7f37; }}
+    .fail {{ color: #cf222e; }}
+    footer {{ margin-top: 32px; font-size: 0.85rem; color: #57606a; }}
+  </style>
+</head>
+<body>
+  <h1>Google Sheets Conformance</h1>
+  <div class="badge">{passed}/{total} · {pct}%</div>
+  <p>ganit formula results verified against Google Sheets oracle on every commit to <code>main</code>.</p>
+
+  <h2>Test Coverage by Category</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Category</th>
+        <th>Unit Tests</th>
+        <th>Google Sheets Conformance</th>
+        <th>Property Cases</th>
+        <th>Total</th>
+      </tr>
+    </thead>
+    <tbody>
+      {''.join(rows_html)}
+    </tbody>
+    <tfoot>
+      <tr>
+        <td>Total</td>
+        <td>{tot_unit:,}</td>
+        <td>{conf['passed']:,}/{conf['total']:,}</td>
+        <td>{tot_prop:,} ({tot_prop_fns}×{CASES:,})</td>
+        <td>~{tot_grand:,}</td>
+      </tr>
+    </tfoot>
+  </table>
+
+  <footer>
+    Oracle: Google Sheets &nbsp;·&nbsp;
+    ✓ = 100% passing &nbsp;·&nbsp; ⚠ = known deviation &nbsp;·&nbsp;
+    Updated: {updated} &nbsp;·&nbsp;
+    <a href="{run_url}">CI run</a>
+  </footer>
+</body>
+</html>""")

--- a/.github/scripts/post-coverage-comment.sh
+++ b/.github/scripts/post-coverage-comment.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# .github/scripts/post-coverage-comment.sh
+#
+# Builds a "Test Coverage by Category" table from three data sources and
+# posts it as a PR comment (idempotent via --edit-last).
+#
+# Usage:
+#   post-coverage-comment.sh <junit.xml> <conformance-report.json> [pr-number]
+#
+# Environment:
+#   GITHUB_REPOSITORY  — set automatically by GitHub Actions (owner/repo)
+#   GH_TOKEN           — set automatically by GitHub Actions
+
+set -euo pipefail
+
+JUNIT_XML="${1:-target/nextest/ci/junit.xml}"
+CONFORMANCE_JSON="${2:-target/conformance-report.json}"
+PR_NUMBER="${3:-}"
+
+if [[ ! -f "$JUNIT_XML" ]]; then
+  echo "::warning::junit.xml not found at $JUNIT_XML — skipping coverage comment"
+  exit 0
+fi
+
+if [[ ! -f "$CONFORMANCE_JSON" ]]; then
+  echo "::warning::conformance-report.json not found at $CONFORMANCE_JSON — skipping coverage comment"
+  exit 0
+fi
+
+# Build the markdown table with Python (available on ubuntu-latest)
+COMMENT=$(python3 - "$JUNIT_XML" "$CONFORMANCE_JSON" <<'PYEOF'
+import sys, json, xml.etree.ElementTree as ET
+from collections import defaultdict
+
+junit_path, conf_path = sys.argv[1], sys.argv[2]
+
+# ── 1. Parse unit tests ───────────────────────────────────────────────────────
+tree = ET.parse(junit_path)
+root = tree.getroot()
+
+unit_counts = defaultdict(int)
+for suite in root.findall('testsuite'):
+    if suite.get('name') == 'ganit-core':
+        for tc in suite.findall('testcase'):
+            name = tc.get('name', '')
+            parts = name.split('::')
+            cat = 'core'
+            if 'functions' in parts:
+                idx = parts.index('functions')
+                if idx + 1 < len(parts):
+                    candidate = parts[idx + 1]
+                    # guard against eval::functions::tests::list_functions_matches_registry
+                    if candidate != 'tests':
+                        cat = candidate
+            unit_counts[cat] += 1
+
+# ── 2. Parse proptest suites ──────────────────────────────────────────────────
+# Skip cross-cutting suites that would double-count
+SKIP_SUITES = {'error_propagation', 'conformance'}
+CASES_PER_PROP = 500
+
+prop_fn_counts = defaultdict(int)  # number of property test functions per category
+for suite in root.findall('testsuite'):
+    sname = suite.get('name', '')
+    if sname.startswith('ganit-core::property_'):
+        cat = sname[len('ganit-core::property_'):]
+        if cat not in SKIP_SUITES:
+            prop_fn_counts[cat] += int(suite.get('tests', 0))
+
+# ── 3. Load conformance data ──────────────────────────────────────────────────
+conf = json.load(open(conf_path))
+cats_conf = conf.get('by_category', {})
+total_conf_passed = conf.get('passed', 0)
+total_conf_total = conf.get('total', 0)
+
+# ── 4. Build sorted category list (exclude 'core') ───────────────────────────
+all_cats = sorted(
+    set(unit_counts.keys()) | set(prop_fn_counts.keys()) | set(cats_conf.keys()) - {'core'}
+)
+# Ensure 'core' is not in the main table (it's a meta bucket)
+all_cats = [c for c in all_cats if c != 'core']
+
+# ── 5. Render table ───────────────────────────────────────────────────────────
+rows = []
+total_unit = 0
+total_prop_cases = 0
+total_grand = 0
+
+for cat in all_cats:
+    unit = unit_counts.get(cat, 0)
+    fn_count = prop_fn_counts.get(cat, 0)
+    conf_data = cats_conf.get(cat, None)
+
+    # Conformance cell
+    if conf_data:
+        cp, ct = conf_data['passed'], conf_data['total']
+        mark = '✓' if cp == ct else '⚠'
+        conf_cell = f'{cp:,}/{ct:,} {mark}'
+    else:
+        cp, ct = 0, 0
+        conf_cell = '—'
+
+    # Proptest cell
+    if fn_count:
+        prop_cases = fn_count * CASES_PER_PROP
+        prop_cell = f'{prop_cases:,} ({fn_count}×{CASES_PER_PROP:,})'
+    else:
+        prop_cases = 0
+        prop_cell = '—'
+
+    row_total = unit + ct + prop_cases
+    display = cat.replace('_', ' ').title()
+
+    rows.append(f'| {display} | {unit:,} | {conf_cell} | {prop_cell} | {row_total:,} |')
+
+    total_unit += unit
+    total_prop_cases += prop_cases
+    total_grand += unit + ct + prop_cases
+
+# Add core to totals (not shown as a separate row)
+core_unit = unit_counts.get('core', 0)
+total_unit += core_unit
+total_grand += core_unit
+
+total_prop_fns = sum(prop_fn_counts.values())
+prop_total_cell = f'{total_prop_cases:,} ({total_prop_fns}×{CASES_PER_PROP:,})'
+conf_total_cell = f'{total_conf_passed:,}/{total_conf_total:,}'
+
+footer = (
+    f'| **Total** | **{total_unit:,}** | **{conf_total_cell}** '
+    f'| **{prop_total_cell}** | **~{total_grand:,}** |'
+)
+
+table = '\n'.join(rows)
+
+print(f'''## Test Coverage by Category
+
+| Category | Unit Tests | Google Sheets Conformance | Property Cases | Total |
+|----------|-----------|--------------------------|----------------|-------|
+{table}
+{footer}
+
+<sub>Oracle: Google Sheets · ✓ = 100% passing · ⚠ = known deviation</sub>''')
+PYEOF
+)
+
+echo "$COMMENT"
+
+# Post comment only on actual PRs
+if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
+  echo "$COMMENT" | gh pr comment "$PR_NUMBER" \
+    --repo "$GITHUB_REPOSITORY" \
+    --body-file - \
+    --edit-last 2>/dev/null || \
+  echo "$COMMENT" | gh pr comment "$PR_NUMBER" \
+    --repo "$GITHUB_REPOSITORY" \
+    --body-file -
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,52 +113,11 @@ jobs:
           fi
           badge_json="{\"schemaVersion\":1,\"label\":\"Google Sheets Conformance\",\"message\":\"${passed}/${total} · ${pct}%\",\"color\":\"${color}\"}"
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          cat > /tmp/conformance.html <<HTML
-          <!DOCTYPE html>
-          <html lang="en">
-          <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Google Sheets Conformance — ganit</title>
-            <style>
-              body { font-family: system-ui, sans-serif; max-width: 700px; margin: 40px auto; padding: 0 20px; color: #24292f; }
-              h1 { font-size: 1.5rem; }
-              .badge { display: inline-block; background: ${hex}; color: #fff; padding: 4px 12px; border-radius: 4px; font-size: 1.1rem; font-weight: bold; margin: 8px 0 24px; }
-              table { border-collapse: collapse; width: 100%; }
-              th, td { border: 1px solid #d0d7de; padding: 8px 12px; text-align: left; }
-              th { background: #f6f8fa; }
-              .pass { color: #1a7f37; }
-              .fail { color: #cf222e; }
-              footer { margin-top: 32px; font-size: 0.85rem; color: #57606a; }
-            </style>
-          </head>
-          <body>
-            <h1>Google Sheets Conformance</h1>
-            <div class="badge">${passed}/${total} · ${pct}%</div>
-            <p>ganit formula results verified against Google Sheets oracle on every commit to <code>main</code>.</p>
-            $(python3 -c "
-          import json, sys
-          d = json.load(open('target/conformance-report.json'))
-          cats = d.get('by_category', {})
-          if not cats:
-              print('<p>No per-category data available.</p>')
-              sys.exit()
-          print('<table><tr><th>Category</th><th>Passed</th><th>Total</th><th>Rate</th></tr>')
-          for name, v in sorted(cats.items()):
-              p, t = v['passed'], v['total']
-              pct2 = f'{p/t*100:.1f}' if t else '0.0'
-              cls = 'pass' if p == t else 'fail'
-              print(f'<tr><td>{name.title()}</td><td class=\"{cls}\">{p}</td><td>{t}</td><td class=\"{cls}\">{pct2}%</td></tr>')
-          print('</table>')
-          " 2>/dev/null || echo "<p>Category breakdown not available.</p>")
-            <footer>
-              Oracle: Google Sheets &nbsp;·&nbsp;
-              Updated: $(date -u '+%Y-%m-%d %H:%M UTC') &nbsp;·&nbsp;
-              <a href="${run_url}">CI run</a>
-            </footer>
-          </body>
-          </html>
-          HTML
+          python3 .github/scripts/generate-pages-html.py \
+            target/nextest/ci/junit.xml \
+            target/conformance-report.json \
+            "$run_url" "${hex}" "${passed}" "${total}" "${pct}" \
+            > /tmp/conformance.html
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin gh-pages 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,18 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
+      - name: Post coverage table as PR comment
+        if: github.event_name == 'pull_request'
+        run: |
+          bash .github/scripts/post-coverage-comment.sh \
+            target/nextest/ci/junit.xml \
+            target/conformance-report.json \
+            "$PR_NUMBER"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
       - name: Publish conformance report to gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
## Summary

- Posts a **Test Coverage by Category** table on every PR, combining unit tests from nextest JUnit XML, Google Sheets conformance rows from conformance-report.json, and property test case counts (N functions × 500 cases)
- Parses `target/nextest/ci/junit.xml` with Python's `xml.etree.ElementTree` to extract per-category unit test counts (segment after `functions::` in test name path)
- Proptest suites named `ganit-core::property_<cat>` are counted (skipping cross-cutting `error_propagation` and `conformance` suites), multiplied by 500 for total cases
- Uses `--edit-last` pattern (same as `post-conformance-comment.sh`) for idempotent updates

## Sample output

| Category | Unit Tests | Google Sheets Conformance | Property Cases | Total |
|----------|-----------|--------------------------|----------------|-------|
| Array | 38 | 209/209 ✓ | 1,000 (2×500) | 1,247 |
| Date | 314 | 259/259 ✓ | 2,500 (5×500) | 3,073 |
| Math | 485 | 1,119/1,119 ✓ | 7,500 (15×500) | 9,104 |
| Web | 0 | 0/23 ⚠ | — | 23 |
| **Total** | **2,388** | **5,024/5,048** | **21,500 (43×500)** | **~28,936** |

closes #381