### PR TITLE
test: fix and expand property_web.rs after code review

### DIFF
--- a/crates/core/tests/property_web.rs
+++ b/crates/core/tests/property_web.rs
@@ -18,18 +18,29 @@ fn run_num(formula: &str, x: f64) -> Value {
 }
 
 fn unreserved_string() -> impl Strategy<Value = String> {
-    "[A-Za-z0-9\\-_.~]{0,30}".prop_map(|s| s)
+    "[A-Za-z0-9\\-_.~]{0,30}"
+}
+
+fn ascii_with_spaces() -> impl Strategy<Value = String> {
+    // Must include at least one space so the %20 expansion path is exercised
+    "[a-z]{0,10} [a-z]{0,10}"
+}
+
+fn pure_alpha() -> impl Strategy<Value = String> {
+    "[a-zA-Z]{1,20}"
 }
 
 fn ascii_string() -> impl Strategy<Value = String> {
-    "[a-z]{0,20}".prop_map(|s| s)
+    "[a-z]{0,20}"
 }
 
 fn small_f64() -> impl Strategy<Value = f64> {
     -1e6f64..1e6f64
 }
 
-// ENCODEURL: unreserved chars are left unchanged
+// ── ENCODEURL ────────────────────────────────────────────────────────────────
+
+// Unreserved chars (RFC 3986) are passed through unchanged
 #[test]
 fn encodeurl_unreserved_chars_unchanged() {
     proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(s in unreserved_string())| {
@@ -39,33 +50,37 @@ fn encodeurl_unreserved_chars_unchanged() {
     eprintln!("proptest: {CASES} cases (s ∈ [A-Za-z0-9\\-_.~]{{0,30}})");
 }
 
-// ENCODEURL: output length >= input length (encoding can only grow)
+// Output length >= input length; space encodes to %20 so > is exercised
 #[test]
 fn encodeurl_output_length_ge_input() {
-    proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(s in ascii_string())| {
+    proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(s in ascii_with_spaces())| {
         let len_s = s.len() as f64;
         let result = run_text("=LEN(ENCODEURL(s))", vec![("s", &s)]);
         if let Value::Number(n) = result {
-            prop_assert!(n >= len_s, "ENCODEURL output shorter than input for {:?}", s);
+            prop_assert!(n > len_s,
+                "expected strict growth for {:?} (space → %20), got len {n}", s);
         }
     });
-    eprintln!("proptest: {CASES} cases (s ∈ [a-z]{{0,20}})");
+    eprintln!("proptest: {CASES} cases (s ∈ [a-z]{{0,10}} [a-z]{{0,10}}, always contains space)");
 }
 
-// ENCODEURL: idempotent on unreserved strings (encoding them again yields same result)
+// ENCODEURL is identity on unreserved inputs, so encoding twice == encoding once
 #[test]
 fn encodeurl_idempotent_on_unreserved() {
     proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(s in unreserved_string())| {
-        let once = run_text("=ENCODEURL(s)", vec![("s", &s)]);
-        if let Value::Text(encoded) = once {
-            let twice = run_text("=ENCODEURL(s)", vec![("s", &encoded)]);
-            prop_assert_eq!(twice, Value::Text(encoded));
+        // Unreserved chars are unchanged, so ENCODEURL(s) == s and re-encoding gives s again
+        let first  = run_text("=ENCODEURL(s)", vec![("s", &s)]);
+        if let Value::Text(ref encoded) = first {
+            let second = run_text("=ENCODEURL(s)", vec![("s", encoded)]);
+            prop_assert_eq!(second, first);
         }
     });
     eprintln!("proptest: {CASES} cases (s ∈ [A-Za-z0-9\\-_.~]{{0,30}})");
 }
 
-// ISURL: always FALSE for numeric inputs
+// ── ISURL ────────────────────────────────────────────────────────────────────
+
+// Non-text values always return FALSE
 #[test]
 fn isurl_false_for_numbers() {
     proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(x in small_f64())| {
@@ -75,18 +90,31 @@ fn isurl_false_for_numbers() {
     eprintln!("proptest: {CASES} cases (x ∈ [-1e6, 1e6])");
 }
 
-// ISURL: always TRUE for https:// URLs
+// Strings with a valid https:// scheme are always TRUE (scheme branch)
 #[test]
 fn isurl_true_for_https_urls() {
     proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(host in "[a-z]{1,10}")| {
         let url = format!("https://{host}.com");
         let result = run_text("=ISURL(s)", vec![("s", &url)]);
-        prop_assert_eq!(result, Value::Bool(true), "expected ISURL to be TRUE for {:?}", url);
+        prop_assert_eq!(result, Value::Bool(true), "expected ISURL TRUE for {:?}", url);
     });
     eprintln!("proptest: {CASES} cases (url = https://<host>.com)");
 }
 
-// HYPERLINK(url) returns url unchanged
+// Strings with no dot and no :// scheme are always FALSE (negative boundary)
+#[test]
+fn isurl_false_for_no_dot_no_scheme() {
+    proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(s in pure_alpha())| {
+        let result = run_text("=ISURL(s)", vec![("s", &s)]);
+        prop_assert_eq!(result, Value::Bool(false),
+            "expected ISURL FALSE for {:?} (no dot, no scheme)", s);
+    });
+    eprintln!("proptest: {CASES} cases (s ∈ [a-zA-Z]{{1,20}}, no dot or ://)");
+}
+
+// ── HYPERLINK ────────────────────────────────────────────────────────────────
+
+// Single-arg form returns the url unchanged
 #[test]
 fn hyperlink_no_label_returns_url() {
     proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(url in ascii_string())| {
@@ -96,7 +124,7 @@ fn hyperlink_no_label_returns_url() {
     eprintln!("proptest: {CASES} cases (url ∈ [a-z]{{0,20}})");
 }
 
-// HYPERLINK(url, label) returns label unchanged
+// Two-arg form returns the label unchanged (text label)
 #[test]
 fn hyperlink_with_label_returns_label() {
     proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(url in ascii_string(), label in ascii_string())| {
@@ -106,13 +134,39 @@ fn hyperlink_with_label_returns_label() {
     eprintln!("proptest: {CASES} cases (url ∈ [a-z]{{0,20}}, label ∈ [a-z]{{0,20}})");
 }
 
-// HYPERLINK: LEN(HYPERLINK(url, label)) == LEN(label)
+// HYPERLINK passes numeric labels through without coercion
 #[test]
-fn hyperlink_label_len_matches() {
-    proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(url in ascii_string(), label in ascii_string())| {
-        let label_len = label.len() as f64;
-        let result = run_text("=LEN(HYPERLINK(url, label))", vec![("url", &url), ("label", &label)]);
-        prop_assert_eq!(result, Value::Number(label_len));
+fn hyperlink_numeric_label_passes_through() {
+    proptest!(proptest::prelude::ProptestConfig::with_cases(CASES), |(x in small_f64())| {
+        let vars: HashMap<String, Value> = [
+            ("url".to_string(), Value::Text("https://example.com".to_string())),
+            ("n".to_string(), Value::Number(x)),
+        ].into_iter().collect();
+        let result = evaluate("=HYPERLINK(url, n)", &vars);
+        prop_assert_eq!(result, Value::Number(x));
     });
-    eprintln!("proptest: {CASES} cases (url ∈ [a-z]{{0,20}}, label ∈ [a-z]{{0,20}})");
+    eprintln!("proptest: {CASES} cases (x ∈ [-1e6, 1e6])");
+}
+
+// ── Sanity checks ─────────────────────────────────────────────────────────────
+
+#[test]
+fn sanity_encodeurl() {
+    let result = run_text("=ENCODEURL(s)", vec![("s", "hello world")]);
+    assert_eq!(result, Value::Text("hello%20world".to_string()));
+}
+
+#[test]
+fn sanity_isurl() {
+    assert_eq!(run_text("=ISURL(s)", vec![("s", "https://example.com")]), Value::Bool(true));
+    assert_eq!(run_text("=ISURL(s)", vec![("s", "not-a-url")]),           Value::Bool(false));
+    assert_eq!(run_text("=ISURL(s)", vec![("s", "example.com")]),         Value::Bool(true));
+}
+
+#[test]
+fn sanity_hyperlink() {
+    assert_eq!(
+        run_text("=HYPERLINK(url, label)", vec![("url", "https://x.com"), ("label", "Click")]),
+        Value::Text("Click".to_string())
+    );
 }


### PR DESCRIPTION
## Summary

Follow-up to #436. Code review identified issues in the property tests — fixed all Important items and acted on the Suggestions.

**Important fixes:**
- `encodeurl_output_length_ge_input` was vacuous — `[a-z]` are all RFC 3986 unreserved chars so encoding never grew the length. Switched to `ascii_with_spaces()` (always contains a space → `%20`) and asserted strict `>` to confirm encoding expansion is exercised
- `hyperlink_label_len_matches` was redundant (implied by `hyperlink_with_label_returns_label`). Replaced with `hyperlink_numeric_label_passes_through` which covers the non-text label pass-through path

**Suggestions acted on:**
- Added `isurl_false_for_no_dot_no_scheme`: pins the negative boundary of the domain-like fallback branch (pure-alpha strings with no dot → always FALSE)
- Added `sanity_encodeurl`, `sanity_isurl`, `sanity_hyperlink`: hard-coded regression anchors matching the convention in all other `property_*.rs` files
- Removed no-op `.prop_map(|s| s)` from strategy definitions
- Clarified `encodeurl_idempotent_on_unreserved` with a comment explaining the unreserved-identity scope

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test -p truecalc-core --test property_web` — 12 passed (was 8)
- [x] `cargo test -p truecalc-core` — 2910 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)