### PR TITLE
feat(rebrand): ganit → truecalc

### DIFF
--- a/.github/scripts/generate-pages-html.py
+++ b/.github/scripts/generate-pages-html.py
@@ -15,7 +15,7 @@ tree = ET.parse(junit_path)
 root = tree.getroot()
 unit_counts = defaultdict(int)
 for suite in root.findall('testsuite'):
-    if suite.get('name') == 'ganit-core':
+    if suite.get('name') == 'truecalc-core':
         for tc in suite.findall('testcase'):
             parts = tc.get('name', '').split('::')
             cat = 'core'
@@ -31,8 +31,8 @@ CASES = 500
 prop_fns = defaultdict(int)
 for suite in root.findall('testsuite'):
     sname = suite.get('name', '')
-    if sname.startswith('ganit-core::property_'):
-        cat = sname[len('ganit-core::property_'):]
+    if sname.startswith('truecalc-core::property_'):
+        cat = sname[len('truecalc-core::property_'):]
         if cat not in SKIP:
             prop_fns[cat] += int(suite.get('tests', 0))
 
@@ -91,7 +91,7 @@ print(f"""<!DOCTYPE html>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Test Transparency — ganit</title>
+  <title>Test Transparency — truecalc</title>
   <style>
     body {{ font-family: system-ui, sans-serif; max-width: 900px; margin: 40px auto; padding: 0 20px; color: #24292f; }}
     h1 {{ font-size: 1.5rem; }}
@@ -110,20 +110,20 @@ print(f"""<!DOCTYPE html>
   </style>
 </head>
 <body>
-  <h1>ganit — Test Transparency</h1>
+  <h1>truecalc — Test Transparency</h1>
 
   <h2>Google Sheets Conformance</h2>
   <div class="badges">
     <span class="badge">{passed}/{total} · {pct}%</span>
-    <img src="https://img.shields.io/codecov/c/github/tryganit/ganit-core?label=coverage&style=flat-square" alt="Code Coverage" height="22">
+    <img src="https://img.shields.io/codecov/c/github/truecalc/core?label=coverage&style=flat-square" alt="Code Coverage" height="22">
   </div>
 
   <div class="explainer">
     <strong>What is Google Sheets conformance?</strong><br>
-    ganit evaluates spreadsheet formulas. To verify correctness, every supported formula is run against
+    truecalc evaluates spreadsheet formulas. To verify correctness, every supported formula is run against
     a <em>Google Sheets oracle</em> — real Google Sheets spreadsheets that produce the expected output.
-    On every commit to <code>main</code>, ganit re-runs all {total} conformance cases and compares
-    results. A ✓ means ganit matches Google Sheets exactly; ⚠ means a known, intentional deviation
+    On every commit to <code>main</code>, truecalc re-runs all {total} conformance cases and compares
+    results. A ✓ means truecalc matches Google Sheets exactly; ⚠ means a known, intentional deviation
     (e.g. a locale difference or an unsupported edge case).<br><br>
     <strong>Property tests</strong> go further: for each formula category, randomly generated inputs
     are checked against mathematical invariants (e.g. <code>ABS(x) ≥ 0</code> for all x,

--- a/.github/scripts/post-conformance-comment.sh
+++ b/.github/scripts/post-conformance-comment.sh
@@ -61,7 +61,7 @@ fi
 # Build comment body
 comment="## Google Sheets Conformance
 
-ganit calculations match Google Sheets — ${passed}/${total} tests passing (${pct}%)
+truecalc calculations match Google Sheets — ${passed}/${total} tests passing (${pct}%)
 
 | Category | Passed | Rate |
 |----------|--------|------|

--- a/.github/scripts/post-coverage-comment.sh
+++ b/.github/scripts/post-coverage-comment.sh
@@ -40,7 +40,7 @@ root = tree.getroot()
 
 unit_counts = defaultdict(int)
 for suite in root.findall('testsuite'):
-    if suite.get('name') == 'ganit-core':
+    if suite.get('name') == 'truecalc-core':
         for tc in suite.findall('testcase'):
             name = tc.get('name', '')
             parts = name.split('::')
@@ -62,8 +62,8 @@ CASES_PER_PROP = 500
 prop_fn_counts = defaultdict(int)  # number of property test functions per category
 for suite in root.findall('testsuite'):
     sname = suite.get('name', '')
-    if sname.startswith('ganit-core::property_'):
-        cat = sname[len('ganit-core::property_'):]
+    if sname.startswith('truecalc-core::property_'):
+        cat = sname[len('truecalc-core::property_'):]
         if cat not in SKIP_SUITES:
             prop_fn_counts[cat] += int(suite.get('tests', 0))
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         if: always()
         with:
           files: target/nextest/ci/junit.xml
-          check_name: ganit-core tests
+          check_name: truecalc-core tests
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -55,7 +55,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Generate conformance report
-        run: cargo test -p ganit-core --test conformance generate_conformance_report -- --nocapture
+        run: cargo test -p truecalc-core --test conformance generate_conformance_report -- --nocapture
 
       - name: Download main-branch conformance baseline
         run: |

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Trigger npm release for ganit-core
+      - name: Trigger npm release for truecalc-core
         if: steps.release-plz.outputs.releases != ''
         env:
           RELEASES: ${{ steps.release-plz.outputs.releases }}
@@ -30,7 +30,7 @@ jobs:
           TAG=$(echo "$RELEASES" | python3 -c "
           import json, sys
           releases = json.load(sys.stdin)
-          r = next((r for r in releases if r['package_name'] == 'ganit-core'), None)
+          r = next((r for r in releases if r['package_name'] == 'truecalc-core'), None)
           if r:
               print(r['tag'])
           ")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (e.g. ganit-core-v0.1.1)"
+        description: "Tag to release (e.g. truecalc-core-v0.1.1)"
         required: true
 
 permissions:
@@ -30,7 +30,7 @@ jobs:
         run: wasm-pack build crates/wasm --target bundler
 
       - name: Set npm package name
-        run: node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json')); p.name='@tryganit/core'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
+        run: node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json')); p.name='@truecalc/core'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
         working-directory: crates/wasm/pkg
 
       - uses: actions/setup-node@v4
@@ -50,13 +50,13 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact: ganit-mcp-linux-x86_64
+            artifact: truecalc-mcp-linux-x86_64
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact: ganit-mcp-macos-x86_64
+            artifact: truecalc-mcp-macos-x86_64
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact: ganit-mcp-macos-arm64
+            artifact: truecalc-mcp-macos-arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -68,10 +68,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build -p ganit-mcp --release --target ${{ matrix.target }}
+        run: cargo build -p truecalc-mcp --release --target ${{ matrix.target }}
 
       - name: Rename binary
-        run: mv "target/${{ matrix.target }}/release/ganit-mcp" "${{ matrix.artifact }}"
+        run: mv "target/${{ matrix.target }}/release/truecalc-mcp" "${{ matrix.artifact }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,10 +74,10 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 **A PR is not done until CI is green.**
 
 After opening or pushing to a PR:
-1. **Check CI immediately:** `gh run list --repo tryganit/ganit-core --branch <branch> --limit 3`
-2. **On failure, read the exact error:** `gh run view <run-id> --log-failed --repo tryganit/ganit-core`
+1. **Check CI immediately:** `gh run list --repo truecalc/core --branch <branch> --limit 3`
+2. **On failure, read the exact error:** `gh run view <run-id> --log-failed --repo truecalc/core`
 3. **Fix root cause** (not symptoms). Common culprits in this repo: `clippy -D warnings`, formatting, test failures from oracle fixture mismatches.
-4. **Verify locally before pushing:** `cargo clippy --workspace -- -D warnings && cargo test -p ganit-core`
+4. **Verify locally before pushing:** `cargo clippy --workspace -- -D warnings && cargo test -p truecalc-core`
 5. **Push the fix** and confirm CI re-runs green.
 
 **PR description must include:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,38 +225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "ganit-core"
-version = "0.4.3"
-dependencies = [
- "calamine",
- "chrono",
- "nom",
- "proptest",
- "regex-lite",
-]
-
-[[package]]
-name = "ganit-mcp"
-version = "0.4.3"
-dependencies = [
- "ganit-core",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ganit-wasm"
-version = "0.4.3"
-dependencies = [
- "ganit-core",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "tsify-next",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +695,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "truecalc-core"
+version = "0.4.3"
+dependencies = [
+ "calamine",
+ "chrono",
+ "nom",
+ "proptest",
+ "regex-lite",
+]
+
+[[package]]
+name = "truecalc-mcp"
+version = "0.4.3"
+dependencies = [
+ "serde",
+ "serde_json",
+ "truecalc-core",
+]
+
+[[package]]
+name = "truecalc-wasm"
+version = "0.4.3"
+dependencies = [
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "truecalc-core",
+ "tsify-next",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ resolver = "2"
 version = "0.4.3"
 edition = "2021"
 license = "MIT"
-authors = ["tryganit"]
-repository = "https://github.com/tryganit/ganit-core"
+authors = ["truecalc"]
+repository = "https://github.com/truecalc/core"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# @tryganit/core
+# @truecalc/core
 
-[![npm](https://img.shields.io/npm/v/@tryganit/core)](https://www.npmjs.com/package/@tryganit/core)
-[![ganit-core](https://img.shields.io/crates/v/ganit-core?label=ganit-core)](https://crates.io/crates/ganit-core)
-[![ganit-mcp](https://img.shields.io/crates/v/ganit-mcp?label=ganit-mcp)](https://crates.io/crates/ganit-mcp)
-[![docs.rs](https://img.shields.io/docsrs/ganit-core)](https://docs.rs/ganit-core)
-[![license](https://img.shields.io/crates/l/ganit-core)](LICENSE)
-[![Google Sheets Conformance](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/tryganit/ganit-core/gh-pages/conformance-badge.json)](https://tryganit.github.io/ganit-core/)
+[![npm](https://img.shields.io/npm/v/@truecalc/core)](https://www.npmjs.com/package/@truecalc/core)
+[![truecalc-core](https://img.shields.io/crates/v/truecalc-core?label=truecalc-core)](https://crates.io/crates/truecalc-core)
+[![truecalc-mcp](https://img.shields.io/crates/v/truecalc-mcp?label=truecalc-mcp)](https://crates.io/crates/truecalc-mcp)
+[![docs.rs](https://img.shields.io/docsrs/truecalc-core)](https://docs.rs/truecalc-core)
+[![license](https://img.shields.io/crates/l/truecalc-core)](LICENSE)
+[![Google Sheets Conformance](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/truecalc/core/gh-pages/conformance-badge.json)](https://truecalc.github.io/core/)
 
 WebAssembly-powered spreadsheet formula engine for JavaScript/TypeScript.
 
 ## Install
 
 ```sh
-npm install @tryganit/core
+npm install @truecalc/core
 ```
 
 ## Usage
@@ -22,7 +22,7 @@ npm install @tryganit/core
 Works out of the box — no bundler configuration needed.
 
 ```js
-const { evaluate, validate, list_functions } = require('@tryganit/core');
+const { evaluate, validate, list_functions } = require('@truecalc/core');
 
 const result = evaluate('SUM(A1, B1)', { A1: 100, B1: 200 });
 // => { type: 'number', value: 300 }
@@ -49,7 +49,7 @@ export default {
 Then import and use normally:
 
 ```js
-import { evaluate } from '@tryganit/core';
+import { evaluate } from '@truecalc/core';
 
 const result = evaluate('IF(A1 > 0, "yes", "no")', { A1: 1 });
 // => { type: 'text', value: 'yes' }

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,7 @@ coverage:
         only_pulls: true
         informational: false
     project:
-      ganit-core:
+      truecalc-core:
         target: 80%
         paths:
           - crates/core/

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.2](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.4.0...ganit-core-v0.4.2) - 2026-04-17
+## [0.4.2](https://github.com/truecalc/core/compare/truecalc-core-v0.4.0...truecalc-core-v0.4.2) - 2026-04-17
 
 ### Fixed
 
@@ -17,13 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - release v0.4.1
 
-## [0.4.1](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.4.0...ganit-core-v0.4.1) - 2026-04-17
+## [0.4.1](https://github.com/truecalc/core/compare/truecalc-core-v0.4.0...truecalc-core-v0.4.1) - 2026-04-17
 
 ### Fixed
 
 - *(concat)* always return Value::Text, remove numeric oracle workaround
 
-## [0.4.0](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.12...ganit-core-v0.4.0) - 2026-04-17
+## [0.4.0](https://github.com/truecalc/core/compare/truecalc-core-v0.3.12...truecalc-core-v0.4.0) - 2026-04-17
 
 ### Added
 
@@ -32,10 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- Merge pull request #352 from tryganit/feat/334-m4-logical-lambda-impl
+- Merge pull request #352 from truecalc/feat/334-m4-logical-lambda-impl
 - Merge remote-tracking branch 'origin/main' into feat/334-m4-logical-lambda-impl
-- Merge pull request #348 from tryganit/feat/325-m3-engineering-complex
-- Merge pull request #347 from tryganit/feat/332-m4-filter
+- Merge pull request #348 from truecalc/feat/325-m3-engineering-complex
+- Merge pull request #347 from truecalc/feat/332-m4-filter
 - resolve merge conflicts with origin/main in count/mod.rs and eval/mod.rs
 - activate M2 text conformance
 - resolve merge conflicts with main; fix SPLIT to return Value::Empty for empty parts
@@ -44,35 +44,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add unit tests for SPLIT, TEXT, VALUE, COUNTA fixes
 - activate M2 text conformance
 
-## [0.3.12](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.10...ganit-core-v0.3.12) - 2026-04-16
+## [0.3.12](https://github.com/truecalc/core/compare/truecalc-core-v0.3.10...truecalc-core-v0.3.12) - 2026-04-16
 
 ### Other
 
-- Merge pull request #320 from tryganit/release-plz-2026-04-16T22-48-53Z
+- Merge pull request #320 from truecalc/release-plz-2026-04-16T22-48-53Z
 - activate M2 info and logical conformance tests
-- Merge pull request #321 from tryganit/feat/120-activate-engineering-conformance
+- Merge pull request #321 from truecalc/feat/120-activate-engineering-conformance
 - activate M2 engineering conformance and fix 10 failures
 
-## [0.3.11](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.10...ganit-core-v0.3.11) - 2026-04-16
+## [0.3.11](https://github.com/truecalc/core/compare/truecalc-core-v0.3.10...truecalc-core-v0.3.11) - 2026-04-16
 
 ### Other
 
-- Merge pull request #321 from tryganit/feat/120-activate-engineering-conformance
+- Merge pull request #321 from truecalc/feat/120-activate-engineering-conformance
 - activate M2 engineering conformance and fix 10 failures
 
-## [0.3.10](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.9...ganit-core-v0.3.10) - 2026-04-16
+## [0.3.10](https://github.com/truecalc/core/compare/truecalc-core-v0.3.9...truecalc-core-v0.3.10) - 2026-04-16
 
 ### Added
 
 - implement BIN2DEC/HEX/OCT, DEC2BIN/HEX/OCT, HEX2BIN/DEC/OCT, OCT2BIN/DEC/HEX
 
-## [0.3.9](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.8...ganit-core-v0.3.9) - 2026-04-16
+## [0.3.9](https://github.com/truecalc/core/compare/truecalc-core-v0.3.8...truecalc-core-v0.3.9) - 2026-04-16
 
 ### Added
 
 - implement BITAND, BITOR, BITXOR, BITLSHIFT, BITRSHIFT, DELTA, GESTEP
 
-## [0.3.8](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.6...ganit-core-v0.3.8) - 2026-04-16
+## [0.3.8](https://github.com/truecalc/core/compare/truecalc-core-v0.3.6...truecalc-core-v0.3.8) - 2026-04-16
 
 ### Added
 
@@ -89,11 +89,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - release v0.3.7
-- Merge pull request #311 from tryganit/feat/105-math-base-conversion
-- Merge pull request #310 from tryganit/feat/105-math-simple
-- Merge pull request #309 from tryganit/feat/105-math-advanced-rounding
+- Merge pull request #311 from truecalc/feat/105-math-base-conversion
+- Merge pull request #310 from truecalc/feat/105-math-simple
+- Merge pull request #309 from truecalc/feat/105-math-advanced-rounding
 
-## [0.3.7](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.6...ganit-core-v0.3.7) - 2026-04-16
+## [0.3.7](https://github.com/truecalc/core/compare/truecalc-core-v0.3.6...truecalc-core-v0.3.7) - 2026-04-16
 
 ### Added
 
@@ -109,11 +109,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- Merge pull request #311 from tryganit/feat/105-math-base-conversion
-- Merge pull request #310 from tryganit/feat/105-math-simple
-- Merge pull request #309 from tryganit/feat/105-math-advanced-rounding
+- Merge pull request #311 from truecalc/feat/105-math-base-conversion
+- Merge pull request #310 from truecalc/feat/105-math-simple
+- Merge pull request #309 from truecalc/feat/105-math-advanced-rounding
 
-## [0.3.6](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.4...ganit-core-v0.3.6) - 2026-04-16
+## [0.3.6](https://github.com/truecalc/core/compare/truecalc-core-v0.3.4...truecalc-core-v0.3.6) - 2026-04-16
 
 ### Added
 
@@ -133,7 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - release v0.3.5
 - replace flat tests.rs with tests/ subdirectory structure for arabic, clean, dollar, fixed, roman
 
-## [0.3.5](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.4...ganit-core-v0.3.5) - 2026-04-16
+## [0.3.5](https://github.com/truecalc/core/compare/truecalc-core-v0.3.4...truecalc-core-v0.3.5) - 2026-04-16
 
 ### Added
 
@@ -152,7 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - replace flat tests.rs with tests/ subdirectory structure for arabic, clean, dollar, fixed, roman
 
-## [0.3.4](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.2...ganit-core-v0.3.4) - 2026-04-16
+## [0.3.4](https://github.com/truecalc/core/compare/truecalc-core-v0.3.2...truecalc-core-v0.3.4) - 2026-04-16
 
 ### Added
 
@@ -168,12 +168,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - release v0.3.3
 - enable m2 statistical conformance test (all 46 functions implemented)
-- Merge pull request #298 from tryganit/feat/82-order-stats
+- Merge pull request #298 from truecalc/feat/82-order-stats
 - add unit tests for order statistics functions; remove shape-stats duplicates
 - add edge tests and failure tests for shape-stats functions
 - add unit tests for variance/stddev statistical functions
 
-## [0.3.3](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.2...ganit-core-v0.3.3) - 2026-04-16
+## [0.3.3](https://github.com/truecalc/core/compare/truecalc-core-v0.3.2...truecalc-core-v0.3.3) - 2026-04-16
 
 ### Added
 
@@ -188,16 +188,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - enable m2 statistical conformance test (all 46 functions implemented)
-- Merge pull request #298 from tryganit/feat/82-order-stats
+- Merge pull request #298 from truecalc/feat/82-order-stats
 - add unit tests for order statistics functions; remove shape-stats duplicates
 - add edge tests and failure tests for shape-stats functions
 - add unit tests for variance/stddev statistical functions
 
-## [0.3.2](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.0...ganit-core-v0.3.2) - 2026-04-16
+## [0.3.2](https://github.com/truecalc/core/compare/truecalc-core-v0.3.0...truecalc-core-v0.3.2) - 2026-04-16
 
 ### Added
 
-- implement CONVERT unit conversion function ([#176](https://github.com/tryganit/ganit-core/pull/176))
+- implement CONVERT unit conversion function ([#176](https://github.com/truecalc/core/pull/176))
 - implement TO_DATE, TO_DOLLARS, TO_PERCENT, TO_PURE_NUMBER, TO_TEXT parser functions
 
 ### Fixed
@@ -207,14 +207,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - release v0.3.1
-- Merge pull request #292 from tryganit/feat/176-convert
+- Merge pull request #292 from truecalc/feat/176-convert
 - activate m2_parser_conformance (all 6 parser functions implemented)
 
-## [0.3.1](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.3.0...ganit-core-v0.3.1) - 2026-04-16
+## [0.3.1](https://github.com/truecalc/core/compare/truecalc-core-v0.3.0...truecalc-core-v0.3.1) - 2026-04-16
 
 ### Added
 
-- implement CONVERT unit conversion function ([#176](https://github.com/tryganit/ganit-core/pull/176))
+- implement CONVERT unit conversion function ([#176](https://github.com/truecalc/core/pull/176))
 - implement TO_DATE, TO_DOLLARS, TO_PERCENT, TO_PURE_NUMBER, TO_TEXT parser functions
 
 ### Fixed
@@ -223,10 +223,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- Merge pull request #292 from tryganit/feat/176-convert
+- Merge pull request #292 from truecalc/feat/176-convert
 - activate m2_parser_conformance (all 6 parser functions implemented)
 
-## [0.3.0](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.2.1...ganit-core-v0.3.0) - 2026-04-16
+## [0.3.0](https://github.com/truecalc/core/compare/truecalc-core-v0.2.1...truecalc-core-v0.3.0) - 2026-04-16
 
 ### Added
 
@@ -234,11 +234,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - implement CELL function (closes #215)
 - implement ISREF and ISFORMULA (closes #211, #213)
 - *(math)* implement COUNTIF, SUMIF, AVERAGEIF (#273, #274, #275)
-- *(text)* implement SEARCH with wildcard support ([#271](https://github.com/tryganit/ganit-core/pull/271))
-- *(statistical)* implement COUNTBLANK ([#272](https://github.com/tryganit/ganit-core/pull/272))
-- *(text)* implement PROPER function ([#270](https://github.com/tryganit/ganit-core/pull/270))
-- *(parser)* add {} array literal syntax ([#269](https://github.com/tryganit/ganit-core/pull/269))
-- *(date)* implement all 26 M2 date/time functions ([#75](https://github.com/tryganit/ganit-core/pull/75))
+- *(text)* implement SEARCH with wildcard support ([#271](https://github.com/truecalc/core/pull/271))
+- *(statistical)* implement COUNTBLANK ([#272](https://github.com/truecalc/core/pull/272))
+- *(text)* implement PROPER function ([#270](https://github.com/truecalc/core/pull/270))
+- *(parser)* add {} array literal syntax ([#269](https://github.com/truecalc/core/pull/269))
+- *(date)* implement all 26 M2 date/time functions ([#75](https://github.com/truecalc/core/pull/75))
 - *(date)* scaffold 26 date/time function stubs
 - *(tests)* add Google Sheets oracle fixtures for M2, M3, M4 conformance
 
@@ -255,35 +255,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Expand M2 conformance coverage for issue #276 functions
 
-## [0.2.1](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.2.0...ganit-core-v0.2.1) - 2026-04-15
+## [0.2.1](https://github.com/truecalc/core/compare/truecalc-core-v0.2.0...truecalc-core-v0.2.1) - 2026-04-15
 
 ### Other
 
-- Merge pull request #266 from tryganit/fix/registry-driven-list-functions
+- Merge pull request #266 from truecalc/fix/registry-driven-list-functions
 - replace static function tables with live registry reference
 
-## [0.2.0](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.1.6...ganit-core-v0.2.0) - 2026-04-15
+## [0.2.0](https://github.com/truecalc/core/compare/truecalc-core-v0.1.6...truecalc-core-v0.2.0) - 2026-04-15
 
 ### Fixed
 
 - *(mcp)* make list_functions registry-driven, delete static catalogue
 
-## [0.1.6](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.1.4...ganit-core-v0.1.6) - 2026-04-15
+## [0.1.6](https://github.com/truecalc/core/compare/truecalc-core-v0.1.4...truecalc-core-v0.1.6) - 2026-04-15
 
 ### Other
 
 - release v0.1.5
-- Merge pull request #73 from tryganit/docs/readme-badges-and-usage
+- Merge pull request #73 from truecalc/docs/readme-badges-and-usage
 - add badges and per-crate READMEs for crates.io and npm
 
-## [0.1.5](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.1.4...ganit-core-v0.1.5) - 2026-04-15
+## [0.1.5](https://github.com/truecalc/core/compare/truecalc-core-v0.1.4...truecalc-core-v0.1.5) - 2026-04-15
 
 ### Other
 
-- Merge pull request #73 from tryganit/docs/readme-badges-and-usage
+- Merge pull request #73 from truecalc/docs/readme-badges-and-usage
 - add badges and per-crate READMEs for crates.io and npm
 
-## [0.1.4](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.1.3...ganit-core-v0.1.4) - 2026-04-15
+## [0.1.4](https://github.com/truecalc/core/compare/truecalc-core-v0.1.3...truecalc-core-v0.1.4) - 2026-04-15
 
 ### Added
 
@@ -294,21 +294,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(clippy)* use is_some() instead of if let Some(_) pattern
 - *(conformance)* pass all 6 M1 oracle conformance test suites
 
-## [0.1.3](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.1.1...ganit-core-v0.1.3) - 2026-04-15
+## [0.1.3](https://github.com/truecalc/core/compare/truecalc-core-v0.1.1...truecalc-core-v0.1.3) - 2026-04-15
 
 ### Other
 
 - release v0.1.2
 - add M1 oracle conformance harness driven by Google Sheets
 
-## [0.1.2](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.1.1...ganit-core-v0.1.2) - 2026-04-15
+## [0.1.2](https://github.com/truecalc/core/compare/truecalc-core-v0.1.1...truecalc-core-v0.1.2) - 2026-04-15
 
 ### Other
 
 - add M1 oracle conformance harness driven by Google Sheets
 
-## [0.1.1](https://github.com/tryganit/ganit-core/compare/ganit-core-v0.1.0...ganit-core-v0.1.1) - 2026-04-15
+## [0.1.1](https://github.com/truecalc/core/compare/truecalc-core-v0.1.0...truecalc-core-v0.1.1) - 2026-04-15
 
 ### Fixed
 
-- *(core)* evaluate() takes variables by reference ([#34](https://github.com/tryganit/ganit-core/pull/34))
+- *(core)* evaluate() takes variables by reference ([#34](https://github.com/truecalc/core/pull/34))

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ganit-core"
+name = "truecalc-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,24 +1,24 @@
-# ganit-core
+# truecalc-core
 
-[![crates.io](https://img.shields.io/crates/v/ganit-core)](https://crates.io/crates/ganit-core)
-[![docs.rs](https://img.shields.io/docsrs/ganit-core)](https://docs.rs/ganit-core)
-[![license](https://img.shields.io/crates/l/ganit-core)](LICENSE)
+[![crates.io](https://img.shields.io/crates/v/truecalc-core)](https://crates.io/crates/truecalc-core)
+[![docs.rs](https://img.shields.io/docsrs/truecalc-core)](https://docs.rs/truecalc-core)
+[![license](https://img.shields.io/crates/l/truecalc-core)](LICENSE)
 
 Spreadsheet formula engine — parser and evaluator for Excel-compatible formulas.
 
-Also available as a WebAssembly npm package: [`@tryganit/core`](https://www.npmjs.com/package/@tryganit/core)
+Also available as a WebAssembly npm package: [`@truecalc/core`](https://www.npmjs.com/package/@truecalc/core)
 
 ## Install
 
 ```toml
 [dependencies]
-ganit-core = "0.1"
+truecalc-core = "0.1"
 ```
 
 Or via cargo:
 
 ```sh
-cargo add ganit-core
+cargo add truecalc-core
 ```
 
 ## Usage
@@ -27,7 +27,7 @@ cargo add ganit-core
 
 ```rust
 use std::collections::HashMap;
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 
 let mut vars = HashMap::new();
 vars.insert("A1".to_string(), Value::Number(100.0));
@@ -41,7 +41,7 @@ assert_eq!(result, Value::Number(300.0));
 
 ```rust
 use std::collections::HashMap;
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 
 let mut vars = HashMap::new();
 vars.insert("score".to_string(), Value::Number(85.0));
@@ -59,7 +59,7 @@ match evaluate("IF(score >= 60, \"pass\", \"fail\")", &vars) {
 ### Validate without evaluating
 
 ```rust
-use ganit_core::validate;
+use truecalc_core::validate;
 
 match validate("SUM(A1, B1)") {
     Ok(_)  => println!("valid"),
@@ -70,7 +70,7 @@ match validate("SUM(A1, B1)") {
 ### Parse to an AST
 
 ```rust
-use ganit_core::parse;
+use truecalc_core::parse;
 
 let expr = parse("1 + 2 * 3").expect("valid formula");
 // expr is an Expr tree you can walk yourself
@@ -106,7 +106,7 @@ let expr = parse("1 + 2 * 3").expect("valid formula");
 Covers math, logical, text, financial, and statistical categories. For the full list with signatures and descriptions, query the live registry:
 
 ```rust
-use ganit_core::Registry;
+use truecalc_core::Registry;
 
 let registry = Registry::new();
 for (name, meta) in registry.list_functions() {

--- a/crates/core/src/display.rs
+++ b/crates/core/src/display.rs
@@ -5,7 +5,7 @@
 ///
 /// # Examples
 /// ```
-/// # use ganit_core::display::display_number;
+/// # use truecalc_core::display::display_number;
 /// assert_eq!(display_number(1.0), "1");
 /// assert_eq!(display_number(0.1 + 0.2), "0.3");
 /// assert_eq!(display_number(f64::NAN), "#NUM!");

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,4 @@
-// ganit-core: spreadsheet formula parser and evaluator
+// truecalc-core: spreadsheet formula parser and evaluator
 
 pub mod display;
 pub mod eval;

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -8,12 +8,12 @@
 //!   col C  oracle value — the result Google Sheets produced
 //!   col D  test category (basic / edge / coercion / error / nested)
 //!
-//! The test evaluates the formula in col B with `ganit_core::evaluate`, then
+//! The test evaluates the formula in col B with `truecalc_core::evaluate`, then
 //! compares against the oracle in col C.  Number comparisons allow a small
 //! floating-point tolerance.  Rows whose oracle cell is empty are skipped.
 
 use calamine::{open_workbook, CellErrorType, Data, Reader, Xlsx};
-use ganit_core::{evaluate, ErrorKind, Value};
+use truecalc_core::{evaluate, ErrorKind, Value};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 

--- a/crates/core/tests/conformance_reporter.rs
+++ b/crates/core/tests/conformance_reporter.rs
@@ -174,7 +174,7 @@ impl ConformanceReport {
     }
 }
 
-/// Known deviations: cases where ganit intentionally differs from Google Sheets.
+/// Known deviations: cases where truecalc intentionally differs from Google Sheets.
 /// These are excluded from failure counts but documented in the report.
 pub const KNOWN_DEVIATIONS: &[KnownDeviation] = &[
     // Add entries here as they are discovered. Format:

--- a/crates/core/tests/conformance_reporter.rs
+++ b/crates/core/tests/conformance_reporter.rs
@@ -4,7 +4,7 @@
 // Called by the generate_conformance_report test in conformance.rs.
 
 use calamine::{open_workbook, CellErrorType, Data, Reader, Xlsx};
-use ganit_core::{evaluate, ErrorKind, Value};
+use truecalc_core::{evaluate, ErrorKind, Value};
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/crates/core/tests/helpers.rs
+++ b/crates/core/tests/helpers.rs
@@ -1,5 +1,5 @@
 // Test helpers for ganit-core integration tests.
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use std::collections::HashMap;
 
 /// Convenience: evaluate a formula with no variables.

--- a/crates/core/tests/helpers.rs
+++ b/crates/core/tests/helpers.rs
@@ -1,4 +1,4 @@
-// Test helpers for ganit-core integration tests.
+// Test helpers for truecalc-core integration tests.
 use truecalc_core::{evaluate, Value};
 use std::collections::HashMap;
 

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -1,5 +1,5 @@
 mod helpers;
-use ganit_core::{Value, ErrorKind};
+use truecalc_core::{Value, ErrorKind};
 use helpers::{eval, eval_with};
 
 // 1. Basic arithmetic
@@ -90,7 +90,7 @@ proptest! {
         // display_number should produce a string that, when parsed as f64,
         // round-trips with relative tolerance 1e-9 and absolute floor 1e-12
         // (consistent with display_number's 14 significant digits of precision).
-        let s = ganit_core::display_number(n);
+        let s = truecalc_core::display_number(n);
         // If it is a valid display string (not "#NUM!"), it should parse back.
         if !s.starts_with('#') {
             let parsed: f64 = s.parse().expect("display_number output should be parseable");
@@ -102,12 +102,12 @@ proptest! {
 
 #[test]
 fn display_number_nan_returns_num_error() {
-    assert_eq!(ganit_core::display_number(f64::NAN), "#NUM!");
+    assert_eq!(truecalc_core::display_number(f64::NAN), "#NUM!");
 }
 
 #[test]
 fn display_number_infinity_returns_num_error() {
-    assert_eq!(ganit_core::display_number(f64::INFINITY), "#NUM!");
+    assert_eq!(truecalc_core::display_number(f64::INFINITY), "#NUM!");
 }
 
 // Temporary debug test for UNIQUE

--- a/crates/core/tests/property_array.rs
+++ b/crates/core/tests/property_array.rs
@@ -3,7 +3,7 @@
 // Property-based tests for array functions.
 // Verifies length-preservation and element-wise invariants.
 
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 

--- a/crates/core/tests/property_conformance.rs
+++ b/crates/core/tests/property_conformance.rs
@@ -6,7 +6,7 @@
 // These tests complement the fixed-row conformance tests in conformance.rs.
 // They catch regressions for inputs that don't appear in the fixture files.
 
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 

--- a/crates/core/tests/property_date.rs
+++ b/crates/core/tests/property_date.rs
@@ -3,7 +3,7 @@
 // Property-based tests for date functions.
 // Verifies mathematical invariants that hold for any valid date input.
 
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 

--- a/crates/core/tests/property_error_propagation.rs
+++ b/crates/core/tests/property_error_propagation.rs
@@ -4,7 +4,7 @@
 // than silently resolving them. This is a correctness invariant derived from
 // Google Sheets behavior: errors are contagious.
 
-use ganit_core::{evaluate, ErrorKind, Value};
+use truecalc_core::{evaluate, ErrorKind, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 

--- a/crates/core/tests/property_financial.rs
+++ b/crates/core/tests/property_financial.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use std::collections::HashMap;
 
 const CASES: u32 = 500;

--- a/crates/core/tests/property_logical.rs
+++ b/crates/core/tests/property_logical.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use std::collections::HashMap;
 
 const CASES: u32 = 500;

--- a/crates/core/tests/property_lookup.rs
+++ b/crates/core/tests/property_lookup.rs
@@ -4,7 +4,7 @@
 // Verifies invariants: out-of-range inputs produce errors, in-range inputs
 // produce values within the searched set.
 
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 

--- a/crates/core/tests/property_math.rs
+++ b/crates/core/tests/property_math.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use std::collections::HashMap;
 
 const CASES: u32 = 500;

--- a/crates/core/tests/property_text.rs
+++ b/crates/core/tests/property_text.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use std::collections::HashMap;
 
 const CASES: u32 = 500;

--- a/crates/mcp/CHANGELOG.md
+++ b/crates/mcp/CHANGELOG.md
@@ -7,83 +7,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.3](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.4.2...ganit-mcp-v0.4.3) - 2026-04-17
+## [0.4.3](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.2...truecalc-mcp-v0.4.3) - 2026-04-17
 
 ### Other
 
-- Merge pull request #363 from tryganit/docs/mcp-readme-badges-install
-- *(mcp)* add ganit-core badge and use --force for install
+- Merge pull request #363 from truecalc/docs/mcp-readme-badges-install
+- *(mcp)* add truecalc-core badge and use --force for install
 
-## [0.4.2](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.4.1...ganit-mcp-v0.4.2) - 2026-04-17
-
-### Other
-
-- update Cargo.lock dependencies
-
-## [0.3.12](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.3.11...ganit-mcp-v0.3.12) - 2026-04-16
+## [0.4.2](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.1...truecalc-mcp-v0.4.2) - 2026-04-17
 
 ### Other
 
 - update Cargo.lock dependencies
 
-## [0.3.8](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.3.7...ganit-mcp-v0.3.8) - 2026-04-16
+## [0.3.12](https://github.com/truecalc/core/compare/truecalc-mcp-v0.3.11...truecalc-mcp-v0.3.12) - 2026-04-16
 
 ### Other
 
 - update Cargo.lock dependencies
 
-## [0.3.6](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.3.5...ganit-mcp-v0.3.6) - 2026-04-16
+## [0.3.8](https://github.com/truecalc/core/compare/truecalc-mcp-v0.3.7...truecalc-mcp-v0.3.8) - 2026-04-16
 
 ### Other
 
 - update Cargo.lock dependencies
 
-## [0.3.4](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.3.3...ganit-mcp-v0.3.4) - 2026-04-16
+## [0.3.6](https://github.com/truecalc/core/compare/truecalc-mcp-v0.3.5...truecalc-mcp-v0.3.6) - 2026-04-16
 
 ### Other
 
 - update Cargo.lock dependencies
 
-## [0.3.2](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.3.1...ganit-mcp-v0.3.2) - 2026-04-16
+## [0.3.4](https://github.com/truecalc/core/compare/truecalc-mcp-v0.3.3...truecalc-mcp-v0.3.4) - 2026-04-16
 
 ### Other
 
 - update Cargo.lock dependencies
 
-## [0.3.0](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.2.1...ganit-mcp-v0.3.0) - 2026-04-16
+## [0.3.2](https://github.com/truecalc/core/compare/truecalc-mcp-v0.3.1...truecalc-mcp-v0.3.2) - 2026-04-16
+
+### Other
+
+- update Cargo.lock dependencies
+
+## [0.3.0](https://github.com/truecalc/core/compare/truecalc-mcp-v0.2.1...truecalc-mcp-v0.3.0) - 2026-04-16
 
 ### Added
 
 - add Value::Date and implement ISDATE (closes #208)
 
-## [0.2.1](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.2.0...ganit-mcp-v0.2.1) - 2026-04-15
+## [0.2.1](https://github.com/truecalc/core/compare/truecalc-mcp-v0.2.0...truecalc-mcp-v0.2.1) - 2026-04-15
 
 ### Other
 
-- Merge pull request #266 from tryganit/fix/registry-driven-list-functions
+- Merge pull request #266 from truecalc/fix/registry-driven-list-functions
 - replace static function tables with live registry reference
 - *(mcp)* add README and wire readme field in Cargo.toml
 
-## [0.2.0](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.1.6...ganit-mcp-v0.2.0) - 2026-04-15
+## [0.2.0](https://github.com/truecalc/core/compare/truecalc-mcp-v0.1.6...truecalc-mcp-v0.2.0) - 2026-04-15
 
 ### Fixed
 
 - *(mcp)* make list_functions registry-driven, delete static catalogue
 
-## [0.1.6](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.1.5...ganit-mcp-v0.1.6) - 2026-04-15
+## [0.1.6](https://github.com/truecalc/core/compare/truecalc-mcp-v0.1.5...truecalc-mcp-v0.1.6) - 2026-04-15
 
 ### Other
 
 - update Cargo.lock dependencies
 
-## [0.1.3](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.1.2...ganit-mcp-v0.1.3) - 2026-04-15
+## [0.1.3](https://github.com/truecalc/core/compare/truecalc-mcp-v0.1.2...truecalc-mcp-v0.1.3) - 2026-04-15
 
 ### Other
 
 - update Cargo.lock dependencies
 
-## [0.1.1](https://github.com/tryganit/ganit-core/compare/ganit-mcp-v0.1.0...ganit-mcp-v0.1.1) - 2026-04-15
+## [0.1.1](https://github.com/truecalc/core/compare/truecalc-mcp-v0.1.0...truecalc-mcp-v0.1.1) - 2026-04-15
 
 ### Fixed
 
-- *(core)* evaluate() takes variables by reference ([#34](https://github.com/tryganit/ganit-core/pull/34))
+- *(core)* evaluate() takes variables by reference ([#34](https://github.com/truecalc/core/pull/34))

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "ganit-mcp"
+name = "truecalc-mcp"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "MCP server exposing ganit formula evaluation as a tool for AI assistants"
+description = "MCP server exposing truecalc formula evaluation as a tool for AI assistants"
 repository.workspace = true
 readme = "README.md"
 
 [[bin]]
-name = "ganit-mcp"
+name = "truecalc-mcp"
 path = "src/main.rs"
 
 [dependencies]
-ganit-core = { path = "../core", version = "0.4" }
+truecalc-core = { path = "../core", version = "0.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -1,17 +1,17 @@
-# ganit-mcp
+# truecalc-mcp
 
-[![ganit-core](https://img.shields.io/crates/v/ganit-core?label=ganit-core)](https://crates.io/crates/ganit-core)
-[![ganit-mcp](https://img.shields.io/crates/v/ganit-mcp?label=ganit-mcp)](https://crates.io/crates/ganit-mcp)
-[![license](https://img.shields.io/crates/l/ganit-mcp)](LICENSE)
+[![truecalc-core](https://img.shields.io/crates/v/truecalc-core?label=truecalc-core)](https://crates.io/crates/truecalc-core)
+[![truecalc-mcp](https://img.shields.io/crates/v/truecalc-mcp?label=truecalc-mcp)](https://crates.io/crates/truecalc-mcp)
+[![license](https://img.shields.io/crates/l/truecalc-mcp)](LICENSE)
 
-MCP server that exposes [ganit](https://crates.io/crates/ganit-core) spreadsheet formula evaluation as tools for AI assistants.
+MCP server that exposes [truecalc](https://crates.io/crates/truecalc-core) spreadsheet formula evaluation as tools for AI assistants.
 
 Plug it into Claude Desktop (or any MCP-compatible client) and your AI can evaluate, validate, and explain Excel-compatible formulas without writing any code.
 
 ## Install
 
 ```sh
-cargo install ganit-mcp --force
+cargo install truecalc-mcp --force
 ```
 
 ## Claude Desktop setup
@@ -21,8 +21,8 @@ Add the server to `~/Library/Application Support/Claude/claude_desktop_config.js
 ```json
 {
   "mcpServers": {
-    "ganit": {
-      "command": "/Users/your-username/.cargo/bin/ganit-mcp"
+    "truecalc": {
+      "command": "/Users/your-username/.cargo/bin/truecalc-mcp"
     }
   }
 }
@@ -85,8 +85,8 @@ Covers math, logical, text, financial, and statistical categories. For the full 
 
 ## Related
 
-- [`ganit-core`](https://crates.io/crates/ganit-core) — the underlying formula engine (Rust library)
-- [`@tryganit/core`](https://www.npmjs.com/package/@tryganit/core) — WebAssembly package for JavaScript/TypeScript
+- [`truecalc-core`](https://crates.io/crates/truecalc-core) — the underlying formula engine (Rust library)
+- [`@truecalc/core`](https://www.npmjs.com/package/@truecalc/core) — WebAssembly package for JavaScript/TypeScript
 
 ## License
 

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -1,9 +1,9 @@
-// ganit MCP server — hand-rolled JSON-RPC over stdio (MCP protocol 2024-11-05)
+// truecalc MCP server — hand-rolled JSON-RPC over stdio (MCP protocol 2024-11-05)
 
 use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 
-use ganit_core::{evaluate, parse, validate, Expr, Registry, Value};
+use truecalc_core::{evaluate, parse, validate, Expr, Registry, Value};
 use serde_json::{json, Value as JsonValue};
 
 fn main() {
@@ -70,7 +70,7 @@ fn handle_request(req: &JsonValue) -> JsonValue {
             "result": {
                 "protocolVersion": "2024-11-05",
                 "capabilities": { "tools": {} },
-                "serverInfo": { "name": "ganit-mcp", "version": "0.1.0" }
+                "serverInfo": { "name": "truecalc-mcp", "version": "0.1.0" }
             }
         }),
 

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ganit-wasm"
+name = "truecalc-wasm"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -12,7 +12,7 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-ganit-core = { path = "../core" }
+truecalc-core = { path = "../core" }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
 serde_json = "1"

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -1,16 +1,16 @@
-# @tryganit/core
+# @truecalc/core
 
-[![npm](https://img.shields.io/npm/v/@tryganit/core)](https://www.npmjs.com/package/@tryganit/core)
-[![crates.io](https://img.shields.io/crates/v/ganit-core)](https://crates.io/crates/ganit-core)
-[![docs.rs](https://img.shields.io/docsrs/ganit-core)](https://docs.rs/ganit-core)
-[![license](https://img.shields.io/crates/l/ganit-core)](LICENSE)
+[![npm](https://img.shields.io/npm/v/@truecalc/core)](https://www.npmjs.com/package/@truecalc/core)
+[![crates.io](https://img.shields.io/crates/v/truecalc-core)](https://crates.io/crates/truecalc-core)
+[![docs.rs](https://img.shields.io/docsrs/truecalc-core)](https://docs.rs/truecalc-core)
+[![license](https://img.shields.io/crates/l/truecalc-core)](LICENSE)
 
 WebAssembly-powered spreadsheet formula engine for JavaScript/TypeScript.
 
 ## Install
 
 ```sh
-npm install @tryganit/core
+npm install @truecalc/core
 ```
 
 ## Usage
@@ -20,7 +20,7 @@ npm install @tryganit/core
 Works out of the box — no bundler configuration needed.
 
 ```js
-const { evaluate, validate, list_functions } = require('@tryganit/core');
+const { evaluate, validate, list_functions } = require('@truecalc/core');
 
 const result = evaluate('SUM(A1, B1)', { A1: 100, B1: 200 });
 // => { type: 'number', value: 300 }
@@ -47,7 +47,7 @@ export default {
 Then import and use normally:
 
 ```js
-import { evaluate } from '@tryganit/core';
+import { evaluate } from '@truecalc/core';
 
 const result = evaluate('IF(A1 > 0, "yes", "no")', { A1: 1 });
 // => { type: 'text', value: 'yes' }

--- a/crates/wasm/package.json
+++ b/crates/wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tryganit/core",
+  "name": "@truecalc/core",
   "publishConfig": {
     "provenance": true,
     "access": "public"

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -8,7 +8,7 @@ use serde_json::json;
 use tsify_next::Tsify;
 use wasm_bindgen::prelude::*;
 
-use ganit_core::Value;
+use truecalc_core::Value;
 
 /// Convert a JSON value (from JS) into a ganit-core Value.
 fn json_to_value(v: &serde_json::Value) -> Value {
@@ -16,7 +16,7 @@ fn json_to_value(v: &serde_json::Value) -> Value {
         serde_json::Value::Number(n) => n
             .as_f64()
             .map(Value::Number)
-            .unwrap_or(Value::Error(ganit_core::ErrorKind::Num)),
+            .unwrap_or(Value::Error(truecalc_core::ErrorKind::Num)),
         serde_json::Value::String(s) => Value::Text(s.clone()),
         serde_json::Value::Bool(b) => Value::Bool(*b),
         serde_json::Value::Null => Value::Empty,
@@ -69,7 +69,7 @@ pub fn evaluate(formula: &str, variables: JsValue) -> EvalResult {
         None => HashMap::new(),
     };
 
-    match ganit_core::evaluate(formula, &vars) {
+    match truecalc_core::evaluate(formula, &vars) {
         Value::Number(n) | Value::Date(n) => EvalResult::Number { value: n },
         Value::Text(s) => EvalResult::Text { value: s },
         Value::Bool(b) => EvalResult::Bool { value: b },
@@ -84,7 +84,7 @@ pub fn evaluate(formula: &str, variables: JsValue) -> EvalResult {
 /// Returns `{ valid: true }` on success or `{ valid: false, error: "..." }` on failure.
 #[wasm_bindgen]
 pub fn validate(formula: &str) -> ValidateResult {
-    match ganit_core::validate(formula) {
+    match truecalc_core::validate(formula) {
         Ok(_) => ValidateResult { valid: true, error: None },
         Err(e) => ValidateResult { valid: false, error: Some(e.to_string()) },
     }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -10,7 +10,7 @@ use wasm_bindgen::prelude::*;
 
 use truecalc_core::Value;
 
-/// Convert a JSON value (from JS) into a ganit-core Value.
+/// Convert a JSON value (from JS) into a truecalc-core Value.
 fn json_to_value(v: &serde_json::Value) -> Value {
     match v {
         serde_json::Value::Number(n) => n

--- a/docs/superpowers/plans/2026-04-18-ci-infrastructure-367-368.md
+++ b/docs/superpowers/plans/2026-04-18-ci-infrastructure-367-368.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace `cargo test` with `cargo-nextest` for richer test output and inline PR annotations (#367), then add `cargo-llvm-cov` + codecov for per-PR coverage delta comments with an 80% gate on `ganit-core` (#368).
+**Goal:** Replace `cargo test` with `cargo-nextest` for richer test output and inline PR annotations (#367), then add `cargo-llvm-cov` + codecov for per-PR coverage delta comments with an 80% gate on `truecalc-core` (#368).
 
 **Architecture:** Two CI steps replace/extend the existing "Test" step. nextest runs first and writes JUnit XML; a separate coverage step runs llvm-cov and uploads LCOV to codecov.io. Both changes live entirely in `.github/workflows/ci.yml` and new config files.
 
@@ -18,7 +18,7 @@
 |--------|------|---------|
 | Create | `.config/nextest.toml` | nextest CI profile — JUnit XML output path |
 | Modify | `.github/workflows/ci.yml` | Replace `cargo test`, add nextest + test-reporter + llvm-cov + codecov steps |
-| Create | `codecov.yml` | Coverage gate: 80% patch minimum on `ganit-core` |
+| Create | `codecov.yml` | Coverage gate: 80% patch minimum on `truecalc-core` |
 
 ---
 
@@ -84,7 +84,7 @@ Replace the entire `Test` step with:
         uses: dorny/test-reporter@v1
         if: always()
         with:
-          name: ganit-core tests
+          name: truecalc-core tests
           path: target/nextest/ci/junit.xml
           reporter: java-junit
           fail-on-error: false
@@ -137,7 +137,7 @@ coverage:
         only_pulls: true
         informational: false
     project:
-      ganit-core:
+      truecalc-core:
         target: 80%
         paths:
           - crates/core/
@@ -147,7 +147,7 @@ coverage:
 
 ```bash
 git add codecov.yml
-git commit -m "chore: add codecov config with 80% coverage gate on ganit-core"
+git commit -m "chore: add codecov config with 80% coverage gate on truecalc-core"
 ```
 
 ---
@@ -210,13 +210,13 @@ Closes #368"
 
 ```bash
 gh pr create \
-  --repo tryganit/ganit-core \
+  --repo truecalc/core \
   --title "feat(ci): nextest + llvm-cov coverage — inline PR annotations and 80% gate" \
   --assignee hhimanshu \
   --body "$(cat <<'EOF'
 ## Summary
 - Replaces `cargo test` with `cargo-nextest` for per-test timing and inline PR failure annotations (via JUnit XML + dorny/test-reporter)
-- Adds `cargo-llvm-cov` + codecov integration with an 80% coverage gate on `ganit-core`
+- Adds `cargo-llvm-cov` + codecov integration with an 80% coverage gate on `truecalc-core`
 
 ## What a failing test looks like in a PR now
 The `dorny/test-reporter` action parses JUnit XML and posts inline annotations on the PR diff showing exactly which file/line failed and what the expected vs actual values were.
@@ -234,12 +234,12 @@ gh pr edit --add-assignee hhimanshu
 - [ ] **Step 2: Monitor CI**
 
 ```bash
-gh run list --repo tryganit/ganit-core --limit 3
+gh run list --repo truecalc/core --limit 3
 ```
 
 Wait for the run triggered by the PR push. If it fails:
 ```bash
-gh run view <run-id> --log-failed --repo tryganit/ganit-core
+gh run view <run-id> --log-failed --repo truecalc/core
 ```
 
 Fix the root cause and push a new commit (do not amend).

--- a/docs/superpowers/plans/2026-04-18-conformance-badge-370.md
+++ b/docs/superpowers/plans/2026-04-18-conformance-badge-370.md
@@ -97,7 +97,7 @@ fi
 # Build comment body
 comment="## Google Sheets Conformance
 
-ganit calculations match Google Sheets — ${passed}/${total} tests passing (${pct}%)
+truecalc calculations match Google Sheets — ${passed}/${total} tests passing (${pct}%)
 
 | Category | Passed | Rate |
 |----------|--------|------|
@@ -144,7 +144,7 @@ chmod +x .github/scripts/post-conformance-comment.sh
 
 ```bash
 # First generate a report
-cargo test -p ganit-core --test conformance generate_conformance_report -- --nocapture 2>/dev/null
+cargo test -p truecalc-core --test conformance generate_conformance_report -- --nocapture 2>/dev/null
 
 # Run the script without a PR number (skips posting)
 bash .github/scripts/post-conformance-comment.sh target/conformance-report.json "" ""
@@ -172,7 +172,7 @@ After the existing test step (nextest), add:
 
 ```yaml
       - name: Generate conformance report
-        run: cargo test -p ganit-core --test conformance generate_conformance_report -- --nocapture
+        run: cargo test -p truecalc-core --test conformance generate_conformance_report -- --nocapture
 
       - name: Download main-branch conformance baseline
         run: |
@@ -237,7 +237,7 @@ head -10 README.md
 Find the line with existing badges (likely shields.io img tags or markdown badge syntax). After the last existing badge, add:
 
 ```markdown
-[![Google Sheets Conformance](https://img.shields.io/badge/Google%20Sheets%20conformance-passing-brightgreen)](https://github.com/tryganit/ganit-core/actions)
+[![Google Sheets Conformance](https://img.shields.io/badge/Google%20Sheets%20conformance-passing-brightgreen)](https://github.com/truecalc/core/actions)
 ```
 
 Note: This is a static badge initially. It will show "passing" — the exact count can be made dynamic in a follow-up using a Shields.io endpoint badge once a public endpoint is set up. For now the static badge communicates the intent clearly.
@@ -263,7 +263,7 @@ git commit -m "docs: add Google Sheets conformance badge to README"
 
 ```bash
 gh pr create \
-  --repo tryganit/ganit-core \
+  --repo truecalc/core \
   --title "feat(ci): Google Sheets conformance badge + PR regression comment" \
   --assignee hhimanshu \
   --body "$(cat <<'EOF'
@@ -276,7 +276,7 @@ gh pr create \
 ## Sample PR comment
 ```
 ## Google Sheets Conformance
-ganit calculations match Google Sheets — 2430/2461 tests passing (98.7%)
+truecalc calculations match Google Sheets — 2430/2461 tests passing (98.7%)
 
 | Category | Passed | Rate |
 |----------|--------|------|
@@ -297,7 +297,7 @@ gh pr edit --add-assignee hhimanshu
 - [ ] **Step 2: Monitor CI**
 
 ```bash
-gh run list --repo tryganit/ganit-core --limit 3
+gh run list --repo truecalc/core --limit 3
 ```
 
-On failure: `gh run view <run-id> --log-failed --repo tryganit/ganit-core`
+On failure: `gh run view <run-id> --log-failed --repo truecalc/core`

--- a/docs/superpowers/plans/2026-04-18-conformance-property-tests-373.md
+++ b/docs/superpowers/plans/2026-04-18-conformance-property-tests-373.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add property tests that verify `ganit(formula) ≈ Google Sheets oracle` across *generated* inputs for each function category — not just the fixed fixture rows. This catches regressions in functions that have oracle fixtures but limited hand-written edge cases.
+**Goal:** Add property tests that verify `truecalc(formula) ≈ Google Sheets oracle` across *generated* inputs for each function category — not just the fixed fixture rows. This catches regressions in functions that have oracle fixtures but limited hand-written edge cases.
 
-**Architecture:** A new `property_conformance.rs` integration test file. For each function category (math, text, logical, financial), proptest generates valid inputs and evaluates the formula through ganit, then asserts the result matches the *mathematical property* that the Google Sheets oracle implies (e.g. ABS always non-negative, ROUND precision, IF branching). This is not a live GS call — the properties are derived from the oracle behavior we've already confirmed in conformance tests.
+**Architecture:** A new `property_conformance.rs` integration test file. For each function category (math, text, logical, financial), proptest generates valid inputs and evaluates the formula through truecalc, then asserts the result matches the *mathematical property* that the Google Sheets oracle implies (e.g. ABS always non-negative, ROUND precision, IF branching). This is not a live GS call — the properties are derived from the oracle behavior we've already confirmed in conformance tests.
 
-**Tech Stack:** proptest 1.x, ganit_core (evaluate, Value, ErrorKind)
+**Tech Stack:** proptest 1.x, truecalc_core (evaluate, Value, ErrorKind)
 
 **GitHub issue:** Closes #373 (sub-issue of epic #366)
 
@@ -36,7 +36,7 @@
 // These tests complement the fixed-row conformance tests in conformance.rs.
 // They catch regressions for inputs that don't appear in the fixture files.
 
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 
@@ -234,7 +234,7 @@ proptest! {
 - [ ] **Step 2: Run all conformance-driven property tests**
 
 ```bash
-cargo test -p ganit-core --test property_conformance -- --nocapture 2>&1 | tail -15
+cargo test -p truecalc-core --test property_conformance -- --nocapture 2>&1 | tail -15
 ```
 
 Expected: all tests pass. If any fail, the output shows the exact input and formula — investigate the evaluator for that function.
@@ -242,7 +242,7 @@ Expected: all tests pass. If any fail, the output shows the exact input and form
 - [ ] **Step 3: Check test count**
 
 ```bash
-cargo test -p ganit-core --test property_conformance -- --list 2>&1 | grep "test$" | wc -l
+cargo test -p truecalc-core --test property_conformance -- --list 2>&1 | grep "test$" | wc -l
 ```
 
 Expected: at least 15 tests listed.
@@ -271,8 +271,8 @@ Closes #373"
 
 ```bash
 gh pr create \
-  --repo tryganit/ganit-core \
-  --title "test(proptest): conformance-driven property tests — ganit ≈ Google Sheets across generated inputs" \
+  --repo truecalc/core \
+  --title "test(proptest): conformance-driven property tests — truecalc ≈ Google Sheets across generated inputs" \
   --assignee hhimanshu \
   --body "$(cat <<'EOF'
 ## Summary
@@ -294,7 +294,7 @@ gh pr edit --add-assignee hhimanshu
 - [ ] **Step 2: Monitor CI**
 
 ```bash
-gh run list --repo tryganit/ganit-core --limit 3
+gh run list --repo truecalc/core --limit 3
 ```
 
-On failure: `gh run view <run-id> --log-failed --repo tryganit/ganit-core`
+On failure: `gh run view <run-id> --log-failed --repo truecalc/core`

--- a/docs/superpowers/plans/2026-04-18-conformance-reporter-369.md
+++ b/docs/superpowers/plans/2026-04-18-conformance-reporter-369.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Add a `collect_fixture_results` function alongside the existing `run_fixture` (which panics on failure). A new test `#[test] fn generate_conformance_report()` calls `collect_fixture_results` for every fixture file, aggregates into a `ConformanceReport` struct, and serializes to JSON. Known deviations (`#[ignore]`-tagged tests) are tracked via a separate `KNOWN_DEVIATIONS` slice. No new dependencies — JSON is hand-serialized.
 
-**Tech Stack:** Rust std, existing `calamine` + `ganit_core` dev-deps
+**Tech Stack:** Rust std, existing `calamine` + `truecalc_core` dev-deps
 
 **GitHub issue:** Closes #369 (sub-issue of epic #366)
 
@@ -35,7 +35,7 @@
 // Called by the generate_conformance_report test in conformance.rs.
 
 use calamine::{open_workbook, Data, Reader, Xlsx};
-use ganit_core::{evaluate, ErrorKind, Value};
+use truecalc_core::{evaluate, ErrorKind, Value};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -106,7 +106,7 @@ impl ConformanceReport {
     }
 }
 
-/// Known deviations: cases where ganit intentionally differs from Google Sheets.
+/// Known deviations: cases where truecalc intentionally differs from Google Sheets.
 /// These are excluded from failure counts but documented in the report.
 pub const KNOWN_DEVIATIONS: &[KnownDeviation] = &[
     // Add entries here as they are discovered. Format:
@@ -276,15 +276,15 @@ pub struct KnownDeviation {
 - [ ] **Step 4: Compile-check**
 
 ```bash
-cargo test -p ganit-core --test conformance generate_conformance_report --no-run 2>&1 | tail -10
+cargo test -p truecalc-core --test conformance generate_conformance_report --no-run 2>&1 | tail -10
 ```
 
-Expected: `Compiling ganit-core` then `Finished` — no errors.
+Expected: `Compiling truecalc-core` then `Finished` — no errors.
 
 - [ ] **Step 5: Run the report generator**
 
 ```bash
-cargo test -p ganit-core --test conformance generate_conformance_report -- --nocapture 2>&1 | tail -5
+cargo test -p truecalc-core --test conformance generate_conformance_report -- --nocapture 2>&1 | tail -5
 ```
 
 Expected output ends with:
@@ -304,7 +304,7 @@ Verify it is valid JSON with `total`, `passed`, `failed`, `by_category`, and `kn
 - [ ] **Step 7: Run existing conformance tests to confirm nothing regressed**
 
 ```bash
-cargo test -p ganit-core --test conformance 2>&1 | tail -5
+cargo test -p truecalc-core --test conformance 2>&1 | tail -5
 ```
 
 Expected: all existing tests pass (same count as before this change).
@@ -329,7 +329,7 @@ Closes #369"
 
 ```bash
 gh pr create \
-  --repo tryganit/ganit-core \
+  --repo truecalc/core \
   --title "feat(conformance): emit structured JSON summary — per-category pass/fail vs Google Sheets" \
   --assignee hhimanshu \
   --body "$(cat <<'EOF'
@@ -360,7 +360,7 @@ gh pr edit --add-assignee hhimanshu
 - [ ] **Step 2: Monitor CI**
 
 ```bash
-gh run list --repo tryganit/ganit-core --limit 3
+gh run list --repo truecalc/core --limit 3
 ```
 
-On failure: `gh run view <run-id> --log-failed --repo tryganit/ganit-core`
+On failure: `gh run view <run-id> --log-failed --repo truecalc/core`

--- a/docs/superpowers/plans/2026-04-18-proptest-expansion-371.md
+++ b/docs/superpowers/plans/2026-04-18-proptest-expansion-371.md
@@ -4,9 +4,9 @@
 
 **Goal:** Add three new *classes* of property-based tests: idempotency (applying a function twice gives the same result as once), round-trips (composing inverse functions returns the original value), and error propagation (errors passed to non-error-handling functions always produce errors). These properties are mathematical invariants — any violation is a bug, independent of the specific input.
 
-**Architecture:** Expand `property_text.rs` and `property_math.rs` with new proptest blocks. Create `property_error_propagation.rs` for the error class. All tests use the existing `proptest` + `ganit_core` dev-dependencies. Error values are injected as variables using `evaluate(formula, &vars)` where `vars` contains a `Value::Error(ErrorKind::...)` entry.
+**Architecture:** Expand `property_text.rs` and `property_math.rs` with new proptest blocks. Create `property_error_propagation.rs` for the error class. All tests use the existing `proptest` + `truecalc_core` dev-dependencies. Error values are injected as variables using `evaluate(formula, &vars)` where `vars` contains a `Value::Error(ErrorKind::...)` entry.
 
-**Tech Stack:** proptest 1.x, ganit_core (evaluate, Value, ErrorKind)
+**Tech Stack:** proptest 1.x, truecalc_core (evaluate, Value, ErrorKind)
 
 **GitHub issue:** Closes #371 (sub-issue of epic #366)
 
@@ -100,7 +100,7 @@ Read the current end of `crates/core/tests/property_text.rs` to find the closing
 - [ ] **Step 2: Run to verify tests pass**
 
 ```bash
-cargo test -p ganit-core --test property_text 2>&1 | tail -8
+cargo test -p truecalc-core --test property_text 2>&1 | tail -8
 ```
 
 Expected: all tests pass including new ones.
@@ -176,7 +176,7 @@ Append before the closing `}` of the `proptest!` block:
 - [ ] **Step 2: Run tests**
 
 ```bash
-cargo test -p ganit-core --test property_math 2>&1 | tail -8
+cargo test -p truecalc-core --test property_math 2>&1 | tail -8
 ```
 
 Expected: all pass.
@@ -206,7 +206,7 @@ Error propagation rule: for any non-error-handling function `f`, if an input is 
 // than silently resolving them. This is a correctness invariant derived from
 // Google Sheets behavior: errors are contagious.
 
-use ganit_core::{evaluate, ErrorKind, Value};
+use truecalc_core::{evaluate, ErrorKind, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 
@@ -291,7 +291,7 @@ proptest! {
 - [ ] **Step 2: Run to see if they pass or reveal bugs**
 
 ```bash
-cargo test -p ganit-core --test property_error_propagation -- --nocapture 2>&1 | tail -15
+cargo test -p truecalc-core --test property_error_propagation -- --nocapture 2>&1 | tail -15
 ```
 
 Expected: all 9 tests pass. If any fail, the failure output will show the exact error variant and function — investigate the evaluator for that function and fix the propagation before committing.
@@ -316,7 +316,7 @@ Closes #371"
 
 ```bash
 gh pr create \
-  --repo tryganit/ganit-core \
+  --repo truecalc/core \
   --title "test(proptest): idempotency, round-trips, and error propagation properties" \
   --assignee hhimanshu \
   --body "$(cat <<'EOF'
@@ -334,7 +334,7 @@ gh pr edit --add-assignee hhimanshu
 - [ ] **Step 2: Monitor CI**
 
 ```bash
-gh run list --repo tryganit/ganit-core --limit 3
+gh run list --repo truecalc/core --limit 3
 ```
 
-On failure: `gh run view <run-id> --log-failed --repo tryganit/ganit-core`
+On failure: `gh run view <run-id> --log-failed --repo truecalc/core`

--- a/docs/superpowers/plans/2026-04-18-proptest-new-categories-372.md
+++ b/docs/superpowers/plans/2026-04-18-proptest-new-categories-372.md
@@ -4,9 +4,9 @@
 
 **Goal:** Add property-based tests for date, lookup, and array functions — three categories currently not covered by any property tests. These tests verify mathematical invariants that hold independently of specific input values.
 
-**Architecture:** Three new integration test files, one per category, each following the existing pattern in `property_math.rs` (a `run` helper + `proptest!` block). No new dependencies — `proptest` and `ganit_core` are already dev-dependencies.
+**Architecture:** Three new integration test files, one per category, each following the existing pattern in `property_math.rs` (a `run` helper + `proptest!` block). No new dependencies — `proptest` and `truecalc_core` are already dev-dependencies.
 
-**Tech Stack:** proptest 1.x, ganit_core (evaluate, Value, ErrorKind), chrono (for understanding valid date ranges)
+**Tech Stack:** proptest 1.x, truecalc_core (evaluate, Value, ErrorKind), chrono (for understanding valid date ranges)
 
 **GitHub issue:** Closes #372 (sub-issue of epic #366)
 
@@ -44,7 +44,7 @@ ls /path/to/crates/core/src/eval/functions/date/ 2>/dev/null || \
 // Property-based tests for date functions.
 // Verifies mathematical invariants that hold for any valid date input.
 
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 
@@ -159,7 +159,7 @@ proptest! {
 - [ ] **Step 2: Run to verify**
 
 ```bash
-cargo test -p ganit-core --test property_date -- --nocapture 2>&1 | tail -10
+cargo test -p truecalc-core --test property_date -- --nocapture 2>&1 | tail -10
 ```
 
 Expected: all tests pass. If a date function is not yet implemented, some tests may return `Value::Error` and be skipped (the `match` guards handle this). Do not add failing tests for unimplemented functions — note them in the PR description instead.
@@ -193,7 +193,7 @@ grep -r "\"VLOOKUP\"\|\"INDEX\"\|\"MATCH\"\|\"CHOOSE\"\|\"OFFSET\"" \
 // Verifies invariants: out-of-range inputs produce errors, in-range inputs
 // produce values within the searched set.
 
-use ganit_core::{evaluate, ErrorKind, Value};
+use truecalc_core::{evaluate, ErrorKind, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 
@@ -245,7 +245,7 @@ proptest! {
 - [ ] **Step 2: Run**
 
 ```bash
-cargo test -p ganit-core --test property_lookup -- --nocapture 2>&1 | tail -10
+cargo test -p truecalc-core --test property_lookup -- --nocapture 2>&1 | tail -10
 ```
 
 Expected: all tests pass. If CHOOSE is not implemented, the test will show errors — note in PR description and add `prop_assume!` guards as needed.
@@ -272,7 +272,7 @@ git commit -m "test(proptest): add lookup function property tests — CHOOSE ran
 // Property-based tests for array functions.
 // Verifies length-preservation and element-wise invariants.
 
-use ganit_core::{evaluate, Value};
+use truecalc_core::{evaluate, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 
@@ -320,7 +320,7 @@ proptest! {
 - [ ] **Step 2: Run**
 
 ```bash
-cargo test -p ganit-core --test property_array -- --nocapture 2>&1 | tail -10
+cargo test -p truecalc-core --test property_array -- --nocapture 2>&1 | tail -10
 ```
 
 Expected: all tests pass, or tests are skipped gracefully if array functions aren't implemented. Do not commit tests that fail due to unimplemented functions — use `prop_assume!` to skip unimplemented cases and note them in the PR.
@@ -342,7 +342,7 @@ Closes #372"
 
 ```bash
 gh pr create \
-  --repo tryganit/ganit-core \
+  --repo truecalc/core \
   --title "test(proptest): property tests for date, lookup, and array functions" \
   --assignee hhimanshu \
   --body "$(cat <<'EOF'
@@ -364,7 +364,7 @@ gh pr edit --add-assignee hhimanshu
 - [ ] **Step 2: Monitor CI**
 
 ```bash
-gh run list --repo tryganit/ganit-core --limit 3
+gh run list --repo truecalc/core --limit 3
 ```
 
-On failure: `gh run view <run-id> --log-failed --repo tryganit/ganit-core`
+On failure: `gh run view <run-id> --log-failed --repo truecalc/core`

--- a/docs/superpowers/specs/2026-04-18-test-excellence-design.md
+++ b/docs/superpowers/specs/2026-04-18-test-excellence-design.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-ganit's calculations match Google Sheets — and we can prove it. This spec defines the work to measure, enforce, report, and market that claim through five phases of test infrastructure improvements.
+truecalc's calculations match Google Sheets — and we can prove it. This spec defines the work to measure, enforce, report, and market that claim through five phases of test infrastructure improvements.
 
 ---
 
@@ -64,7 +64,7 @@ One GitHub epic. Eight sub-issues across five phases. Each issue is scoped for a
 - Outputs JUnit XML; the GitHub test reporter action parses this and posts inline annotations on the PR diff for each failing test
 - Failure annotation format:
   ```
-  ● ganit-core/src/eval/functions/concat.rs line 42
+  ● truecalc-core/src/eval/functions/concat.rs line 42
     FAILED: concat_numbers
     expected: Text("12")   got: Text("12.0")
   ```
@@ -78,12 +78,12 @@ One GitHub epic. Eight sub-issues across five phases. Each issue is scoped for a
 - Every PR gets a comment showing per-crate coverage delta:
   ```
   Coverage Report
-  ganit-core    87.3%  (+2.1%)  ↑
-  ganit-wasm     0.0%  (new)    ⚠
-  ganit-mcp     12.4%  (new)    ⚠
+  truecalc-core    87.3%  (+2.1%)  ↑
+  truecalc-wasm     0.0%  (new)    ⚠
+  truecalc-mcp     12.4%  (new)    ⚠
   PR drops overall coverage by 0.2%. Gate: 80%.
   ```
-- Coverage gate: 80% minimum on `ganit-core`. PRs that drop below fail CI.
+- Coverage gate: 80% minimum on `truecalc-core`. PRs that drop below fail CI.
 - Files changed: `.github/workflows/ci.yml`, new `codecov.yml`
 
 ### Phase 3 — Conformance Reporter (Issue 3)
@@ -151,7 +151,7 @@ Depends on: Issues 1 (nextest/JUnit), 2 (coverage), 3 (reporter JSON) merged.
 - Files: new `property_date.rs`, `property_lookup.rs`, `property_array.rs`
 
 **Issue 7 — Conformance-driven property tests:**
-- For each function present in the fixture files, generate varied inputs beyond the fixture rows and verify `ganit(formula) ≈ google_sheets_oracle` within documented tolerance
+- For each function present in the fixture files, generate varied inputs beyond the fixture rows and verify `truecalc(formula) ≈ google_sheets_oracle` within documented tolerance
 - This catches regressions in functions that have oracle fixtures but limited hand-written edge cases
 - Files: new `property_conformance.rs`
 
@@ -203,7 +203,7 @@ Issues 5, 6, 7 are pure test additions — no CI files, no shared code — safe 
 ## Success Criteria
 
 - Every PR shows: nextest pass/fail with inline annotations, coverage delta with 80% gate, Google Sheets conformance table with regression detection
-- `ganit-core` coverage ≥ 80% enforced on CI
+- `truecalc-core` coverage ≥ 80% enforced on CI
 - Conformance badge visible in README: `N/M tests · X% · Google Sheets`
 - Property tests cover date, lookup, and array functions
 - Known deviations from GS are documented with reasons and do not fail CI


### PR DESCRIPTION
## Summary

- Rename Rust crates: `ganit-core` → `truecalc-core`, `ganit-mcp` → `truecalc-mcp`, `ganit-wasm` → `truecalc-wasm`
- Update all Rust source files: `ganit_core` → `truecalc_core`, binary name, server info string
- Rename npm package `@tryganit/core` → `@truecalc/core` in `package.json` and `release.yml`
- Update GitHub URLs `tryganit/ganit-core` → `truecalc/core` across all CHANGELOGs, badges, and config files
- Update CI/CD: `check_name`, `cargo -p` flags, binary artifact names, `release-plz` package filter, `codecov.yml`
- Update all READMEs and plan docs

## Test Plan

- [x] `cargo test --workspace` — 2505 passed, 3 ignored
- [x] Zero remaining `ganit`/`tryganit` references in tracked files
- [ ] Verify CI passes after merge

closes #392
closes #393
closes #394
closes #395
closes #396
closes #397
closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)