### PR TITLE
fix(release): add MIT license field to npm package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: wasm-pack build crates/wasm --target bundler
 
       - name: Set npm package name
-        run: node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json')); p.name='@truecalc/core'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
+        run: node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json')); p.name='@truecalc/core'; p.license='MIT'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
         working-directory: crates/wasm/pkg
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
wasm-pack does not resolve `license.workspace = true` from `Cargo.toml`, so the generated `pkg/package.json` has no `license` field — causing npm and shields.io to show "no license".

Sets `p.license = 'MIT'` in the same step that sets the package name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)