### PR TITLE
feat(ci): self-host coverage badge on gh-pages

### DIFF
--- a/.github/scripts/generate-pages-html.py
+++ b/.github/scripts/generate-pages-html.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Generates index.html for gh-pages with Google Sheets Conformance + Test Coverage by Category.
-# Usage: generate-pages-html.py <junit.xml> <conformance.json> <run_url> <hex> <passed> <total> <pct>
+# Usage: generate-pages-html.py <junit.xml> <conformance.json> <run_url> <hex> <passed> <total> <pct> <cov_pct>
 
 import sys
 import json
@@ -8,7 +8,13 @@ import xml.etree.ElementTree as ET
 from collections import defaultdict
 from datetime import datetime, timezone
 
-junit_path, conf_path, run_url, hex_color, passed, total, pct = sys.argv[1:8]
+junit_path, conf_path, run_url, hex_color, passed, total, pct, cov_pct = sys.argv[1:9]
+
+cov_float = float(cov_pct)
+if   cov_float >= 80.0: cov_hex = "#4c1"
+elif cov_float >= 60.0: cov_hex = "#3c3"
+elif cov_float >= 40.0: cov_hex = "#db1"
+else:                   cov_hex = "#e05"
 
 # ── Unit tests per category ───────────────────────────────────────────────────
 tree = ET.parse(junit_path)
@@ -115,7 +121,7 @@ print(f"""<!DOCTYPE html>
   <h2>Google Sheets Conformance</h2>
   <div class="badges">
     <span class="badge">{passed}/{total} · {pct}%</span>
-    <img src="https://img.shields.io/codecov/c/github/truecalc/core?label=coverage&style=flat-square" alt="Code Coverage" height="22">
+    <span class="badge" style="background:{cov_hex}">coverage · {cov_pct}%</span>
   </div>
 
   <div class="explainer">

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,21 +111,35 @@ jobs:
           else color="red"; hex="#e05"
           fi
           badge_json="{\"schemaVersion\":1,\"label\":\"Google Sheets Conformance\",\"message\":\"${passed}/${total} · ${pct}%\",\"color\":\"${color}\"}"
+          cov_pct=$(python3 -c "
+import re
+content = open('lcov.info').read()
+lh = sum(int(m) for m in re.findall(r'^LH:(\d+)', content, re.M))
+lf = sum(int(m) for m in re.findall(r'^LF:(\d+)', content, re.M))
+print(f'{lh/lf*100:.1f}' if lf else '0.0')
+")
+          if   (( $(echo "$cov_pct >= 80.0" | bc -l) )); then cov_color="brightgreen"
+          elif (( $(echo "$cov_pct >= 60.0" | bc -l) )); then cov_color="green"
+          elif (( $(echo "$cov_pct >= 40.0" | bc -l) )); then cov_color="yellow"
+          else cov_color="red"
+          fi
+          cov_badge_json="{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${cov_pct}%\",\"color\":\"${cov_color}\"}"
           run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           python3 .github/scripts/generate-pages-html.py \
             target/nextest/ci/junit.xml \
             target/conformance-report.json \
-            "$run_url" "${hex}" "${passed}" "${total}" "${pct}" \
+            "$run_url" "${hex}" "${passed}" "${total}" "${pct}" "${cov_pct}" \
             > /tmp/conformance.html
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin gh-pages 2>/dev/null || true
           git checkout gh-pages 2>/dev/null || git checkout --orphan gh-pages
           echo "$badge_json" > conformance-badge.json
+          echo "$cov_badge_json" > coverage-badge.json
           cp /tmp/conformance.html index.html
           touch .nojekyll
-          git add conformance-badge.json index.html .nojekyll
-          git diff --cached --quiet || git commit -m "chore: update Google Sheets conformance report [skip ci]"
+          git add conformance-badge.json coverage-badge.json index.html .nojekyll
+          git diff --cached --quiet || git commit -m "chore: update conformance + coverage report [skip ci]"
           git push --force origin gh-pages
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Parses `lcov.info` (already generated by CI) to compute line coverage %
- Publishes `coverage-badge.json` to gh-pages alongside the existing `conformance-badge.json`
- Replaces the broken codecov badge on the Test Transparency page with an inline self-hosted badge
- Removes all dependency on codecov / external tokens

## How it works
On every push to `main`, CI now:
1. Parses `lcov.info` → sums `LH` (lines hit) / `LF` (lines found) → coverage %
2. Writes `coverage-badge.json` (shields.io endpoint format) to gh-pages
3. Passes coverage % to `generate-pages-html.py` which renders it as an inline badge next to the conformance badge

## Test plan
- [ ] CI green on this PR
- [ ] After merge, https://truecalc.github.io/core/ shows a real coverage % badge (no "unknown")

🤖 Generated with [Claude Code](https://claude.com/claude-code)