### PR TITLE
chore: release v0.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "calamine",
  "chrono",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/truecalc/core/compare/truecalc-core-v0.4.5...truecalc-core-v0.4.6) - 2026-04-18
+
+### Other
+
+- Merge pull request #420 from truecalc/test/logical-core-coverage-415
+- Merge pull request #419 from truecalc/test/financial-coverage-414
+- Merge pull request #418 from truecalc/test/date-coverage-413
+- Merge pull request #417 from truecalc/test/lookup-coverage-412
+- *(lookup)* add edge test for mismatched lookup result range
+- *(lookup)* add xlookup invalid match mode test
+- *(lookup)* add tests for LOOKUP, XLOOKUP, XMATCH, ROW, COLUMN gaps
+
 ## [0.4.4](https://github.com/truecalc/core/compare/truecalc-core-v0.4.3...truecalc-core-v0.4.4) - 2026-04-18
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.4.5 -> 0.4.6 (✓ API compatible changes)
* `truecalc-mcp`: 0.4.5 -> 0.4.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.4.6](https://github.com/truecalc/core/compare/truecalc-core-v0.4.5...truecalc-core-v0.4.6) - 2026-04-18

### Other

- Merge pull request #420 from truecalc/test/logical-core-coverage-415
- Merge pull request #419 from truecalc/test/financial-coverage-414
- Merge pull request #418 from truecalc/test/date-coverage-413
- Merge pull request #417 from truecalc/test/lookup-coverage-412
- *(lookup)* add edge test for mismatched lookup result range
- *(lookup)* add xlookup invalid match mode test
- *(lookup)* add tests for LOOKUP, XLOOKUP, XMATCH, ROW, COLUMN gaps
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.4.5](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.4...truecalc-mcp-v0.4.5) - 2026-04-18

### Other

- release v0.4.5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).