### PR TITLE
chore: release v0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,38 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "ganit-core"
-version = "0.4.4"
-dependencies = [
- "calamine",
- "chrono",
- "nom",
- "proptest",
- "regex-lite",
-]
-
-[[package]]
-name = "ganit-mcp"
-version = "0.4.4"
-dependencies = [
- "ganit-core",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ganit-wasm"
-version = "0.4.4"
-dependencies = [
- "ganit-core",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "tsify-next",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +695,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "truecalc-core"
+version = "0.4.4"
+dependencies = [
+ "calamine",
+ "chrono",
+ "nom",
+ "proptest",
+ "regex-lite",
+]
+
+[[package]]
+name = "truecalc-mcp"
+version = "0.4.4"
+dependencies = [
+ "serde",
+ "serde_json",
+ "truecalc-core",
+]
+
+[[package]]
+name = "truecalc-wasm"
+version = "0.4.4"
+dependencies = [
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "truecalc-core",
+ "tsify-next",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/mcp/CHANGELOG.md
+++ b/crates/mcp/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/truecalc/core/releases/tag/truecalc-mcp-v0.4.4) - 2026-04-18
+
+### Added
+
+- *(rebrand)* update all URLs, READMEs, npm package, and docs to truecalc
+- *(rebrand)* update Rust source files to use truecalc_core
+- *(rebrand)* rename Rust crates to truecalc-* in Cargo.toml
+- add Value::Date and implement ISDATE (closes #208)
+- *(mcp)* implement 5-tool MCP server over stdio — issue #9
+
+### Fixed
+
+- *(mcp)* make list_functions registry-driven, delete static catalogue
+- *(core)* evaluate() takes variables by reference ([#34](https://github.com/truecalc/core/pull/34))
+- *(publish)* add version to ganit-core path dep in ganit-mcp
+- *(publish)* add description and repository to crate manifests
+- *(mcp)* JSON-RPC parse errors, isError flag, graceful EOF, remove hot-path unwrap
+
+### Other
+
+- release v0.4.3
+- Merge pull request #363 from tryganit/docs/mcp-readme-badges-install
+- *(mcp)* add ganit-core badge and use --force for install
+- release v0.4.0
+- release v0.3.11
+- release v0.3.8
+- release v0.3.6
+- release v0.3.4
+- release v0.3.2
+- release v0.3.0
+- release v0.2.1
+- Merge pull request #266 from tryganit/fix/registry-driven-list-functions
+- replace static function tables with live registry reference
+- *(mcp)* add README and wire readme field in Cargo.toml
+- release v0.1.6
+- release v0.1.3
+- release v0.1.1
+- Set up Cargo workspace with core, wasm, and mcp crates
+
 ## [0.4.3](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.2...truecalc-mcp-v0.4.3) - 2026-04-17
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.4.4
* `truecalc-mcp`: 0.4.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.4.4](https://github.com/truecalc/core/compare/truecalc-core-v0.4.3...truecalc-core-v0.4.4) - 2026-04-18

### Added

- *(tests)* use CASES=500 constant for all proptest files — up from 256
- *(tests)* surface proptest case counts in CI output per property test
- *(conformance)* emit structured JSON summary — per-category pass/fail vs Google Sheets ([#378](https://github.com/truecalc/core/pull/378))
- *(proptest)* property tests for date, lookup, and array functions ([#376](https://github.com/truecalc/core/pull/376))

### Fixed

- *(tests)* replace all hardcoded 256 with CASES constant in eprintln strings

### Other

- *(proptest)* add array function property tests — SEQUENCE length and value invariants
- *(proptest)* add lookup function property tests — CHOOSE range invariants
- *(proptest)* add date function property tests — YEAR/MONTH/DAY roundtrip, DATEDIF invariants
- *(proptest)* add error propagation property tests for math and text functions
- *(proptest)* add idempotency, monotonicity, and round-trip properties for math functions
- *(proptest)* add idempotency and length properties for text functions
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.4.4](https://github.com/truecalc/core/releases/tag/truecalc-mcp-v0.4.4) - 2026-04-18

### Added

- *(rebrand)* update all URLs, READMEs, npm package, and docs to truecalc
- *(rebrand)* update Rust source files to use truecalc_core
- *(rebrand)* rename Rust crates to truecalc-* in Cargo.toml
- add Value::Date and implement ISDATE (closes #208)
- *(mcp)* implement 5-tool MCP server over stdio — issue #9

### Fixed

- *(mcp)* make list_functions registry-driven, delete static catalogue
- *(core)* evaluate() takes variables by reference ([#34](https://github.com/truecalc/core/pull/34))
- *(publish)* add version to ganit-core path dep in ganit-mcp
- *(publish)* add description and repository to crate manifests
- *(mcp)* JSON-RPC parse errors, isError flag, graceful EOF, remove hot-path unwrap

### Other

- release v0.4.3
- Merge pull request #363 from tryganit/docs/mcp-readme-badges-install
- *(mcp)* add ganit-core badge and use --force for install
- release v0.4.0
- release v0.3.11
- release v0.3.8
- release v0.3.6
- release v0.3.4
- release v0.3.2
- release v0.3.0
- release v0.2.1
- Merge pull request #266 from tryganit/fix/registry-driven-list-functions
- replace static function tables with live registry reference
- *(mcp)* add README and wire readme field in Cargo.toml
- release v0.1.6
- release v0.1.3
- release v0.1.1
- Set up Cargo workspace with core, wasm, and mcp crates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).