### PR TITLE
fix(ci): copy html/ subdir so coverage report lands at /coverage/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
             target/conformance-report.json \
             "$run_url" "${hex}" "${passed}" "${total}" "${pct}" "${cov_pct}" \
             > /tmp/conformance.html
-          cp -r target/coverage-html /tmp/coverage-html
+          cp -r target/coverage-html/html /tmp/coverage-html
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin gh-pages 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `cargo llvm-cov --html --output-dir target/coverage-html` puts files in `target/coverage-html/html/`
- Was copying the parent dir, so report ended up at `/coverage/html/` instead of `/coverage/`
- Now copies the inner `html/` directory so the report is at https://truecalc.github.io/core/coverage/

🤖 Generated with [Claude Code](https://claude.com/claude-code)