### PR TITLE
test(date): add tests for weekend codes 2-17, WEEKNUM types 11-17, DATEDIF MD/YM/YD

### DIFF
--- a/crates/core/src/eval/functions/date/datedif/tests/success.rs
+++ b/crates/core/src/eval/functions/date/datedif/tests/success.rs
@@ -66,3 +66,46 @@ fn unit_is_case_insensitive() {
     let args = [num(43831.0), num(45458.0), Value::Text("y".into())];
     assert_eq!(datedif_fn(&args), Value::Number(4.0));
 }
+
+// MD: days remaining after complete months are stripped
+#[test]
+fn unit_md_partial_month_days() {
+    // DATEDIF(DATE(2024,1,1), DATE(2024,1,20), "MD") = 19
+    // 45311 = 45292 + 19 = 2024-01-20
+    let args = [num(45292.0), num(45311.0), Value::Text("MD".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(19.0));
+}
+
+#[test]
+fn unit_md_zero_when_same_day_of_month() {
+    // DATEDIF(DATE(2024,1,15), DATE(2024,2,15), "MD") = 0
+    // 45306 = 45292+14 = 2024-01-15, 45337 = 45306+31 = 2024-02-15
+    let args = [num(45306.0), num(45337.0), Value::Text("MD".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(0.0));
+}
+
+// YM: months remaining after complete years
+#[test]
+fn unit_ym_same_year_months() {
+    // DATEDIF(DATE(2024,1,1), DATE(2024,7,1), "YM") = 6
+    // 45474 = 45292+182 = 2024-07-01
+    let args = [num(45292.0), num(45474.0), Value::Text("YM".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(6.0));
+}
+
+#[test]
+fn unit_ym_strips_full_years() {
+    // DATEDIF(DATE(2023,1,1), DATE(2024,7,1), "YM") = 6
+    // 44927 = 2023-01-01, 45474 = 2024-07-01
+    let args = [num(44927.0), num(45474.0), Value::Text("YM".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(6.0));
+}
+
+// YD: days from start to end as if in same year
+#[test]
+fn unit_yd_same_year() {
+    // DATEDIF(DATE(2024,1,1), DATE(2024,4,1), "YD") = 91
+    // 45383 = 45292+91 = 2024-04-01
+    let args = [num(45292.0), num(45383.0), Value::Text("YD".into())];
+    assert_eq!(datedif_fn(&args), Value::Number(91.0));
+}

--- a/crates/core/src/eval/functions/date/weekend.rs
+++ b/crates/core/src/eval/functions/date/weekend.rs
@@ -40,3 +40,135 @@ pub fn weekend_mask(weekend: Option<&Value>) -> Result<[bool; 7], Value> {
         _ => Err(Value::Error(ErrorKind::Value)),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ErrorKind, Value};
+
+    #[test]
+    fn code_1_sat_sun() {
+        let mask = weekend_mask(Some(&Value::Number(1.0))).unwrap();
+        assert_eq!(mask, [false, false, false, false, false, true, true]);
+    }
+
+    #[test]
+    fn code_2_sun_mon() {
+        let mask = weekend_mask(Some(&Value::Number(2.0))).unwrap();
+        assert_eq!(mask, [true, false, false, false, false, false, true]);
+    }
+
+    #[test]
+    fn code_3_mon_tue() {
+        let mask = weekend_mask(Some(&Value::Number(3.0))).unwrap();
+        assert_eq!(mask, [true, true, false, false, false, false, false]);
+    }
+
+    #[test]
+    fn code_4_tue_wed() {
+        let mask = weekend_mask(Some(&Value::Number(4.0))).unwrap();
+        assert_eq!(mask, [false, true, true, false, false, false, false]);
+    }
+
+    #[test]
+    fn code_5_wed_thu() {
+        let mask = weekend_mask(Some(&Value::Number(5.0))).unwrap();
+        assert_eq!(mask, [false, false, true, true, false, false, false]);
+    }
+
+    #[test]
+    fn code_6_thu_fri() {
+        let mask = weekend_mask(Some(&Value::Number(6.0))).unwrap();
+        assert_eq!(mask, [false, false, false, true, true, false, false]);
+    }
+
+    #[test]
+    fn code_7_fri_sat() {
+        let mask = weekend_mask(Some(&Value::Number(7.0))).unwrap();
+        assert_eq!(mask, [false, false, false, false, true, true, false]);
+    }
+
+    #[test]
+    fn code_11_sun_only() {
+        let mask = weekend_mask(Some(&Value::Number(11.0))).unwrap();
+        assert_eq!(mask, [false, false, false, false, false, false, true]);
+    }
+
+    #[test]
+    fn code_12_mon_only() {
+        let mask = weekend_mask(Some(&Value::Number(12.0))).unwrap();
+        assert_eq!(mask, [true, false, false, false, false, false, false]);
+    }
+
+    #[test]
+    fn code_13_tue_only() {
+        let mask = weekend_mask(Some(&Value::Number(13.0))).unwrap();
+        assert_eq!(mask, [false, true, false, false, false, false, false]);
+    }
+
+    #[test]
+    fn code_14_wed_only() {
+        let mask = weekend_mask(Some(&Value::Number(14.0))).unwrap();
+        assert_eq!(mask, [false, false, true, false, false, false, false]);
+    }
+
+    #[test]
+    fn code_15_thu_only() {
+        let mask = weekend_mask(Some(&Value::Number(15.0))).unwrap();
+        assert_eq!(mask, [false, false, false, true, false, false, false]);
+    }
+
+    #[test]
+    fn code_16_fri_only() {
+        let mask = weekend_mask(Some(&Value::Number(16.0))).unwrap();
+        assert_eq!(mask, [false, false, false, false, true, false, false]);
+    }
+
+    #[test]
+    fn code_17_sat_only() {
+        let mask = weekend_mask(Some(&Value::Number(17.0))).unwrap();
+        assert_eq!(mask, [false, false, false, false, false, true, false]);
+    }
+
+    #[test]
+    fn none_defaults_to_sat_sun() {
+        let mask = weekend_mask(None).unwrap();
+        assert_eq!(mask, [false, false, false, false, false, true, true]);
+    }
+
+    #[test]
+    fn string_bitmask_all_zeros_no_weekend() {
+        let mask = weekend_mask(Some(&Value::Text("0000000".into()))).unwrap();
+        assert_eq!(mask, [false; 7]);
+    }
+
+    #[test]
+    fn string_bitmask_all_ones_all_weekend() {
+        let mask = weekend_mask(Some(&Value::Text("1111111".into()))).unwrap();
+        assert_eq!(mask, [true; 7]);
+    }
+
+    #[test]
+    fn string_bitmask_selective() {
+        let mask = weekend_mask(Some(&Value::Text("1010100".into()))).unwrap();
+        assert_eq!(mask, [true, false, true, false, true, false, false]);
+    }
+
+    #[test]
+    fn invalid_code_returns_value_error() {
+        let result = weekend_mask(Some(&Value::Number(8.0)));
+        assert_eq!(result, Err(Value::Error(ErrorKind::Value)));
+    }
+
+    #[test]
+    fn code_10_invalid_returns_value_error() {
+        let result = weekend_mask(Some(&Value::Number(10.0)));
+        assert_eq!(result, Err(Value::Error(ErrorKind::Value)));
+    }
+
+    #[test]
+    fn wrong_string_length_returns_value_error() {
+        let result = weekend_mask(Some(&Value::Text("011".into())));
+        assert_eq!(result, Err(Value::Error(ErrorKind::Value)));
+    }
+}

--- a/crates/core/src/eval/functions/date/weeknum/tests/success.rs
+++ b/crates/core/src/eval/functions/date/weeknum/tests/success.rs
@@ -45,3 +45,58 @@ fn jan8_monday_type2_is_week2() {
     let args = [Value::Number(45299.0), Value::Number(2.0)];
     assert_eq!(weeknum_fn(&args), Value::Number(2.0));
 }
+
+// Return types 11-17 and 21
+// DATE(2024,1,1)=45292 (Mon), DATE(2024,1,7)=45298 (Sun)
+
+#[test]
+fn type_11_week_starts_monday_same_as_2() {
+    // Type 11 = Mon start (same as type 2); Jan 7 2024 (Sun) is still in week 1
+    let args = [Value::Number(45298.0), Value::Number(11.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn type_12_week_starts_tuesday() {
+    // Jan 1 2024 (Mon): Tue-start means offset=6, week=(0+6)/7+1=1
+    let args = [Value::Number(45292.0), Value::Number(12.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn type_13_week_starts_wednesday() {
+    let args = [Value::Number(45292.0), Value::Number(13.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn type_14_week_starts_thursday() {
+    let args = [Value::Number(45292.0), Value::Number(14.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn type_15_week_starts_friday() {
+    let args = [Value::Number(45292.0), Value::Number(15.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn type_16_week_starts_saturday() {
+    let args = [Value::Number(45292.0), Value::Number(16.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn type_17_week_starts_sunday_same_as_1() {
+    // Type 17 = Sun start (same as type 1); Jan 1 2024 (Mon), offset=1, week=(0+1)/7+1=1
+    let args = [Value::Number(45292.0), Value::Number(17.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}
+
+#[test]
+fn type_21_iso_week_for_jan1_2024() {
+    // 2024-01-01 (Mon) is ISO week 1
+    let args = [Value::Number(45292.0), Value::Number(21.0)];
+    assert_eq!(weeknum_fn(&args), Value::Number(1.0));
+}


### PR DESCRIPTION
## Summary

- Adds 21 inline tests to `weekend.rs` covering all numeric codes 1–7, 11–17, string bitmask (all zeros, all ones, selective), `None` default, and invalid inputs
- Appends 8 tests to `weeknum/tests/success.rs` for return types 11–17 and ISO week 21
- Appends 5 tests to `datedif/tests/success.rs` for MD, YM, and YD units (including multi-year strips)
- Corrects a plan error: WEEKNUM type 11 is Monday-start (same as type 2), not Sunday-start

## Test plan
- [ ] `cargo test -p truecalc-core eval::functions::date` — all pass
- [ ] Full CI green

closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)