### PR TITLE
feat: Google Sheets oracle adapter (T3.8)

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,11 +5,12 @@ mod gen_math;
 mod gen_statistical;
 mod gen_text_date_eng_fin;
 mod generate;
+mod oracle_sheets;
 mod types;
 
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use types::Platform;
@@ -79,9 +80,109 @@ fn main() -> Result<()> {
             }
             run_generate_fixtures(platform.to_platform(), category.as_deref(), all)?;
         }
-        Commands::OracleEvaluate { .. } => {
-            println!("not yet implemented — see T3.8");
+        Commands::OracleEvaluate {
+            platform,
+            all,
+            category,
+        } => {
+            if !all && category.is_none() {
+                bail!("Specify --all or --category <name>");
+            }
+            let api_key = std::env::var("GOOGLE_SHEETS_API_KEY")
+                .context("GOOGLE_SHEETS_API_KEY env var not set")?;
+            run_oracle_evaluate(platform.to_platform(), category.as_deref(), all, &api_key)?;
         }
+    }
+
+    Ok(())
+}
+
+fn read_tsv(path: &std::path::Path) -> Result<Vec<types::TestCase>> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .delimiter(b'\t')
+        .from_path(path)
+        .with_context(|| format!("open TSV: {}", path.display()))?;
+
+    let mut cases = Vec::new();
+    for result in rdr.records() {
+        let record = result?;
+        // Columns: description, formula_text, expected_value, test_category, expected_type
+        let description = record.get(0).unwrap_or("").to_string();
+        let formula_text = record.get(1).unwrap_or("").to_string();
+        let expected_value = record.get(2).unwrap_or("").to_string();
+        let test_category = record.get(3).unwrap_or("").to_string();
+        let expected_type = record.get(4).unwrap_or("").to_string();
+        cases.push(types::TestCase {
+            description,
+            formula: formula_text,
+            expected_value,
+            test_category,
+            expected_type,
+        });
+    }
+    Ok(cases)
+}
+
+fn run_oracle_evaluate(
+    platform: Platform,
+    category: Option<&str>,
+    all: bool,
+    api_key: &str,
+) -> Result<()> {
+    let input_dir = PathBuf::from("target/fixture-gen").join(platform.dir_name());
+    let output_dir = PathBuf::from("crates/core/tests/fixtures").join(platform.dir_name());
+    std::fs::create_dir_all(&output_dir)?;
+
+    let oracle = oracle_sheets::SheetsOracle::new(api_key.to_string());
+
+    let categories: &[&str] = &[
+        "math",
+        "statistical",
+        "array",
+        "filter",
+        "lookup",
+        "text",
+        "date",
+        "engineering",
+        "financial",
+        "database",
+    ];
+
+    for &cat in categories {
+        if !all && category != Some(cat) {
+            continue;
+        }
+
+        let input_path = input_dir.join(format!("{}.tsv", cat));
+        if !input_path.exists() {
+            println!("skipping {} — input TSV not found: {}", cat, input_path.display());
+            continue;
+        }
+
+        println!("evaluating {} …", cat);
+        let cases = read_tsv(&input_path)?;
+        let evaluated = oracle.evaluate(&cases)?;
+
+        // write_tsv writes "={formula}" — but our TestCase.formula field already
+        // has the "=" prefix from the input TSV, so strip it before passing in.
+        let stripped: Vec<types::TestCase> = evaluated
+            .into_iter()
+            .map(|mut c| {
+                if c.formula.starts_with('=') {
+                    c.formula = c.formula[1..].to_string();
+                }
+                c
+            })
+            .collect();
+
+        let output_path = output_dir.join(format!("{}.tsv", cat));
+        generate::write_tsv(&stripped, &output_path)?;
+        println!(
+            "wrote {} ({} cases) → {}",
+            cat,
+            stripped.len(),
+            output_path.display()
+        );
     }
 
     Ok(())

--- a/xtask/src/oracle_sheets.rs
+++ b/xtask/src/oracle_sheets.rs
@@ -1,0 +1,195 @@
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Value};
+
+use crate::types::TestCase;
+
+pub struct SheetsOracle {
+    api_key: String,
+    client: reqwest::blocking::Client,
+}
+
+impl SheetsOracle {
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            client: reqwest::blocking::Client::new(),
+        }
+    }
+
+    /// Evaluate a batch of TestCases; returns them with expected_value/expected_type filled in.
+    pub fn evaluate(&self, cases: &[TestCase]) -> Result<Vec<TestCase>> {
+        const BATCH_SIZE: usize = 500;
+        let mut results = Vec::with_capacity(cases.len());
+
+        for chunk in cases.chunks(BATCH_SIZE) {
+            let evaluated = self.evaluate_batch(chunk)?;
+            results.extend(evaluated);
+        }
+
+        Ok(results)
+    }
+
+    fn evaluate_batch(&self, cases: &[TestCase]) -> Result<Vec<TestCase>> {
+        let n = cases.len();
+
+        // Step 1: Create a new spreadsheet
+        let spreadsheet_id = self.create_spreadsheet()?;
+
+        // Ensure cleanup happens even on error
+        let result = self.evaluate_batch_inner(cases, &spreadsheet_id, n);
+        self.delete_spreadsheet(&spreadsheet_id).ok();
+        result
+    }
+
+    fn evaluate_batch_inner(
+        &self,
+        cases: &[TestCase],
+        spreadsheet_id: &str,
+        n: usize,
+    ) -> Result<Vec<TestCase>> {
+        // Step 2: Write formulas to column A
+        // formula_text in the TSV already has the "=" prefix; use it directly.
+        let rows: Vec<Value> = cases
+            .iter()
+            .map(|c| json!([c.formula]))
+            .collect();
+
+        self.write_values(spreadsheet_id, n, &rows)?;
+
+        // Step 3: Read evaluated values from column A
+        let values = self.read_values(spreadsheet_id, n)?;
+
+        // Step 4: Build result TestCases
+        let mut results = Vec::with_capacity(n);
+        for (i, case) in cases.iter().enumerate() {
+            let cell_value = values.get(i).and_then(|row| row.first());
+            let (expected_value, expected_type) = infer_value_and_type(cell_value);
+            results.push(TestCase {
+                description: case.description.clone(),
+                formula: case.formula.clone(),
+                expected_value,
+                test_category: case.test_category.clone(),
+                expected_type,
+            });
+        }
+
+        Ok(results)
+    }
+
+    fn create_spreadsheet(&self) -> Result<String> {
+        let url = format!(
+            "https://sheets.googleapis.com/v4/spreadsheets?key={}",
+            self.api_key
+        );
+        let body = json!({
+            "properties": { "title": "truecalc-oracle-tmp" }
+        });
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .context("create spreadsheet request failed")?;
+
+        let status = resp.status();
+        let json: Value = resp.json().context("create spreadsheet: invalid JSON")?;
+
+        if !status.is_success() {
+            bail!("create spreadsheet failed ({}): {}", status, json);
+        }
+
+        json["spreadsheetId"]
+            .as_str()
+            .map(|s| s.to_string())
+            .context("create spreadsheet: missing spreadsheetId")
+    }
+
+    fn write_values(&self, id: &str, n: usize, rows: &[Value]) -> Result<()> {
+        let url = format!(
+            "https://sheets.googleapis.com/v4/spreadsheets/{}/values/A1:A{}?valueInputOption=USER_ENTERED&key={}",
+            id, n, self.api_key
+        );
+        let body = json!({ "values": rows });
+        let resp = self
+            .client
+            .put(&url)
+            .json(&body)
+            .send()
+            .context("write values request failed")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let json: Value = resp.json().unwrap_or(Value::Null);
+            bail!("write values failed ({}): {}", status, json);
+        }
+
+        Ok(())
+    }
+
+    fn read_values(&self, id: &str, n: usize) -> Result<Vec<Vec<Value>>> {
+        let url = format!(
+            "https://sheets.googleapis.com/v4/spreadsheets/{}/values/A1:A{}?valueRenderOption=UNFORMATTED_VALUE&key={}",
+            id, n, self.api_key
+        );
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .context("read values request failed")?;
+
+        let status = resp.status();
+        let json: Value = resp.json().context("read values: invalid JSON")?;
+
+        if !status.is_success() {
+            bail!("read values failed ({}): {}", status, json);
+        }
+
+        // "values" may be absent if the sheet is empty
+        let values = match json.get("values").and_then(|v| v.as_array()) {
+            Some(rows) => rows
+                .iter()
+                .map(|row| {
+                    row.as_array()
+                        .cloned()
+                        .unwrap_or_default()
+                })
+                .collect(),
+            None => vec![],
+        };
+
+        Ok(values)
+    }
+
+    fn delete_spreadsheet(&self, id: &str) -> Result<()> {
+        let url = format!(
+            "https://www.googleapis.com/drive/v3/files/{}?key={}",
+            id, self.api_key
+        );
+        self.client
+            .delete(&url)
+            .send()
+            .context("delete spreadsheet request failed")?;
+        Ok(())
+    }
+}
+
+/// Infer (expected_value, expected_type) from a raw JSON cell value.
+fn infer_value_and_type(cell: Option<&Value>) -> (String, String) {
+    match cell {
+        None => (String::new(), "error".to_string()),
+        Some(Value::Number(n)) => (n.to_string(), "number".to_string()),
+        Some(Value::Bool(b)) => (b.to_string(), "boolean".to_string()),
+        Some(Value::String(s)) => {
+            // Error values start with "#" followed by letters (e.g., "#REF!", "#VALUE!")
+            let is_error = s.starts_with('#')
+                && s.len() > 1
+                && s.chars().nth(1).is_some_and(|c| c.is_ascii_alphabetic());
+            if is_error {
+                (s.clone(), "error".to_string())
+            } else {
+                (s.clone(), "string".to_string())
+            }
+        }
+        Some(other) => (other.to_string(), "string".to_string()),
+    }
+}


### PR DESCRIPTION
## Summary

- Add `xtask/src/oracle_sheets.rs` with `SheetsOracle` struct that calls the Google Sheets API to batch-evaluate formula fixtures
- Wire `OracleEvaluate` subcommand in `xtask/src/main.rs` to read pre-oracle TSVs, call the oracle, and write filled TSVs to `crates/core/tests/fixtures/google_sheets/`
- Uses `reqwest` blocking client with `GOOGLE_SHEETS_API_KEY` env var; batches 500 rows per spreadsheet create/read/delete cycle

closes #458

## Test plan

- [ ] `cargo build -p xtask` passes (no API key needed)
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] Manual smoke test: `GOOGLE_SHEETS_API_KEY=<key> cargo xtask oracle-evaluate --platform sheets --category math` reads `target/fixture-gen/google_sheets/math.tsv` and writes `crates/core/tests/fixtures/google_sheets/math.tsv` with values filled in

🤖 Generated with [Claude Code](https://claude.com/claude-code)