### PR TITLE
fix(ci): force-push gh-pages to handle branch divergence after org rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           touch .nojekyll
           git add conformance-badge.json index.html .nojekyll
           git diff --cached --quiet || git commit -m "chore: update Google Sheets conformance report [skip ci]"
-          git push origin gh-pages
+          git push --force origin gh-pages
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- `git push origin gh-pages` → `git push --force origin gh-pages`

The gh-pages push failed on the first CI run after the org rename because the remote branch tip was ahead. gh-pages is always fully regenerated from scratch on each run, so force-push is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)