### PR TITLE
chore: release v0.4.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "calamine",
  "chrono",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp", "xtask"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.14"
+version = "0.4.15"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.15](https://github.com/truecalc/core/compare/truecalc-core-v0.4.14...truecalc-core-v0.4.15) - 2026-04-21
+
+### Added
+
+- enable per-function conformance coverage gate (T3.12)
+- complete array+filter fixture generator (T3.4)
+- oracle-evaluate all 15 fixture categories via GAS web app
+- complete registry integrity — remove context-limited functions and add alias
+- panic on duplicate function registration at startup
+
+### Fixed
+
+- update XMATCH unit tests to reflect correct mode=1/-1 behavior
+- BUG-19 BETA.INV accepts 3 args with optional lo/hi defaults to 0/1
+- BUG-16/BUG-17 TEXT time formats and VALUE comma/percent/dollar parsing
+- BUG-12/BUG-13/BUG-14 wildcard matching in XLOOKUP, XMATCH, MATCH
+- BUG-11 SORTN now sorts and returns top N elements
+- BUG-09/BUG-10/BUG-04 SORT/SORTBY/UNIQUE 1D array handling
+- re-evaluate fixtures with corrected oracle and restore CI green
+- add missing TSV fixtures so all conformance tests pass on Track 1 branch
+
+### Other
+
+- Merge pull request #478 from truecalc/feat/453-array-filter-generator
+- resolve merge conflicts with main (Track 1 + generators merged)
+- remove duplicate function registrations before assertion lands
+
 ## [0.4.14](https://github.com/truecalc/core/compare/truecalc-core-v0.4.12...truecalc-core-v0.4.14) - 2026-04-20
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.4.14 -> 0.4.15 (✓ API compatible changes)
* `truecalc-mcp`: 0.4.14 -> 0.4.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.4.15](https://github.com/truecalc/core/compare/truecalc-core-v0.4.14...truecalc-core-v0.4.15) - 2026-04-21

### Added

- enable per-function conformance coverage gate (T3.12)
- complete array+filter fixture generator (T3.4)
- oracle-evaluate all 15 fixture categories via GAS web app
- complete registry integrity — remove context-limited functions and add alias
- panic on duplicate function registration at startup

### Fixed

- update XMATCH unit tests to reflect correct mode=1/-1 behavior
- BUG-19 BETA.INV accepts 3 args with optional lo/hi defaults to 0/1
- BUG-16/BUG-17 TEXT time formats and VALUE comma/percent/dollar parsing
- BUG-12/BUG-13/BUG-14 wildcard matching in XLOOKUP, XMATCH, MATCH
- BUG-11 SORTN now sorts and returns top N elements
- BUG-09/BUG-10/BUG-04 SORT/SORTBY/UNIQUE 1D array handling
- re-evaluate fixtures with corrected oracle and restore CI green
- add missing TSV fixtures so all conformance tests pass on Track 1 branch

### Other

- Merge pull request #478 from truecalc/feat/453-array-filter-generator
- resolve merge conflicts with main (Track 1 + generators merged)
- remove duplicate function registrations before assertion lands
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.4.14](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.13...truecalc-mcp-v0.4.14) - 2026-04-20

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).