### PR TITLE
fix(ci): collapse multiline Python in YAML run block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,13 +111,7 @@ jobs:
           else color="red"; hex="#e05"
           fi
           badge_json="{\"schemaVersion\":1,\"label\":\"Google Sheets Conformance\",\"message\":\"${passed}/${total} · ${pct}%\",\"color\":\"${color}\"}"
-          cov_pct=$(python3 -c "
-import re
-content = open('lcov.info').read()
-lh = sum(int(m) for m in re.findall(r'^LH:(\d+)', content, re.M))
-lf = sum(int(m) for m in re.findall(r'^LF:(\d+)', content, re.M))
-print(f'{lh/lf*100:.1f}' if lf else '0.0')
-")
+          cov_pct=$(python3 -c "import re; c=open('lcov.info').read(); lh=sum(int(m) for m in re.findall(r'^LH:(\d+)',c,re.M)); lf=sum(int(m) for m in re.findall(r'^LF:(\d+)',c,re.M)); print(f'{lh/lf*100:.1f}' if lf else '0.0')")
           if   (( $(echo "$cov_pct >= 80.0" | bc -l) )); then cov_color="brightgreen"
           elif (( $(echo "$cov_pct >= 60.0" | bc -l) )); then cov_color="green"
           elif (( $(echo "$cov_pct >= 40.0" | bc -l) )); then cov_color="yellow"


### PR DESCRIPTION
## Summary
- Fixes YAML syntax error introduced in #405
- The `python3 -c "..."` block had unindented lines that YAML parsed as top-level keys, causing the entire workflow to fail to load
- Collapsed to a single-line Python invocation

## Test plan
- [ ] CI green (workflow loads and runs)
- [ ] After merge to main, coverage badge appears on https://truecalc.github.io/core/

🤖 Generated with [Claude Code](https://claude.com/claude-code)