### PR TITLE
fix(ci): remove codecov upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,6 @@ jobs:
       - name: Generate coverage report
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
 
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: lcov.info
-          fail_ci_if_error: false
-
       - name: Generate conformance report
         run: cargo test -p truecalc-core --test conformance generate_conformance_report -- --nocapture
 


### PR DESCRIPTION
## Summary
- Removes the `codecov/codecov-action@v4` upload step entirely
- Coverage is now self-hosted: `lcov.info` is parsed and published as `coverage-badge.json` on gh-pages (added in #405/#406)
- No external tokens or third-party services needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)