### PR TITLE
feat: add xtask generators for logical, info, operator, parser, web fixtures

### DIFF
--- a/xtask/src/gen_logical_info.rs
+++ b/xtask/src/gen_logical_info.rs
@@ -1,0 +1,390 @@
+use crate::types::{Platform, TestCase};
+
+fn tc(description: &str, formula: &str, test_category: &str, expected_type: &str) -> TestCase {
+    TestCase::new(description, formula, "", test_category, expected_type)
+}
+
+pub fn generate_logical(_platform: Platform) -> Vec<TestCase> {
+    let mut cases: Vec<TestCase> = Vec::new();
+
+    // ── AND ──────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("AND two TRUE", "AND(TRUE,TRUE)", "basic", "boolean"),
+        tc("AND one FALSE", "AND(TRUE,FALSE)", "basic", "boolean"),
+        tc("AND 1 coerces TRUE", "AND(1,1)", "coercion", "boolean"),
+        tc("AND 0 coerces FALSE", "AND(1,0)", "coercion", "boolean"),
+        tc("AND text -> #VALUE!", r#"AND("1",TRUE)"#, "error", "error"),
+        tc("AND no args -> error", "AND()", "error", "error"),
+        tc("AND nested comparisons", "AND(1>0,2>1)", "nested", "boolean"),
+        tc("AND #DIV/0! propagates", "AND(1/0,TRUE)", "error", "error"),
+    ]);
+
+    // ── OR ───────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("OR one TRUE", "OR(TRUE,FALSE)", "basic", "boolean"),
+        tc("OR all FALSE", "OR(FALSE,FALSE)", "basic", "boolean"),
+        tc("OR 1,0 coercion", "OR(1,0)", "coercion", "boolean"),
+        tc("OR text -> #VALUE!", r#"OR("TRUE")"#, "error", "error"),
+        tc("OR no args -> error", "OR()", "error", "error"),
+        tc("OR nested formula args", r#"OR(ISNUMBER("a"),ISTEXT("a"))"#, "nested", "boolean"),
+        tc("OR #N/A propagates", "OR(NA(),FALSE)", "error", "error"),
+        tc("OR three some true", "OR(FALSE,FALSE,TRUE)", "basic", "boolean"),
+    ]);
+
+    // ── XOR ──────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("XOR TRUE,FALSE -> TRUE", "XOR(TRUE,FALSE)", "basic", "boolean"),
+        tc("XOR TRUE,TRUE -> FALSE", "XOR(TRUE,TRUE)", "basic", "boolean"),
+        tc("XOR FALSE,FALSE -> FALSE", "XOR(FALSE,FALSE)", "basic", "boolean"),
+        tc("XOR 1,0 coercion", "XOR(1,0)", "coercion", "boolean"),
+        tc("XOR 1,1 -> FALSE", "XOR(1,1)", "coercion", "boolean"),
+        tc("XOR three odd -> TRUE", "XOR(TRUE,TRUE,TRUE)", "basic", "boolean"),
+        tc("XOR no args -> error", "XOR()", "error", "error"),
+        tc("XOR text -> error", r#"XOR("TRUE",FALSE)"#, "error", "error"),
+    ]);
+
+    // ── NOT ──────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("NOT(TRUE) -> FALSE", "NOT(TRUE)", "basic", "boolean"),
+        tc("NOT(FALSE) -> TRUE", "NOT(FALSE)", "basic", "boolean"),
+        tc("NOT 1 -> FALSE", "NOT(1)", "coercion", "boolean"),
+        tc("NOT 0 -> TRUE", "NOT(0)", "coercion", "boolean"),
+        tc("NOT text -> error", r#"NOT("1")"#, "error", "error"),
+        tc("NOT no args -> error", "NOT()", "error", "error"),
+        tc("NOT #DIV/0! propagates", "NOT(1/0)", "error", "error"),
+        tc("NOT nested double NOT", "NOT(NOT(TRUE))", "nested", "boolean"),
+    ]);
+
+    // ── IF ───────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("IF true branch", "IF(TRUE,1,2)", "basic", "number"),
+        tc("IF false branch", "IF(FALSE,1,2)", "basic", "number"),
+        tc("IF string branches", r#"IF(TRUE,"yes","no")"#, "basic", "string"),
+        tc("IF 1 is truthy", r#"IF(1,"yes","no")"#, "coercion", "string"),
+        tc("IF 0 is falsy", r#"IF(0,"yes","no")"#, "coercion", "string"),
+        tc("IF missing false branch", "IF(FALSE,1)", "edge", "boolean"),
+        tc("IF error in condition propagates", "IF(1/0,1,2)", "error", "error"),
+        tc("IF nested", r#"IF(1>2,"big",IF(1<2,"small","equal"))"#, "nested", "string"),
+    ]);
+
+    // ── IFERROR ──────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("IFERROR non-error passes through", r#"IFERROR(1,"err")"#, "basic", "number"),
+        tc("IFERROR catches #DIV/0!", r#"IFERROR(1/0,"caught")"#, "basic", "string"),
+        tc("IFERROR catches #NUM!", r#"IFERROR(SQRT(-1),"caught")"#, "basic", "string"),
+        tc("IFERROR catches #N/A", r#"IFERROR(NA(),"caught")"#, "basic", "string"),
+        tc("IFERROR returns 0 on error", "IFERROR(1/0,0)", "basic", "number"),
+        tc("IFERROR missing 2nd arg on error -> empty", "IFERROR(1/0)", "edge", "string"),
+        tc("IFERROR no args -> error", "IFERROR()", "error", "error"),
+        tc("IFERROR nested chain", r#"IFERROR(1/0,IFERROR(SQRT(-1),42))"#, "nested", "number"),
+    ]);
+
+    // ── IFNA ─────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("IFNA non-NA passes through", r#"IFNA(1,"x")"#, "basic", "number"),
+        tc("IFNA catches #N/A", r#"IFNA(NA(),"caught")"#, "basic", "string"),
+        tc("IFNA #DIV/0! NOT caught", r#"IFNA(1/0,"caught")"#, "error", "error"),
+        tc("IFNA text passes through", r#"IFNA("hello","x")"#, "basic", "string"),
+        tc("IFNA no args -> error", "IFNA()", "error", "error"),
+        tc("IFNA nested double", r#"IFNA(IFNA(NA(),NA()),"both")"#, "nested", "string"),
+        tc("IFNA zero passes through", r#"IFNA(0,"x")"#, "basic", "number"),
+        tc("IFNA FALSE passes through", r#"IFNA(FALSE,"x")"#, "basic", "boolean"),
+    ]);
+
+    // ── IFS ──────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("IFS first condition true", r#"IFS(TRUE,"a","b")"#, "basic", "string"),
+        tc("IFS second condition", r#"IFS(FALSE,"a",TRUE,"b")"#, "basic", "string"),
+        tc("IFS numeric condition coercion", r#"IFS(1,"one",0,"zero")"#, "coercion", "string"),
+        tc("IFS no condition true -> #N/A", r#"IFS(FALSE,"a",FALSE,"b")"#, "error", "error"),
+        tc("IFS no args -> error", "IFS()", "error", "error"),
+        tc("IFS nested formula condition", r#"IFS(1>2,"big",1<2,"small")"#, "nested", "string"),
+        tc("IFS first match wins", r#"IFS(TRUE,"first",TRUE,"second")"#, "basic", "string"),
+        tc("IFS #N/A propagates in condition", r#"IFS(NA(),"x")"#, "error", "error"),
+    ]);
+
+    // ── SWITCH ───────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("SWITCH first match", r#"SWITCH(1,1,"one",2,"two")"#, "basic", "string"),
+        tc("SWITCH second match", r#"SWITCH(2,1,"one",2,"two")"#, "basic", "string"),
+        tc("SWITCH default used", r#"SWITCH(3,1,"one",2,"two","other")"#, "basic", "string"),
+        tc("SWITCH no match no default -> #N/A", r#"SWITCH(3,1,"one",2,"two")"#, "error", "error"),
+        tc("SWITCH string match", r#"SWITCH("b","a",1,"b",2)"#, "basic", "number"),
+        tc("SWITCH no args -> error", "SWITCH()", "error", "error"),
+        tc("SWITCH nested formula expr", r#"SWITCH(ABS(-1),1,"one",2,"two")"#, "nested", "string"),
+        tc("SWITCH boolean match", r#"SWITCH(TRUE,TRUE,"yes",FALSE,"no")"#, "basic", "string"),
+    ]);
+
+    // ── LET ──────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("LET basic binding", "LET(x,5,x*2)", "basic", "number"),
+        tc("LET two bindings", "LET(x,3,y,4,x+y)", "basic", "number"),
+        tc("LET string value", r#"LET(s,"hello",LEN(s))"#, "nested", "number"),
+        tc("LET reuse binding in body", "LET(n,10,n*n)", "basic", "number"),
+        tc("LET nested arithmetic", "LET(a,2,b,3,a*b+1)", "basic", "number"),
+        tc("LET error in binding propagates", "LET(x,1/0,x+1)", "error", "error"),
+        tc("LET no args -> error", "LET()", "error", "error"),
+        tc("LET binding used in nested fn", "LET(x,4,SQRT(x))", "nested", "number"),
+    ]);
+
+    // ── LAMBDA ───────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("LAMBDA immediately invoked double", "LAMBDA(x,x*2)(5)", "basic", "number"),
+        tc("LAMBDA add two args", "LAMBDA(x,y,x+y)(3,4)", "basic", "number"),
+        tc("LAMBDA string result", r#"LAMBDA(s,LEN(s))("hello")"#, "nested", "number"),
+        tc("LAMBDA returns boolean", "LAMBDA(x,x>0)(5)", "basic", "boolean"),
+        tc("LAMBDA nested call", "LAMBDA(x,LAMBDA(y,x+y)(10))(5)", "nested", "number"),
+        tc("LAMBDA no args -> error", "LAMBDA()", "error", "error"),
+        tc("LAMBDA zero returns zero", "LAMBDA(x,x*0)(99)", "basic", "number"),
+        tc("LAMBDA uses ABS", "LAMBDA(x,ABS(x))(-7)", "basic", "number"),
+    ]);
+
+    // ── NA ───────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("NA returns #N/A", "NA()", "basic", "error"),
+        tc("NA with arg -> error", "NA(1)", "error", "error"),
+        tc("ISNA(NA()) -> TRUE", "ISNA(NA())", "nested", "boolean"),
+        tc("IFERROR catches NA()", r#"IFERROR(NA(),"caught")"#, "nested", "string"),
+        tc("NA in arithmetic propagates", "NA()+1", "error", "error"),
+        tc("IFNA catches NA()", r#"IFNA(NA(),"ok")"#, "nested", "string"),
+        tc("ISERROR(NA()) -> TRUE", "ISERROR(NA())", "nested", "boolean"),
+        tc("ERROR.TYPE(NA()) -> 7", "ERROR.TYPE(NA())", "nested", "number"),
+    ]);
+
+    // ── N ────────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("N number returns number", "N(5)", "basic", "number"),
+        tc("N zero", "N(0)", "basic", "number"),
+        tc("N negative", "N(-3.14)", "basic", "number"),
+        tc("N TRUE -> 1", "N(TRUE)", "coercion", "number"),
+        tc("N FALSE -> 0", "N(FALSE)", "coercion", "number"),
+        tc("N text -> 0", r#"N("hello")"#, "coercion", "number"),
+        tc("N error propagates", "N(1/0)", "error", "error"),
+        tc("N no args -> error", "N()", "error", "error"),
+    ]);
+
+    // ── TRUE / FALSE ─────────────────────────────────────────────────────────
+    cases.extend([
+        tc("TRUE() returns TRUE", "TRUE()", "basic", "boolean"),
+        tc("TRUE no arg required", "TRUE()", "basic", "boolean"),
+        tc("FALSE() returns FALSE", "FALSE()", "basic", "boolean"),
+        tc("NOT(TRUE()) -> FALSE", "NOT(TRUE())", "nested", "boolean"),
+        tc("AND(TRUE(),FALSE()) -> FALSE", "AND(TRUE(),FALSE())", "nested", "boolean"),
+        tc("IF(TRUE(),1,2) -> 1", "IF(TRUE(),1,2)", "nested", "number"),
+        tc("TRUE() with arg -> error", "TRUE(1)", "error", "error"),
+        tc("FALSE() with arg -> error", "FALSE(1)", "error", "error"),
+    ]);
+
+    cases
+}
+
+pub fn generate_info(_platform: Platform) -> Vec<TestCase> {
+    let mut cases: Vec<TestCase> = Vec::new();
+
+    // ── ISBLANK ───────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISBLANK empty string -> FALSE", r#"ISBLANK("")"#, "basic", "boolean"),
+        tc("ISBLANK number -> FALSE", "ISBLANK(0)", "basic", "boolean"),
+        tc("ISBLANK text -> FALSE", r#"ISBLANK("text")"#, "basic", "boolean"),
+        tc("ISBLANK TRUE -> FALSE", "ISBLANK(TRUE)", "basic", "boolean"),
+        tc("ISBLANK error -> FALSE", "ISBLANK(NA())", "edge", "boolean"),
+        tc("ISBLANK formula result -> FALSE", "ISBLANK(1+0)", "edge", "boolean"),
+        tc("ISBLANK no args -> error", "ISBLANK()", "error", "error"),
+        tc("NOT(ISBLANK text)", r#"NOT(ISBLANK("x"))"#, "nested", "boolean"),
+    ]);
+
+    // ── ISDATE ───────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISDATE date serial -> TRUE", "ISDATE(DATE(2024,1,15))", "basic", "boolean"),
+        tc("ISDATE plain number -> FALSE", "ISDATE(42)", "basic", "boolean"),
+        tc("ISDATE text date string -> TRUE", r#"ISDATE("2024-01-15")"#, "basic", "boolean"),
+        tc("ISDATE text non-date -> FALSE", r#"ISDATE("hello")"#, "basic", "boolean"),
+        tc("ISDATE TRUE -> FALSE", "ISDATE(TRUE)", "basic", "boolean"),
+        tc("ISDATE no args -> error", "ISDATE()", "error", "error"),
+        tc("ISDATE error -> FALSE", "ISDATE(NA())", "edge", "boolean"),
+        tc("IF(ISDATE(DATE(2024,1,1)),1,0)", "IF(ISDATE(DATE(2024,1,1)),1,0)", "nested", "number"),
+    ]);
+
+    // ── ISEMAIL ──────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISEMAIL valid email -> TRUE", r#"ISEMAIL("user@example.com")"#, "basic", "boolean"),
+        tc("ISEMAIL no @ -> FALSE", r#"ISEMAIL("notanemail")"#, "basic", "boolean"),
+        tc("ISEMAIL empty string -> FALSE", r#"ISEMAIL("")"#, "basic", "boolean"),
+        tc("ISEMAIL number -> FALSE", "ISEMAIL(42)", "coercion", "boolean"),
+        tc("ISEMAIL TRUE -> FALSE", "ISEMAIL(TRUE)", "coercion", "boolean"),
+        tc("ISEMAIL no args -> error", "ISEMAIL()", "error", "error"),
+        tc("ISEMAIL domain only -> FALSE", r#"ISEMAIL("@example.com")"#, "edge", "boolean"),
+        tc("IF(ISEMAIL email,1,0)", r#"IF(ISEMAIL("a@b.com"),1,0)"#, "nested", "number"),
+    ]);
+
+    // ── ISERR ────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISERR #DIV/0! -> TRUE", "ISERR(1/0)", "basic", "boolean"),
+        tc("ISERR #N/A -> FALSE (excludes N/A)", "ISERR(NA())", "basic", "boolean"),
+        tc("ISERR #NUM! -> TRUE", "ISERR(SQRT(-1))", "basic", "boolean"),
+        tc("ISERR number -> FALSE", "ISERR(1)", "basic", "boolean"),
+        tc("ISERR text -> FALSE", r#"ISERR("hello")"#, "basic", "boolean"),
+        tc("ISERR no args -> error", "ISERR()", "error", "error"),
+        tc("ISERR nested", r#"ISERR(ABS("x"))"#, "nested", "boolean"),
+        tc("IF(ISERR(1/0),err,ok)", r#"IF(ISERR(1/0),"err","ok")"#, "nested", "string"),
+    ]);
+
+    // ── ISERROR ──────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISERROR #DIV/0! -> TRUE", "ISERROR(1/0)", "basic", "boolean"),
+        tc("ISERROR #N/A -> TRUE (includes N/A)", "ISERROR(NA())", "basic", "boolean"),
+        tc("ISERROR #NUM! -> TRUE", "ISERROR(SQRT(-1))", "basic", "boolean"),
+        tc("ISERROR number -> FALSE", "ISERROR(1)", "basic", "boolean"),
+        tc("ISERROR text -> FALSE", r#"ISERROR("hello")"#, "basic", "boolean"),
+        tc("ISERROR no args -> error", "ISERROR()", "error", "error"),
+        tc("ISERROR vs ISERR on #N/A", "ISERROR(NA())-ISERR(NA())", "nested", "number"),
+        tc("IF(ISERROR(SQRT(-1)),bad,ok)", r#"IF(ISERROR(SQRT(-1)),"bad","ok")"#, "nested", "string"),
+    ]);
+
+    // ── ISLOGICAL ────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISLOGICAL TRUE -> TRUE", "ISLOGICAL(TRUE)", "basic", "boolean"),
+        tc("ISLOGICAL FALSE -> TRUE", "ISLOGICAL(FALSE)", "basic", "boolean"),
+        tc("ISLOGICAL number -> FALSE", "ISLOGICAL(1)", "basic", "boolean"),
+        tc("ISLOGICAL text -> FALSE", r#"ISLOGICAL("TRUE")"#, "basic", "boolean"),
+        tc("ISLOGICAL error -> FALSE", "ISLOGICAL(NA())", "edge", "boolean"),
+        tc("ISLOGICAL no args -> error", "ISLOGICAL()", "error", "error"),
+        tc("ISLOGICAL AND result -> TRUE", "ISLOGICAL(AND(TRUE,FALSE))", "nested", "boolean"),
+        tc("ISLOGICAL comparison -> TRUE", "ISLOGICAL(1>0)", "nested", "boolean"),
+    ]);
+
+    // ── ISNA ─────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISNA #N/A -> TRUE", "ISNA(NA())", "basic", "boolean"),
+        tc("ISNA #DIV/0! -> FALSE", "ISNA(1/0)", "basic", "boolean"),
+        tc("ISNA number -> FALSE", "ISNA(1)", "basic", "boolean"),
+        tc("ISNA text -> FALSE", r#"ISNA("hello")"#, "basic", "boolean"),
+        tc("ISNA empty string -> FALSE", r#"ISNA("")"#, "edge", "boolean"),
+        tc("ISNA no args -> error", "ISNA()", "error", "error"),
+        tc("ISNA(IFERROR(NA(),NA()))", "ISNA(IFERROR(NA(),NA()))", "nested", "boolean"),
+        tc("IF(ISNA(NA()),na,ok)", r#"IF(ISNA(NA()),"na","ok")"#, "nested", "string"),
+    ]);
+
+    // ── ISNONTEXT ────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISNONTEXT number -> TRUE", "ISNONTEXT(1)", "basic", "boolean"),
+        tc("ISNONTEXT TRUE -> TRUE", "ISNONTEXT(TRUE)", "basic", "boolean"),
+        tc("ISNONTEXT text -> FALSE", r#"ISNONTEXT("hello")"#, "basic", "boolean"),
+        tc("ISNONTEXT empty string -> FALSE", r#"ISNONTEXT("")"#, "basic", "boolean"),
+        tc("ISNONTEXT error -> TRUE", "ISNONTEXT(NA())", "edge", "boolean"),
+        tc("ISNONTEXT no args -> error", "ISNONTEXT()", "error", "error"),
+        tc("NOT(ISNONTEXT text)", r#"NOT(ISNONTEXT("hello"))"#, "nested", "boolean"),
+        tc("ISNONTEXT zero -> TRUE", "ISNONTEXT(0)", "basic", "boolean"),
+    ]);
+
+    // ── ISNUMBER ─────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISNUMBER integer -> TRUE", "ISNUMBER(42)", "basic", "boolean"),
+        tc("ISNUMBER decimal -> TRUE", "ISNUMBER(3.14)", "basic", "boolean"),
+        tc("ISNUMBER zero -> TRUE", "ISNUMBER(0)", "basic", "boolean"),
+        tc("ISNUMBER text -> FALSE", r#"ISNUMBER("42")"#, "basic", "boolean"),
+        tc("ISNUMBER TRUE -> FALSE", "ISNUMBER(TRUE)", "basic", "boolean"),
+        tc("ISNUMBER error -> FALSE", "ISNUMBER(NA())", "edge", "boolean"),
+        tc("ISNUMBER no args -> error", "ISNUMBER()", "error", "error"),
+        tc("AND(ISNUMBER(1),ISNUMBER(2))", "AND(ISNUMBER(1),ISNUMBER(2))", "nested", "boolean"),
+    ]);
+
+    // ── ISREF ────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISREF number -> FALSE", "ISREF(1)", "basic", "boolean"),
+        tc("ISREF text -> FALSE", r#"ISREF("A1")"#, "basic", "boolean"),
+        tc("ISREF TRUE -> FALSE", "ISREF(TRUE)", "basic", "boolean"),
+        tc("ISREF error -> FALSE", "ISREF(NA())", "edge", "boolean"),
+        tc("ISREF no args -> error", "ISREF()", "error", "error"),
+        tc("ISREF empty string -> FALSE", r#"ISREF("")"#, "basic", "boolean"),
+        tc("NOT(ISREF(1))", "NOT(ISREF(1))", "nested", "boolean"),
+        tc("IF(ISREF(1),yes,no)", r#"IF(ISREF(1),"yes","no")"#, "nested", "string"),
+    ]);
+
+    // ── ISTEXT ───────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISTEXT text -> TRUE", r#"ISTEXT("hello")"#, "basic", "boolean"),
+        tc("ISTEXT empty string -> TRUE", r#"ISTEXT("")"#, "basic", "boolean"),
+        tc("ISTEXT number -> FALSE", "ISTEXT(42)", "basic", "boolean"),
+        tc("ISTEXT TRUE -> FALSE", "ISTEXT(TRUE)", "basic", "boolean"),
+        tc("ISTEXT error -> FALSE", "ISTEXT(NA())", "edge", "boolean"),
+        tc("ISTEXT no args -> error", "ISTEXT()", "error", "error"),
+        tc("AND(ISTEXT text, ISTEXT num)", r#"AND(ISTEXT("a"),ISTEXT(1))"#, "nested", "boolean"),
+        tc("ISTEXT numeric string -> TRUE", r#"ISTEXT("42")"#, "basic", "boolean"),
+    ]);
+
+    // ── ERROR.TYPE ───────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ERROR.TYPE #DIV/0! -> 2", "ERROR.TYPE(1/0)", "basic", "number"),
+        tc("ERROR.TYPE #N/A -> 7", "ERROR.TYPE(NA())", "basic", "number"),
+        tc("ERROR.TYPE #NUM! -> 6", "ERROR.TYPE(SQRT(-1))", "basic", "number"),
+        tc("ERROR.TYPE non-error -> #N/A", "ERROR.TYPE(1)", "edge", "error"),
+        tc("ERROR.TYPE no args -> error", "ERROR.TYPE()", "error", "error"),
+        tc("ERROR.TYPE nested result +1", "ERROR.TYPE(NA())+1", "nested", "number"),
+        tc("ERROR.TYPE #VALUE! -> 3", r#"ERROR.TYPE("a"+1)"#, "basic", "number"),
+        tc("ERROR.TYPE nested error", r#"ERROR.TYPE(ABS("x"))"#, "nested", "number"),
+    ]);
+
+    // ── N ────────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("N number returns number", "N(5)", "basic", "number"),
+        tc("N TRUE -> 1", "N(TRUE)", "coercion", "number"),
+        tc("N FALSE -> 0", "N(FALSE)", "coercion", "number"),
+        tc("N text -> 0", r#"N("hello")"#, "coercion", "number"),
+        tc("N zero", "N(0)", "basic", "number"),
+        tc("N error propagates", "N(1/0)", "error", "error"),
+        tc("N no args -> error", "N()", "error", "error"),
+        tc("N nested in arithmetic", "N(TRUE)+N(FALSE)", "nested", "number"),
+    ]);
+
+    // ── NA ───────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("NA() returns #N/A", "NA()", "basic", "error"),
+        tc("NA with arg -> error", "NA(1)", "error", "error"),
+        tc("ISNA(NA()) -> TRUE", "ISNA(NA())", "nested", "boolean"),
+        tc("ISERROR(NA()) -> TRUE", "ISERROR(NA())", "nested", "boolean"),
+        tc("ISERR(NA()) -> FALSE", "ISERR(NA())", "nested", "boolean"),
+        tc("IFNA(NA(),0) -> 0", "IFNA(NA(),0)", "nested", "number"),
+        tc("NA propagates in sum", "NA()+1", "error", "error"),
+        tc("ERROR.TYPE(NA()) -> 7", "ERROR.TYPE(NA())", "nested", "number"),
+    ]);
+
+    // ── TYPE ─────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("TYPE number -> 1", "TYPE(5)", "basic", "number"),
+        tc("TYPE text -> 2", r#"TYPE("hello")"#, "basic", "number"),
+        tc("TYPE boolean -> 4", "TYPE(TRUE)", "basic", "number"),
+        tc("TYPE error -> 16", "TYPE(NA())", "basic", "number"),
+        tc("TYPE array -> 64", "TYPE({1,2,3})", "basic", "number"),
+        tc("TYPE zero -> 1", "TYPE(0)", "basic", "number"),
+        tc("TYPE no args -> error", "TYPE()", "error", "error"),
+        tc("TYPE nested formula result", "TYPE(1+1)", "nested", "number"),
+    ]);
+
+    // ── CELL ─────────────────────────────────────────────────────────────────
+    // CELL is context-limited in eval (no cell grid); test what is testable.
+    cases.extend([
+        tc("CELL type of number -> n", r#"CELL("type",5)"#, "basic", "string"),
+        tc("CELL type of text -> l", r#"CELL("type","hello")"#, "basic", "string"),
+        tc("CELL type of boolean -> b", r#"CELL("type",TRUE)"#, "basic", "string"),
+        tc("CELL no args -> error", "CELL()", "error", "error"),
+        tc("CELL unknown info type -> error", r#"CELL("unknown",1)"#, "error", "error"),
+        tc("CELL one arg -> error", r#"CELL("type")"#, "error", "error"),
+        tc("CELL type of error -> e", r#"CELL("type",NA())"#, "edge", "string"),
+        tc("IF using CELL type result", r#"IF(CELL("type",1)="n",1,0)"#, "nested", "number"),
+    ]);
+
+    // ── SHEETS ───────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("SHEETS returns 1 single-sheet", "SHEETS()", "basic", "number"),
+        tc("SHEETS too many args -> error", "SHEETS(1,2)", "error", "error"),
+        tc("SHEETS result is number", "ISNUMBER(SHEETS())", "nested", "boolean"),
+        tc("SHEETS +0 still 1", "SHEETS()+0", "nested", "number"),
+        tc("SHEETS result > 0", "SHEETS()>0", "nested", "boolean"),
+        tc("SHEETS N(SHEETS()) = 1", "N(SHEETS())", "nested", "number"),
+        tc("SHEETS nested in IF", "IF(SHEETS()=1,TRUE,FALSE)", "nested", "boolean"),
+        tc("SHEETS with ref arg", "SHEETS(A1:B2)", "basic", "number"),
+    ]);
+
+    cases
+}

--- a/xtask/src/gen_operator.rs
+++ b/xtask/src/gen_operator.rs
@@ -1,0 +1,235 @@
+use crate::types::{Platform, TestCase};
+
+fn tc(description: &str, formula: &str, test_category: &str, expected_type: &str) -> TestCase {
+    TestCase::new(description, formula, "", test_category, expected_type)
+}
+
+pub fn generate_operator(_platform: Platform) -> Vec<TestCase> {
+    let mut cases: Vec<TestCase> = Vec::new();
+
+    // ── ADD ──────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ADD integers", "ADD(3,4)", "basic", "number"),
+        tc("ADD decimals", "ADD(1.5,2.5)", "basic", "number"),
+        tc("ADD negative", "ADD(-5,3)", "basic", "number"),
+        tc("ADD both zero", "ADD(0,0)", "basic", "number"),
+        tc("ADD large numbers", "ADD(1E+15,1E+15)", "edge", "number"),
+        tc("ADD TRUE coerces to 1", "ADD(TRUE,1)", "coercion", "number"),
+        tc("ADD text number coercion", r#"ADD("5",3)"#, "coercion", "number"),
+        tc("ADD text abc -> #VALUE!", r#"ADD("abc",1)"#, "error", "error"),
+        tc("ADD #DIV/0! propagates", "ADD(1/0,1)", "error", "error"),
+        tc("ADD no args -> error", "ADD()", "error", "error"),
+    ]);
+
+    // ── MINUS ────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("MINUS integers", "MINUS(10,3)", "basic", "number"),
+        tc("MINUS decimals", "MINUS(5.5,2.5)", "basic", "number"),
+        tc("MINUS negative result", "MINUS(3,10)", "basic", "number"),
+        tc("MINUS both zero", "MINUS(0,0)", "basic", "number"),
+        tc("MINUS large numbers", "MINUS(1E+15,1E+14)", "edge", "number"),
+        tc("MINUS TRUE coerces to 1", "MINUS(TRUE,1)", "coercion", "number"),
+        tc("MINUS text number", r#"MINUS("10",3)"#, "coercion", "number"),
+        tc("MINUS text abc -> #VALUE!", r#"MINUS("abc",1)"#, "error", "error"),
+        tc("MINUS #N/A propagates", "MINUS(NA(),1)", "error", "error"),
+        tc("MINUS no args -> error", "MINUS()", "error", "error"),
+    ]);
+
+    // ── MULTIPLY ─────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("MULTIPLY integers", "MULTIPLY(3,4)", "basic", "number"),
+        tc("MULTIPLY decimals", "MULTIPLY(1.5,2.0)", "basic", "number"),
+        tc("MULTIPLY by zero", "MULTIPLY(5,0)", "basic", "number"),
+        tc("MULTIPLY negatives", "MULTIPLY(-3,-4)", "basic", "number"),
+        tc("MULTIPLY large numbers", "MULTIPLY(1E+7,1E+7)", "edge", "number"),
+        tc("MULTIPLY TRUE coercion", "MULTIPLY(TRUE,5)", "coercion", "number"),
+        tc("MULTIPLY text number", r#"MULTIPLY("3",4)"#, "coercion", "number"),
+        tc("MULTIPLY text -> #VALUE!", r#"MULTIPLY("abc",1)"#, "error", "error"),
+        tc("MULTIPLY #DIV/0! propagates", "MULTIPLY(1/0,2)", "error", "error"),
+        tc("MULTIPLY no args -> error", "MULTIPLY()", "error", "error"),
+    ]);
+
+    // ── DIVIDE ───────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("DIVIDE integers", "DIVIDE(10,2)", "basic", "number"),
+        tc("DIVIDE fractional result", "DIVIDE(1,3)", "basic", "number"),
+        tc("DIVIDE zero dividend", "DIVIDE(0,5)", "basic", "number"),
+        tc("DIVIDE negative dividend", "DIVIDE(-10,2)", "basic", "number"),
+        tc("DIVIDE both negative", "DIVIDE(-10,-2)", "basic", "number"),
+        tc("DIVIDE by zero -> #DIV/0!", "DIVIDE(5,0)", "error", "error"),
+        tc("DIVIDE TRUE coercion", "DIVIDE(TRUE,2)", "coercion", "number"),
+        tc("DIVIDE text number", r#"DIVIDE("10",2)"#, "coercion", "number"),
+        tc("DIVIDE text -> #VALUE!", r#"DIVIDE("abc",2)"#, "error", "error"),
+        tc("DIVIDE no args -> error", "DIVIDE()", "error", "error"),
+    ]);
+
+    // ── EQ ───────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("EQ equal integers -> TRUE", "EQ(1,1)", "basic", "boolean"),
+        tc("EQ unequal integers -> FALSE", "EQ(1,2)", "basic", "boolean"),
+        tc("EQ equal strings -> TRUE", r#"EQ("abc","abc")"#, "basic", "boolean"),
+        tc("EQ case-insensitive match", r#"EQ("abc","ABC")"#, "basic", "boolean"),
+        tc("EQ equal decimals", "EQ(3.14,3.14)", "basic", "boolean"),
+        tc("EQ zero equals zero", "EQ(0,0)", "basic", "boolean"),
+        tc("EQ number vs text -> FALSE", r#"EQ(1,"1")"#, "coercion", "boolean"),
+        tc("EQ #N/A propagates", "EQ(NA(),1)", "error", "error"),
+        tc("EQ no args -> error", "EQ()", "error", "error"),
+        tc("EQ nested formula args", "EQ(ABS(-5),5)", "nested", "boolean"),
+    ]);
+
+    // ── GT ───────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("GT greater -> TRUE", "GT(5,3)", "basic", "boolean"),
+        tc("GT equal -> FALSE", "GT(3,3)", "basic", "boolean"),
+        tc("GT less -> FALSE", "GT(2,5)", "basic", "boolean"),
+        tc("GT negative comparison", "GT(-1,-5)", "basic", "boolean"),
+        tc("GT decimals", "GT(3.14,3.13)", "basic", "boolean"),
+        tc("GT TRUE coerces to 1", "GT(TRUE,0)", "coercion", "boolean"),
+        tc("GT text comparison", r#"GT("b","a")"#, "basic", "boolean"),
+        tc("GT #N/A propagates", "GT(NA(),1)", "error", "error"),
+        tc("GT no args -> error", "GT()", "error", "error"),
+        tc("GT nested formula args", "GT(SUM(2,3),4)", "nested", "boolean"),
+    ]);
+
+    // ── GTE ──────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("GTE greater -> TRUE", "GTE(5,3)", "basic", "boolean"),
+        tc("GTE equal -> TRUE", "GTE(3,3)", "basic", "boolean"),
+        tc("GTE less -> FALSE", "GTE(2,5)", "basic", "boolean"),
+        tc("GTE negative equal", "GTE(-3,-3)", "basic", "boolean"),
+        tc("GTE decimals equal", "GTE(1.5,1.5)", "basic", "boolean"),
+        tc("GTE TRUE coerces to 1", "GTE(TRUE,1)", "coercion", "boolean"),
+        tc("GTE text comparison", r#"GTE("b","a")"#, "basic", "boolean"),
+        tc("GTE #N/A propagates", "GTE(NA(),1)", "error", "error"),
+        tc("GTE no args -> error", "GTE()", "error", "error"),
+        tc("GTE nested formula args", "GTE(ABS(-4),4)", "nested", "boolean"),
+    ]);
+
+    // ── LT ───────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("LT less -> TRUE", "LT(3,5)", "basic", "boolean"),
+        tc("LT equal -> FALSE", "LT(3,3)", "basic", "boolean"),
+        tc("LT greater -> FALSE", "LT(5,2)", "basic", "boolean"),
+        tc("LT negative comparison", "LT(-5,-1)", "basic", "boolean"),
+        tc("LT decimals", "LT(3.13,3.14)", "basic", "boolean"),
+        tc("LT FALSE coerces to 0", "LT(FALSE,1)", "coercion", "boolean"),
+        tc("LT text comparison", r#"LT("a","b")"#, "basic", "boolean"),
+        tc("LT #N/A propagates", "LT(NA(),1)", "error", "error"),
+        tc("LT no args -> error", "LT()", "error", "error"),
+        tc("LT nested formula args", "LT(MINUS(10,8),3)", "nested", "boolean"),
+    ]);
+
+    // ── LTE ──────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("LTE less -> TRUE", "LTE(3,5)", "basic", "boolean"),
+        tc("LTE equal -> TRUE", "LTE(3,3)", "basic", "boolean"),
+        tc("LTE greater -> FALSE", "LTE(5,2)", "basic", "boolean"),
+        tc("LTE negative equal", "LTE(-3,-3)", "basic", "boolean"),
+        tc("LTE decimals equal", "LTE(1.5,1.5)", "basic", "boolean"),
+        tc("LTE FALSE coerces to 0", "LTE(FALSE,0)", "coercion", "boolean"),
+        tc("LTE text comparison", r#"LTE("a","b")"#, "basic", "boolean"),
+        tc("LTE #N/A propagates", "LTE(NA(),1)", "error", "error"),
+        tc("LTE no args -> error", "LTE()", "error", "error"),
+        tc("LTE nested formula args", "LTE(ADD(1,2),3)", "nested", "boolean"),
+    ]);
+
+    // ── NE ───────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("NE unequal -> TRUE", "NE(1,2)", "basic", "boolean"),
+        tc("NE equal -> FALSE", "NE(1,1)", "basic", "boolean"),
+        tc("NE strings unequal -> TRUE", r#"NE("abc","xyz")"#, "basic", "boolean"),
+        tc("NE strings equal -> FALSE", r#"NE("abc","abc")"#, "basic", "boolean"),
+        tc("NE case-insensitive equal", r#"NE("abc","ABC")"#, "basic", "boolean"),
+        tc("NE number vs text -> TRUE", r#"NE(1,"1")"#, "coercion", "boolean"),
+        tc("NE TRUE vs FALSE", "NE(TRUE,FALSE)", "basic", "boolean"),
+        tc("NE #N/A propagates", "NE(NA(),1)", "error", "error"),
+        tc("NE no args -> error", "NE()", "error", "error"),
+        tc("NE nested formula args", "NE(ABS(-3),3)", "nested", "boolean"),
+    ]);
+
+    // ── POW ──────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("POW 2^3 -> 8", "POW(2,3)", "basic", "number"),
+        tc("POW 5^0 -> 1", "POW(5,0)", "basic", "number"),
+        tc("POW 0^5 -> 0", "POW(0,5)", "basic", "number"),
+        tc("POW decimal exponent", "POW(4,0.5)", "basic", "number"),
+        tc("POW negative base even exp", "POW(-2,2)", "basic", "number"),
+        tc("POW negative base odd exp", "POW(-2,3)", "basic", "number"),
+        tc("POW large", "POW(10,10)", "edge", "number"),
+        tc("POW 0^0 -> 1", "POW(0,0)", "edge", "number"),
+        tc("POW #N/A propagates", "POW(NA(),2)", "error", "error"),
+        tc("POW no args -> error", "POW()", "error", "error"),
+    ]);
+
+    // ── UMINUS ───────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("UMINUS positive -> negative", "UMINUS(5)", "basic", "number"),
+        tc("UMINUS negative -> positive", "UMINUS(-5)", "basic", "number"),
+        tc("UMINUS zero -> zero", "UMINUS(0)", "basic", "number"),
+        tc("UMINUS decimal", "UMINUS(3.14)", "basic", "number"),
+        tc("UMINUS large number", "UMINUS(1E+15)", "edge", "number"),
+        tc("UMINUS TRUE coerces to 1", "UMINUS(TRUE)", "coercion", "number"),
+        tc("UMINUS FALSE coerces to 0", "UMINUS(FALSE)", "coercion", "number"),
+        tc("UMINUS text -> #VALUE!", r#"UMINUS("abc")"#, "error", "error"),
+        tc("UMINUS #N/A propagates", "UMINUS(NA())", "error", "error"),
+        tc("UMINUS no args -> error", "UMINUS()", "error", "error"),
+    ]);
+
+    // ── UPLUS ────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("UPLUS positive", "UPLUS(5)", "basic", "number"),
+        tc("UPLUS negative", "UPLUS(-5)", "basic", "number"),
+        tc("UPLUS zero", "UPLUS(0)", "basic", "number"),
+        tc("UPLUS decimal", "UPLUS(3.14)", "basic", "number"),
+        tc("UPLUS large number", "UPLUS(1E+15)", "edge", "number"),
+        tc("UPLUS TRUE coerces to 1", "UPLUS(TRUE)", "coercion", "number"),
+        tc("UPLUS FALSE coerces to 0", "UPLUS(FALSE)", "coercion", "number"),
+        tc("UPLUS text -> #VALUE!", r#"UPLUS("abc")"#, "error", "error"),
+        tc("UPLUS #N/A propagates", "UPLUS(NA())", "error", "error"),
+        tc("UPLUS no args -> error", "UPLUS()", "error", "error"),
+    ]);
+
+    // ── UNARY_PERCENT ─────────────────────────────────────────────────────────
+    cases.extend([
+        tc("UNARY_PERCENT 100 -> 1", "UNARY_PERCENT(100)", "basic", "number"),
+        tc("UNARY_PERCENT 50 -> 0.5", "UNARY_PERCENT(50)", "basic", "number"),
+        tc("UNARY_PERCENT 0 -> 0", "UNARY_PERCENT(0)", "basic", "number"),
+        tc("UNARY_PERCENT negative", "UNARY_PERCENT(-50)", "basic", "number"),
+        tc("UNARY_PERCENT decimal 0.5 -> 0.005", "UNARY_PERCENT(0.5)", "basic", "number"),
+        tc("UNARY_PERCENT TRUE coerces to 1", "UNARY_PERCENT(TRUE)", "coercion", "number"),
+        tc("UNARY_PERCENT text -> #VALUE!", r#"UNARY_PERCENT("abc")"#, "error", "error"),
+        tc("UNARY_PERCENT #N/A propagates", "UNARY_PERCENT(NA())", "error", "error"),
+        tc("UNARY_PERCENT no args -> error", "UNARY_PERCENT()", "error", "error"),
+        tc("UNARY_PERCENT nested 200 -> 2", "UNARY_PERCENT(ADD(100,100))", "nested", "number"),
+    ]);
+
+    // ── CONCAT ───────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("CONCAT two strings", r#"CONCAT("Hello"," World")"#, "basic", "string"),
+        tc("CONCAT empty+text", r#"CONCAT("","hello")"#, "basic", "string"),
+        tc("CONCAT both empty", r#"CONCAT("","")"#, "basic", "string"),
+        tc("CONCAT number+number", "CONCAT(1,2)", "coercion", "number"),
+        tc("CONCAT text+number", r#"CONCAT("x",5)"#, "coercion", "string"),
+        tc("CONCAT TRUE coercion", r#"CONCAT(TRUE,"!")"#, "coercion", "string"),
+        tc("CONCAT FALSE coercion", r#"CONCAT(FALSE,"?")"#, "coercion", "string"),
+        tc("CONCAT #DIV/0! propagates", r#"CONCAT(1/0,"x")"#, "error", "error"),
+        tc("CONCAT no args -> error", "CONCAT()", "error", "error"),
+        tc("CONCAT nested CHAR args", "CONCAT(CHAR(65),CHAR(66))", "nested", "string"),
+    ]);
+
+    // ── ISBETWEEN ────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISBETWEEN value in range -> TRUE", "ISBETWEEN(5,1,10)", "basic", "boolean"),
+        tc("ISBETWEEN value at lower bound -> TRUE", "ISBETWEEN(1,1,10)", "basic", "boolean"),
+        tc("ISBETWEEN value at upper bound -> TRUE", "ISBETWEEN(10,1,10)", "basic", "boolean"),
+        tc("ISBETWEEN value below range -> FALSE", "ISBETWEEN(0,1,10)", "basic", "boolean"),
+        tc("ISBETWEEN value above range -> FALSE", "ISBETWEEN(11,1,10)", "basic", "boolean"),
+        tc("ISBETWEEN exclusive lower bound", "ISBETWEEN(1,1,10,FALSE,TRUE)", "edge", "boolean"),
+        tc("ISBETWEEN exclusive upper bound", "ISBETWEEN(10,1,10,TRUE,FALSE)", "edge", "boolean"),
+        tc("ISBETWEEN negative range", "ISBETWEEN(-5,-10,-1)", "basic", "boolean"),
+        tc("ISBETWEEN no args -> error", "ISBETWEEN()", "error", "error"),
+        tc("ISBETWEEN nested formula value", "ISBETWEEN(ABS(-5),1,10)", "nested", "boolean"),
+    ]);
+
+    cases
+}

--- a/xtask/src/gen_parser_web.rs
+++ b/xtask/src/gen_parser_web.rs
@@ -1,0 +1,145 @@
+use crate::types::{Platform, TestCase};
+
+fn tc(description: &str, formula: &str, test_category: &str, expected_type: &str) -> TestCase {
+    TestCase::new(description, formula, "", test_category, expected_type)
+}
+
+pub fn generate_parser(_platform: Platform) -> Vec<TestCase> {
+    let mut cases: Vec<TestCase> = Vec::new();
+
+    // ── CONVERT ──────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("CONVERT 1 km -> 1000 m", r#"CONVERT(1,"km","m")"#, "basic", "number"),
+        tc("CONVERT 1 m -> 0.001 km", r#"CONVERT(1,"m","km")"#, "basic", "number"),
+        tc("CONVERT 100 C -> 212 F", r#"CONVERT(100,"C","F")"#, "basic", "number"),
+        tc("CONVERT 0 C -> 32 F", r#"CONVERT(0,"C","F")"#, "basic", "number"),
+        tc("CONVERT 32 F -> 0 C", r#"CONVERT(32,"F","C")"#, "basic", "number"),
+        tc("CONVERT 1 hr -> 60 mn", r#"CONVERT(1,"hr","mn")"#, "basic", "number"),
+        tc("CONVERT 1 day -> 24 hr", r#"CONVERT(1,"day","hr")"#, "basic", "number"),
+        tc("CONVERT 1 kg -> lbm approx", r#"ROUND(CONVERT(1,"kg","lbm"),4)"#, "basic", "number"),
+        tc("CONVERT 1 mi -> km approx", r#"ROUND(CONVERT(1,"mi","km"),4)"#, "edge", "number"),
+        tc("CONVERT incompatible units J->W -> #N/A", r#"CONVERT(1,"J","W")"#, "error", "error"),
+        tc("CONVERT unknown unit -> #N/A", r#"CONVERT(1,"xyz","m")"#, "error", "error"),
+        tc("CONVERT no args -> #N/A", "CONVERT()", "error", "error"),
+    ]);
+
+    // ── TO_DATE ──────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("TO_DATE serial 1", "TO_DATE(1)", "basic", "number"),
+        tc("TO_DATE serial 45292", "TO_DATE(45292)", "basic", "number"),
+        tc("TO_DATE serial 0", "TO_DATE(0)", "basic", "number"),
+        tc("TO_DATE serial 44927 (2023-01-01)", "TO_DATE(44927)", "basic", "number"),
+        tc("TO_DATE negative serial -1", "TO_DATE(-1)", "edge", "number"),
+        tc("TO_DATE DATE serial as input", "TO_DATE(DATE(2024,1,15))", "edge", "number"),
+        tc("TO_DATE large serial 50000", "TO_DATE(50000)", "edge", "number"),
+        tc("TO_DATE text -> error", r#"TO_DATE("text")"#, "error", "string"),
+        tc("TO_DATE no args -> #N/A", "TO_DATE()", "error", "error"),
+        tc("TO_DATE nested in ISNUMBER", "ISNUMBER(TO_DATE(45292))", "nested", "boolean"),
+    ]);
+
+    // ── TO_DOLLARS ───────────────────────────────────────────────────────────
+    cases.extend([
+        tc("TO_DOLLARS integer 42", "TO_DOLLARS(42)", "basic", "number"),
+        tc("TO_DOLLARS decimal 3.14159", "TO_DOLLARS(3.14159)", "basic", "number"),
+        tc("TO_DOLLARS zero", "TO_DOLLARS(0)", "basic", "number"),
+        tc("TO_DOLLARS negative -5", "TO_DOLLARS(-5)", "basic", "number"),
+        tc("TO_DOLLARS large number 1000000", "TO_DOLLARS(1000000)", "basic", "number"),
+        tc("TO_DOLLARS small fraction 0.01", "TO_DOLLARS(0.01)", "basic", "number"),
+        tc("TO_DOLLARS negative fraction -0.99", "TO_DOLLARS(-0.99)", "edge", "number"),
+        tc("TO_DOLLARS text -> error", r#"TO_DOLLARS("text")"#, "error", "string"),
+        tc("TO_DOLLARS no args -> #N/A", "TO_DOLLARS()", "error", "error"),
+        tc("TO_PURE_NUMBER strips TO_DOLLARS", "TO_PURE_NUMBER(TO_DOLLARS(42))", "nested", "number"),
+    ]);
+
+    // ── TO_PERCENT ───────────────────────────────────────────────────────────
+    cases.extend([
+        tc("TO_PERCENT 0.5 -> 0.5 (shown 50%)", "TO_PERCENT(0.5)", "basic", "number"),
+        tc("TO_PERCENT 1 -> 1 (shown 100%)", "TO_PERCENT(1)", "basic", "number"),
+        tc("TO_PERCENT 0 -> 0", "TO_PERCENT(0)", "basic", "number"),
+        tc("TO_PERCENT -0.25", "TO_PERCENT(-0.25)", "basic", "number"),
+        tc("TO_PERCENT 0.001 small fraction", "TO_PERCENT(0.001)", "basic", "number"),
+        tc("TO_PERCENT 2.5 over 100%", "TO_PERCENT(2.5)", "edge", "number"),
+        tc("TO_PERCENT -1 negative 100%", "TO_PERCENT(-1)", "edge", "number"),
+        tc("TO_PERCENT text -> error", r#"TO_PERCENT("text")"#, "error", "string"),
+        tc("TO_PERCENT no args -> #N/A", "TO_PERCENT()", "error", "error"),
+        tc("TO_PURE_NUMBER strips TO_PERCENT", "TO_PURE_NUMBER(TO_PERCENT(0.5))", "nested", "number"),
+    ]);
+
+    // ── TO_PURE_NUMBER ───────────────────────────────────────────────────────
+    cases.extend([
+        tc("TO_PURE_NUMBER integer 42", "TO_PURE_NUMBER(42)", "basic", "number"),
+        tc("TO_PURE_NUMBER decimal 3.14", "TO_PURE_NUMBER(3.14)", "basic", "number"),
+        tc("TO_PURE_NUMBER zero", "TO_PURE_NUMBER(0)", "basic", "number"),
+        tc("TO_PURE_NUMBER negative -5.5", "TO_PURE_NUMBER(-5.5)", "basic", "number"),
+        tc("TO_PURE_NUMBER large 1000000", "TO_PURE_NUMBER(1000000)", "basic", "number"),
+        tc("TO_PURE_NUMBER strip TO_DOLLARS", "TO_PURE_NUMBER(TO_DOLLARS(42))", "nested", "number"),
+        tc("TO_PURE_NUMBER strip TO_PERCENT", "TO_PURE_NUMBER(TO_PERCENT(0.5))", "nested", "number"),
+        tc("TO_PURE_NUMBER text -> error", r#"TO_PURE_NUMBER("text")"#, "error", "string"),
+        tc("TO_PURE_NUMBER no args -> #N/A", "TO_PURE_NUMBER()", "error", "error"),
+        tc("TO_PURE_NUMBER ISNUMBER result", "ISNUMBER(TO_PURE_NUMBER(42))", "nested", "boolean"),
+    ]);
+
+    // ── TO_TEXT ──────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("TO_TEXT integer 42 -> string", "TO_TEXT(42)", "basic", "number"),
+        tc("TO_TEXT decimal 3.14", "TO_TEXT(3.14)", "basic", "number"),
+        tc("TO_TEXT TRUE -> \"TRUE\"", "TO_TEXT(TRUE)", "basic", "string"),
+        tc("TO_TEXT FALSE -> \"FALSE\"", "TO_TEXT(FALSE)", "basic", "string"),
+        tc("TO_TEXT zero -> \"0\"", "TO_TEXT(0)", "basic", "number"),
+        tc("TO_TEXT negative -5", "TO_TEXT(-5)", "basic", "number"),
+        tc("TO_TEXT large number 100000", "TO_TEXT(100000)", "edge", "number"),
+        tc("TO_TEXT small decimal 0.001", "TO_TEXT(0.001)", "edge", "number"),
+        tc("TO_TEXT no args -> #N/A", "TO_TEXT()", "error", "error"),
+        tc("LEN(TO_TEXT(12345)) -> 5", "LEN(TO_TEXT(12345))", "nested", "number"),
+    ]);
+
+    cases
+}
+
+pub fn generate_web(_platform: Platform) -> Vec<TestCase> {
+    let mut cases: Vec<TestCase> = Vec::new();
+
+    // ── ENCODEURL ────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ENCODEURL space -> %20", r#"ENCODEURL("hello world")"#, "basic", "string"),
+        tc("ENCODEURL special chars encoded", r#"ENCODEURL("a+b=c&d")"#, "basic", "string"),
+        tc("ENCODEURL no special chars -> unchanged", r#"ENCODEURL("hello")"#, "basic", "string"),
+        tc("ENCODEURL empty string -> empty", r#"ENCODEURL("")"#, "basic", "string"),
+        tc("ENCODEURL percent sign -> %25", r#"ENCODEURL("100%")"#, "basic", "string"),
+        tc("ENCODEURL slash encoded", r#"ENCODEURL("a/b")"#, "edge", "string"),
+        tc("ENCODEURL LEN of encoded space = 13", r#"LEN(ENCODEURL("hello world"))"#, "nested", "number"),
+        tc("ENCODEURL no args -> #N/A", "ENCODEURL()", "error", "error"),
+        tc("ENCODEURL number arg coercion", "ENCODEURL(42)", "coercion", "string"),
+        tc("ENCODEURL unicode chars", r#"ENCODEURL("caf\u00e9")"#, "edge", "string"),
+    ]);
+
+    // ── HYPERLINK ────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("HYPERLINK with label -> returns label", r#"HYPERLINK("https://example.com","Click here")"#, "basic", "string"),
+        tc("HYPERLINK no label -> returns url", r#"HYPERLINK("https://example.com")"#, "basic", "string"),
+        tc("HYPERLINK LEN of label = 5", r#"LEN(HYPERLINK("https://example.com","Click"))"#, "nested", "number"),
+        tc("HYPERLINK empty label -> empty string", r#"HYPERLINK("https://example.com","")"#, "basic", "string"),
+        tc("HYPERLINK numeric label coerced to text", r#"HYPERLINK("https://example.com",42)"#, "coercion", "number"),
+        tc("HYPERLINK label with spaces -> returns label", r#"HYPERLINK("https://example.com","Go here now")"#, "basic", "string"),
+        tc("HYPERLINK no args -> #N/A", "HYPERLINK()", "error", "error"),
+        tc("HYPERLINK ISTEXT of label result", r#"ISTEXT(HYPERLINK("https://example.com","label"))"#, "nested", "boolean"),
+        tc("HYPERLINK http url", r#"HYPERLINK("http://example.com","link")"#, "basic", "string"),
+        tc("HYPERLINK label is boolean", r#"HYPERLINK("https://example.com",TRUE)"#, "coercion", "string"),
+    ]);
+
+    // ── ISURL ────────────────────────────────────────────────────────────────
+    cases.extend([
+        tc("ISURL https url -> TRUE", r#"ISURL("https://example.com")"#, "basic", "boolean"),
+        tc("ISURL http url -> TRUE", r#"ISURL("http://example.com")"#, "basic", "boolean"),
+        tc("ISURL ftp url -> TRUE", r#"ISURL("ftp://example.com")"#, "basic", "boolean"),
+        tc("ISURL plain text -> FALSE", r#"ISURL("not a url")"#, "basic", "boolean"),
+        tc("ISURL empty string -> FALSE", r#"ISURL("")"#, "basic", "boolean"),
+        tc("ISURL number -> FALSE", "ISURL(42)", "coercion", "boolean"),
+        tc("ISURL no args -> #N/A", "ISURL()", "error", "error"),
+        tc("ISURL domain only", r#"ISURL("example.com")"#, "basic", "boolean"),
+        tc("IF(ISURL url, 1, 0)", r#"IF(ISURL("https://example.com"),1,0)"#, "nested", "number"),
+        tc("AND(ISURL https, ISURL http)", r#"AND(ISURL("https://a.com"),ISURL("http://b.com"))"#, "nested", "boolean"),
+    ]);
+
+    cases
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,7 +1,10 @@
 mod gen_array_filter;
 mod gen_database;
+mod gen_logical_info;
 mod gen_lookup;
 mod gen_math;
+mod gen_operator;
+mod gen_parser_web;
 mod gen_statistical;
 mod gen_text_date_eng_fin;
 mod generate;
@@ -146,6 +149,11 @@ fn run_oracle_evaluate(
         "engineering",
         "financial",
         "database",
+        "logical",
+        "info",
+        "operator",
+        "parser",
+        "web",
     ];
 
     for &cat in categories {
@@ -203,6 +211,11 @@ fn run_generate_fixtures(platform: Platform, category: Option<&str>, all: bool) 
         "engineering",
         "financial",
         "database",
+        "logical",
+        "info",
+        "operator",
+        "parser",
+        "web",
     ];
 
     for &cat in categories {
@@ -221,6 +234,11 @@ fn run_generate_fixtures(platform: Platform, category: Option<&str>, all: bool) 
             "engineering" => gen_text_date_eng_fin::generate_engineering(platform),
             "financial" => gen_text_date_eng_fin::generate_financial(platform),
             "database" => gen_database::generate(platform),
+            "logical" => gen_logical_info::generate_logical(platform),
+            "info" => gen_logical_info::generate_info(platform),
+            "operator" => gen_operator::generate_operator(platform),
+            "parser" => gen_parser_web::generate_parser(platform),
+            "web" => gen_parser_web::generate_web(platform),
             _ => vec![],
         };
 


### PR DESCRIPTION
## Summary

- Adds `gen_logical_info.rs` covering `logical` (AND, OR, XOR, NOT, IF, IFERROR, IFNA, IFS, SWITCH, LET, LAMBDA, NA, N, TRUE, FALSE) and `info` (ISBLANK, ISDATE, ISEMAIL, ISERR, ISERROR, ISLOGICAL, ISNA, ISNONTEXT, ISNUMBER, ISREF, ISTEXT, ERROR.TYPE, N, NA, TYPE, CELL, SHEETS) categories
- Adds `gen_operator.rs` covering all 16 operator functions (ADD, MINUS, MULTIPLY, DIVIDE, EQ, GT, GTE, LT, LTE, NE, POW, UMINUS, UPLUS, UNARY_PERCENT, CONCAT, ISBETWEEN)
- Adds `gen_parser_web.rs` covering `parser` (CONVERT, TO_DATE, TO_DOLLARS, TO_PERCENT, TO_PURE_NUMBER, TO_TEXT) and `web` (ENCODEURL, HYPERLINK, ISURL) categories
- Wires all 5 new categories into both `run_generate_fixtures()` and `run_oracle_evaluate()` in `main.rs`

## Test plan

- [x] `cargo build -p xtask` succeeds
- [x] `cargo xtask generate-fixtures --platform sheets --all` produces all 15 TSVs (logical: 112 cases, info: 136, operator: 160, parser: 62, web: 30)
- [x] `cargo clippy --workspace -- -D warnings` — no issues

closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)