### PR TITLE
fix: SUBSTITUTE overlapping instances, SEARCH tilde escape, REGEXEXTRACT capture group

### DIFF
--- a/crates/core/src/eval/functions/text/regexextract/mod.rs
+++ b/crates/core/src/eval/functions/text/regexextract/mod.rs
@@ -4,7 +4,8 @@ use crate::types::{ErrorKind, Value};
 use regex_lite::Regex;
 
 /// `REGEXEXTRACT(text, pattern)` — returns the first match of pattern in text.
-/// Returns `#N/A` if no match. Returns `#REF!` if the pattern contains capture groups.
+/// If the pattern contains a capture group, returns the content of the first capture group.
+/// Returns `#N/A` if no match.
 pub fn regexextract_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 2) {
         return err;
@@ -21,12 +22,12 @@ pub fn regexextract_fn(args: &[Value]) -> Value {
         Ok(r) => r,
         Err(_) => return Value::Error(ErrorKind::Value),
     };
-    // Capture groups (beyond the implicit group 0) → #REF!
-    if re.captures_len() > 1 {
-        return Value::Error(ErrorKind::Ref);
-    }
-    match re.find(&text) {
-        Some(m) => Value::Text(m.as_str().to_string()),
+    match re.captures(&text) {
+        Some(caps) => {
+            // If there is a capture group, return the first group; otherwise the full match.
+            let matched = caps.get(1).unwrap_or_else(|| caps.get(0).unwrap());
+            Value::Text(matched.as_str().to_string())
+        }
         None => Value::Error(ErrorKind::NA),
     }
 }

--- a/crates/core/src/eval/functions/text/regexextract/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/regexextract/tests/failure.rs
@@ -25,12 +25,13 @@ fn no_match_returns_na() {
 }
 
 #[test]
-fn capture_groups_return_ref_error() {
+fn capture_group_returns_first_group() {
+    // With capture groups, REGEXEXTRACT returns the first group's content.
     assert_eq!(
         regexextract_fn(&[
             Value::Text("2024-01-15".into()),
             Value::Text("([0-9]{4})-([0-9]{2})".into())
         ]),
-        Value::Error(ErrorKind::Ref)
+        Value::Text("2024".into())
     );
 }

--- a/crates/core/src/eval/functions/text/search/mod.rs
+++ b/crates/core/src/eval/functions/text/search/mod.rs
@@ -4,11 +4,26 @@ use crate::types::{ErrorKind, Value};
 
 /// Match `pattern` as a prefix of `text` (prefix match, not full match).
 /// `?` matches any single char; `*` matches any sequence of chars.
+/// `~?` matches literal `?`, `~*` matches literal `*`, `~~` matches literal `~`.
 /// When pattern is exhausted, remaining text is ignored (prefix semantics).
 fn wildcard_match(pattern: &[char], text: &[char]) -> bool {
     match pattern.first() {
         // Pattern exhausted — prefix matched successfully
         None => true,
+        Some('~') if pattern.len() >= 2 => {
+            // Tilde escape: next char is treated as a literal
+            match text.first() {
+                None => false,
+                Some(t) => {
+                    let escaped = &pattern[1];
+                    if escaped.to_lowercase().next() == t.to_lowercase().next() {
+                        wildcard_match(&pattern[2..], &text[1..])
+                    } else {
+                        false
+                    }
+                }
+            }
+        }
         Some('*') => {
             // '*' can consume 0, 1, 2, ... chars from text
             for i in 0..=text.len() {

--- a/crates/core/src/eval/functions/text/substitute/mod.rs
+++ b/crates/core/src/eval/functions/text/substitute/mod.rs
@@ -39,21 +39,35 @@ pub fn substitute_fn(args: &[Value]) -> Value {
             if target == 0 {
                 return Value::Error(ErrorKind::Value);
             }
-            let mut result = String::new();
-            let mut remaining = text.as_str();
+            // Count overlapping occurrences: advance one char at a time.
+            let chars: Vec<char> = text.chars().collect();
+            let old_chars: Vec<char> = old_text.chars().collect();
+            let new_chars: Vec<char> = new_text.chars().collect();
+            let old_len = old_chars.len();
+            let mut result: Vec<char> = Vec::new();
+            let mut i = 0usize;
             let mut count = 0usize;
-            while let Some(pos) = remaining.find(&old_text) {
-                count += 1;
-                result.push_str(&remaining[..pos]);
-                if count == target {
-                    result.push_str(&new_text);
+            while i <= chars.len().saturating_sub(old_len) {
+                if chars[i..i + old_len] == old_chars[..] {
+                    count += 1;
+                    if count == target {
+                        result.extend_from_slice(&new_chars);
+                        i += old_len;
+                        // Append the rest unchanged
+                        result.extend_from_slice(&chars[i..]);
+                        return Value::Text(result.into_iter().collect());
+                    } else {
+                        result.push(chars[i]);
+                        i += 1;
+                    }
                 } else {
-                    result.push_str(&old_text);
+                    result.push(chars[i]);
+                    i += 1;
                 }
-                remaining = &remaining[pos + old_text.len()..];
             }
-            result.push_str(remaining);
-            Value::Text(result)
+            // Target not reached — append remaining chars and return unchanged
+            result.extend_from_slice(&chars[i..]);
+            Value::Text(result.into_iter().collect())
         }
     }
 }


### PR DESCRIPTION
## Summary

- **SUBSTITUTE**: Fix instance counting to use overlapping occurrences (advance 1 char at a time instead of `old_text.len()`), matching Google Sheets semantics where `=SUBSTITUTE("aaaaaa","aa","X",3)` → `"aaXaa"`
- **SEARCH**: Add tilde escape handling (`~?` → literal `?`, `~*` → literal `*`, `~~` → literal `~`) so `=SEARCH("~?","hello?")` → `6`
- **REGEXEXTRACT**: Return first capture group content instead of `#REF!`; `=REGEXEXTRACT("hello123world","([0-9]+)")` → `"123"`

Also updates the unit test `capture_groups_return_ref_error` (renamed to `capture_group_returns_first_group`) that was asserting the old wrong behavior.

## Test plan

- [x] `cargo nextest run -p truecalc-core --test conformance bugs_conformance` — rows 41, 42, 43 now PASS (3 passed total, up from 0)
- [x] `cargo test -p truecalc-core` — all 2910 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — no issues

closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)