### PR TITLE
chore: release v0.4.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "calamine",
  "chrono",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.13](https://github.com/truecalc/core/compare/truecalc-core-v0.4.12...truecalc-core-v0.4.13) - 2026-04-19
+
+### Other
+
+- Merge pull request #439 from truecalc/fix/435-property-web-improvements
+- fix and expand property_web.rs after code review
+
 ## [0.4.12](https://github.com/truecalc/core/compare/truecalc-core-v0.4.11...truecalc-core-v0.4.12) - 2026-04-19
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.4.12 -> 0.4.13 (✓ API compatible changes)
* `truecalc-mcp`: 0.4.12 -> 0.4.13

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.4.13](https://github.com/truecalc/core/compare/truecalc-core-v0.4.12...truecalc-core-v0.4.13) - 2026-04-19

### Other

- Merge pull request #439 from truecalc/fix/435-property-web-improvements
- fix and expand property_web.rs after code review
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.4.11](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.10...truecalc-mcp-v0.4.11) - 2026-04-19

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).