### PR TITLE
feat(ci): publish HTML coverage report to gh-pages

### DIFF
--- a/.github/scripts/generate-pages-html.py
+++ b/.github/scripts/generate-pages-html.py
@@ -165,7 +165,8 @@ print(f"""<!DOCTYPE html>
     Oracle: Google Sheets &nbsp;·&nbsp;
     ✓ = 100% passing &nbsp;·&nbsp; ⚠ = known deviation &nbsp;·&nbsp;
     Updated: {updated} &nbsp;·&nbsp;
-    <a href="{run_url}">CI run</a>
+    <a href="{run_url}">CI run</a> &nbsp;·&nbsp;
+    <a href="coverage/">Full coverage report</a>
   </footer>
 </body>
 </html>""")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Generate coverage report
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info --html --output-dir target/coverage-html
+        run: |
+          cargo llvm-cov --workspace --lcov --output-path lcov.info
+          cargo llvm-cov --workspace --html --output-dir target/coverage-html
 
       - name: Generate conformance report
         run: cargo test -p truecalc-core --test conformance generate_conformance_report -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Generate coverage report
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info --html --output-dir target/coverage-html
 
       - name: Generate conformance report
         run: cargo test -p truecalc-core --test conformance generate_conformance_report -- --nocapture
@@ -118,6 +118,7 @@ jobs:
             target/conformance-report.json \
             "$run_url" "${hex}" "${passed}" "${total}" "${pct}" "${cov_pct}" \
             > /tmp/conformance.html
+          cp -r target/coverage-html /tmp/coverage-html
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin gh-pages 2>/dev/null || true
@@ -125,8 +126,9 @@ jobs:
           echo "$badge_json" > conformance-badge.json
           echo "$cov_badge_json" > coverage-badge.json
           cp /tmp/conformance.html index.html
+          rm -rf coverage && cp -r /tmp/coverage-html coverage
           touch .nojekyll
-          git add conformance-badge.json coverage-badge.json index.html .nojekyll
+          git add conformance-badge.json coverage-badge.json index.html .nojekyll coverage/
           git diff --cached --quiet || git commit -m "chore: update conformance + coverage report [skip ci]"
           git push --force origin gh-pages
         env:


### PR DESCRIPTION
## Summary
- Generates full line-by-line HTML coverage report via `cargo llvm-cov --html`
- Publishes it to gh-pages under `/coverage/` on every push to `main`
- Adds "Full coverage report" link in the footer of the Test Transparency page
- Also removes the `codecov/codecov-action` upload step (superseded by self-hosted badge in #405/#406)

After merge, coverage drill-down available at: https://truecalc.github.io/core/coverage/

🤖 Generated with [Claude Code](https://claude.com/claude-code)