### PR TITLE
chore: release v0.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "calamine",
  "chrono",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/mcp/CHANGELOG.md
+++ b/crates/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.4...truecalc-mcp-v0.4.5) - 2026-04-18
+
+### Other
+
+- release v0.4.5
+
 ## [0.4.4](https://github.com/truecalc/core/releases/tag/truecalc-mcp-v0.4.4) - 2026-04-18
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.4.4 -> 0.4.5
* `truecalc-mcp`: 0.4.4 -> 0.4.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.4.4](https://github.com/truecalc/core/compare/truecalc-core-v0.4.3...truecalc-core-v0.4.4) - 2026-04-18

### Added

- *(tests)* use CASES=500 constant for all proptest files — up from 256
- *(tests)* surface proptest case counts in CI output per property test
- *(conformance)* emit structured JSON summary — per-category pass/fail vs Google Sheets ([#378](https://github.com/truecalc/core/pull/378))
- *(proptest)* property tests for date, lookup, and array functions ([#376](https://github.com/truecalc/core/pull/376))

### Fixed

- *(tests)* replace all hardcoded 256 with CASES constant in eprintln strings

### Other

- *(proptest)* add array function property tests — SEQUENCE length and value invariants
- *(proptest)* add lookup function property tests — CHOOSE range invariants
- *(proptest)* add date function property tests — YEAR/MONTH/DAY roundtrip, DATEDIF invariants
- *(proptest)* add error propagation property tests for math and text functions
- *(proptest)* add idempotency, monotonicity, and round-trip properties for math functions
- *(proptest)* add idempotency and length properties for text functions
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.4.5](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.4...truecalc-mcp-v0.4.5) - 2026-04-18

### Other

- release v0.4.5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).