### PR TITLE
chore: release v0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "calamine",
  "chrono",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8](https://github.com/truecalc/core/compare/truecalc-core-v0.4.6...truecalc-core-v0.4.8) - 2026-04-19
+
+### Other
+
+- Merge pull request #426 from truecalc/feat/coverage-array-operator-tests
+- cover uncovered array functions and operator overflow paths
+- add property tests for 7 missing categories
+- *(operator)* add tests for comparison and unary operators
+
 ## [0.4.7](https://github.com/truecalc/core/compare/truecalc-core-v0.4.6...truecalc-core-v0.4.7) - 2026-04-19
 
 ### Other

--- a/crates/mcp/CHANGELOG.md
+++ b/crates/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.7...truecalc-mcp-v0.4.8) - 2026-04-19
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.4.5](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.4...truecalc-mcp-v0.4.5) - 2026-04-18
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.4.6 -> 0.4.8
* `truecalc-mcp`: 0.4.7 -> 0.4.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.4.8](https://github.com/truecalc/core/compare/truecalc-core-v0.4.6...truecalc-core-v0.4.8) - 2026-04-19

### Other

- Merge pull request #426 from truecalc/feat/coverage-array-operator-tests
- cover uncovered array functions and operator overflow paths
- add property tests for 7 missing categories
- *(operator)* add tests for comparison and unary operators
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.4.8](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.7...truecalc-mcp-v0.4.8) - 2026-04-19

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).