### PR TITLE
fix(ci): restore CODECOV_TOKEN for protected-branch upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Generate conformance report
         run: cargo test -p truecalc-core --test conformance generate_conformance_report -- --nocapture


### PR DESCRIPTION
## Summary
- Restores `CODECOV_TOKEN` removed in #403
- Tokenless upload only works for unprotected branches; `main` is protected, so codecov rejects uploads without an explicit token

## Pre-requisite
Add the `CODECOV_TOKEN` secret from [codecov.io/gh/truecalc/core](https://app.codecov.io/gh/truecalc/core) → Settings → to GitHub repo → Settings → Secrets → Actions.

## Test plan
- [ ] `CODECOV_TOKEN` secret added to GitHub repo
- [ ] CI green on this PR
- [ ] After merge, codecov badge on https://truecalc.github.io/core/ shows a real percentage

closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)