### PR TITLE
test(financial): add error-path tests for PRICE, YIELD, ACCRINT, validate_basis/frequency

### DIFF
--- a/crates/core/src/eval/functions/financial/bonds/tests/failure.rs
+++ b/crates/core/src/eval/functions/financial/bonds/tests/failure.rs
@@ -92,16 +92,6 @@ fn coupdays_invalid_frequency() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn basis_0_is_valid() {
-    assert_eq!(validate_basis(0.0), Ok(0));
-}
-
-#[test]
-fn basis_4_is_valid() {
-    assert_eq!(validate_basis(4.0), Ok(4));
-}
-
-#[test]
 fn basis_5_is_invalid() {
     assert_eq!(validate_basis(5.0), Err(Value::Error(ErrorKind::Num)));
 }
@@ -114,21 +104,6 @@ fn basis_negative_is_invalid() {
 // ---------------------------------------------------------------------------
 // validate_frequency
 // ---------------------------------------------------------------------------
-
-#[test]
-fn frequency_1_annual_valid() {
-    assert_eq!(validate_frequency(1.0), Ok(1));
-}
-
-#[test]
-fn frequency_2_semiannual_valid() {
-    assert_eq!(validate_frequency(2.0), Ok(2));
-}
-
-#[test]
-fn frequency_4_quarterly_valid() {
-    assert_eq!(validate_frequency(4.0), Ok(4));
-}
 
 #[test]
 fn frequency_3_invalid() {

--- a/crates/core/src/eval/functions/financial/bonds/tests/failure.rs
+++ b/crates/core/src/eval/functions/financial/bonds/tests/failure.rs
@@ -86,3 +86,168 @@ fn coupdays_invalid_frequency() {
     ];
     assert_eq!(coupdays_fn(&args), Value::Error(ErrorKind::Num));
 }
+
+// ---------------------------------------------------------------------------
+// validate_basis
+// ---------------------------------------------------------------------------
+
+#[test]
+fn basis_0_is_valid() {
+    assert_eq!(validate_basis(0.0), Ok(0));
+}
+
+#[test]
+fn basis_4_is_valid() {
+    assert_eq!(validate_basis(4.0), Ok(4));
+}
+
+#[test]
+fn basis_5_is_invalid() {
+    assert_eq!(validate_basis(5.0), Err(Value::Error(ErrorKind::Num)));
+}
+
+#[test]
+fn basis_negative_is_invalid() {
+    assert_eq!(validate_basis(-1.0), Err(Value::Error(ErrorKind::Num)));
+}
+
+// ---------------------------------------------------------------------------
+// validate_frequency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn frequency_1_annual_valid() {
+    assert_eq!(validate_frequency(1.0), Ok(1));
+}
+
+#[test]
+fn frequency_2_semiannual_valid() {
+    assert_eq!(validate_frequency(2.0), Ok(2));
+}
+
+#[test]
+fn frequency_4_quarterly_valid() {
+    assert_eq!(validate_frequency(4.0), Ok(4));
+}
+
+#[test]
+fn frequency_3_invalid() {
+    assert_eq!(validate_frequency(3.0), Err(Value::Error(ErrorKind::Num)));
+}
+
+#[test]
+fn frequency_0_invalid() {
+    assert_eq!(validate_frequency(0.0), Err(Value::Error(ErrorKind::Num)));
+}
+
+// ---------------------------------------------------------------------------
+// PRICE error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn price_settlement_after_maturity_returns_num() {
+    // settlement=46022 (2025-12-31) > maturity=45292 (2024-01-01)
+    let args = [
+        Value::Number(46022.0),
+        Value::Number(45292.0),
+        Value::Number(0.05),
+        Value::Number(0.05),
+        Value::Number(100.0),
+        Value::Number(2.0),
+    ];
+    assert_eq!(price_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn price_invalid_frequency_returns_num() {
+    // frequency=3 is invalid
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(46022.0),
+        Value::Number(0.05),
+        Value::Number(0.05),
+        Value::Number(100.0),
+        Value::Number(3.0),
+    ];
+    assert_eq!(price_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn price_invalid_basis_returns_num() {
+    // basis=5 is invalid
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(46022.0),
+        Value::Number(0.05),
+        Value::Number(0.05),
+        Value::Number(100.0),
+        Value::Number(2.0),
+        Value::Number(5.0),
+    ];
+    assert_eq!(price_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+// ---------------------------------------------------------------------------
+// YIELD error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn yield_settlement_after_maturity_returns_num() {
+    // settlement=46022 > maturity=45292
+    let args = [
+        Value::Number(46022.0),
+        Value::Number(45292.0),
+        Value::Number(0.05),
+        Value::Number(100.0),
+        Value::Number(100.0),
+        Value::Number(2.0),
+    ];
+    assert_eq!(yield_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn yield_invalid_frequency_returns_num() {
+    // frequency=3 is invalid
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(46022.0),
+        Value::Number(0.05),
+        Value::Number(100.0),
+        Value::Number(100.0),
+        Value::Number(3.0),
+    ];
+    assert_eq!(yield_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+// ---------------------------------------------------------------------------
+// ACCRINT error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accrint_invalid_frequency_returns_num() {
+    // frequency=3 is invalid; args: issue, first_interest, settlement, rate, par, frequency
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(45383.0),
+        Value::Number(45474.0),
+        Value::Number(0.05),
+        Value::Number(1000.0),
+        Value::Number(3.0),
+    ];
+    assert_eq!(accrint_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn accrint_invalid_basis_returns_num() {
+    // basis=9 is invalid
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(45383.0),
+        Value::Number(45474.0),
+        Value::Number(0.05),
+        Value::Number(1000.0),
+        Value::Number(2.0),
+        Value::Number(9.0),
+    ];
+    assert_eq!(accrint_fn(&args), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/financial/bonds/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/bonds/tests/success.rs
@@ -143,8 +143,41 @@ fn price_rate_equals_yield_returns_near_par() {
     ];
     let result = price_fn(&args);
     if let Value::Number(p) = result {
-        assert!((p - 100.0).abs() < 0.5, "price {} should be near 100", p);
+        assert!((p - 100.0).abs() < 0.1, "price {} should be near 100", p);
     } else {
         panic!("expected Number, got {:?}", result);
     }
+}
+
+// ---------------------------------------------------------------------------
+// validate_basis
+// ---------------------------------------------------------------------------
+
+#[test]
+fn basis_0_is_valid() {
+    assert_eq!(validate_basis(0.0), Ok(0));
+}
+
+#[test]
+fn basis_4_is_valid() {
+    assert_eq!(validate_basis(4.0), Ok(4));
+}
+
+// ---------------------------------------------------------------------------
+// validate_frequency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn frequency_1_annual_valid() {
+    assert_eq!(validate_frequency(1.0), Ok(1));
+}
+
+#[test]
+fn frequency_2_semiannual_valid() {
+    assert_eq!(validate_frequency(2.0), Ok(2));
+}
+
+#[test]
+fn frequency_4_quarterly_valid() {
+    assert_eq!(validate_frequency(4.0), Ok(4));
 }

--- a/crates/core/src/eval/functions/financial/bonds/tests/success.rs
+++ b/crates/core/src/eval/functions/financial/bonds/tests/success.rs
@@ -124,3 +124,27 @@ fn coupdays_semiannual_30_360() {
     ];
     assert!(approx(coupdays_fn(&args), 180.0, 1e-4));
 }
+
+// ---------------------------------------------------------------------------
+// PRICE happy path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn price_rate_equals_yield_returns_near_par() {
+    // When rate == yield, PRICE should be near redemption (100)
+    // settlement=45292 (2024-01-01), maturity=46022 (2025-12-31)
+    let args = [
+        Value::Number(45292.0),
+        Value::Number(46022.0),
+        Value::Number(0.05),
+        Value::Number(0.05),
+        Value::Number(100.0),
+        Value::Number(2.0),
+    ];
+    let result = price_fn(&args);
+    if let Value::Number(p) = result {
+        assert!((p - 100.0).abs() < 0.5, "price {} should be near 100", p);
+    } else {
+        panic!("expected Number, got {:?}", result);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 17 tests to existing `bonds/tests/` (failure.rs + success.rs)
- Covers `validate_basis` (valid 0/4, invalid 5/negative) and `validate_frequency` (valid 1/2/4, invalid 3/0)
- PRICE error paths: settlement>maturity, invalid frequency, invalid basis; plus happy-path rate==yield near par
- YIELD error paths: settlement>maturity, invalid frequency
- ACCRINT error paths: invalid frequency, invalid basis

## Test plan
- [ ] `cargo test -p truecalc-core eval::functions::financial::bonds` — all pass
- [ ] Full CI green

closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)