### PR TITLE
fix(ci): switch codecov upload to tokenless auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Generate conformance report
         run: cargo test -p truecalc-core --test conformance generate_conformance_report -- --nocapture


### PR DESCRIPTION
## Summary
- Removes `CODECOV_TOKEN` secret from the codecov upload step
- The Codecov GitHub App (now installed on truecalc/core) handles auth automatically for public repos — no token needed

## Test plan
- [ ] CI runs green on this PR
- [ ] After merge to main, codecov.io receives coverage data
- [ ] Badge on https://truecalc.github.io/core/ shows a real percentage instead of "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)