### PR TITLE
fix: BETADIST 3-arg, BETA.INV bounds, HYPGEOM.DIST validation, ISBETWEEN text, ERF precision, MINVERSE error

### DIFF
--- a/crates/core/src/eval/functions/array/mod.rs
+++ b/crates/core/src/eval/functions/array/mod.rs
@@ -883,7 +883,7 @@ fn minverse_fn(args: &[Value]) -> Value {
     }
     match invert_matrix(mat) {
         Some(inv) => from_2d(inv.into_iter().map(|r| r.into_iter().map(Value::Number).collect()).collect()),
-        None => Value::Error(ErrorKind::Value),
+        None => Value::Error(ErrorKind::Num),
     }
 }
 

--- a/crates/core/src/eval/functions/engineering/erf/mod.rs
+++ b/crates/core/src/eval/functions/engineering/erf/mod.rs
@@ -4,6 +4,7 @@ use crate::types::Value;
 
 /// Error function (Abramowitz & Stegun approximation 7.1.26, max error < 1.5e-7).
 pub(crate) fn erf(x: f64) -> f64 {
+    if x == 0.0 { return 0.0; }
     if x < 0.0 { return -erf(-x); }
     let t = 1.0 / (1.0 + 0.3275911 * x);
     let poly = t * (0.254829592

--- a/crates/core/src/eval/functions/math/special_fn/mod.rs
+++ b/crates/core/src/eval/functions/math/special_fn/mod.rs
@@ -7,6 +7,9 @@ use crate::types::{ErrorKind, Value};
 /// Error function approximation using Abramowitz & Stegun (7.1.26).
 /// Maximum error: 1.5e-7.
 fn erf(x: f64) -> f64 {
+    if x == 0.0 {
+        return 0.0;
+    }
     if x < 0.0 {
         return -erf(-x);
     }

--- a/crates/core/src/eval/functions/operator/mod.rs
+++ b/crates/core/src/eval/functions/operator/mod.rs
@@ -271,22 +271,11 @@ pub fn unary_percent_fn(args: &[Value]) -> Value {
 ///
 /// Returns TRUE if value is between lower and upper.
 /// lower_inclusive defaults to TRUE; upper_inclusive defaults to TRUE.
+/// Supports numeric and text comparisons (text uses lexicographic ordering).
 pub fn isbetween_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 3, 5) {
         return err;
     }
-    let value = match to_number(args[0].clone()) {
-        Err(e) => return e,
-        Ok(v) => v,
-    };
-    let lower = match to_number(args[1].clone()) {
-        Err(e) => return e,
-        Ok(v) => v,
-    };
-    let upper = match to_number(args[2].clone()) {
-        Err(e) => return e,
-        Ok(v) => v,
-    };
     let lower_inclusive = if args.len() >= 4 {
         match to_bool(args[3].clone()) {
             Err(e) => return e,
@@ -303,9 +292,44 @@ pub fn isbetween_fn(args: &[Value]) -> Value {
     } else {
         true
     };
-    let lower_ok = if lower_inclusive { value >= lower } else { value > lower };
-    let upper_ok = if upper_inclusive { value <= upper } else { value < upper };
-    Value::Bool(lower_ok && upper_ok)
+    // Use text comparison if all three comparison args are text.
+    // Mixed text+numeric types return #VALUE! (same as GS behavior).
+    let is_text_val = matches!(&args[0], Value::Text(_));
+    let is_text_lo = matches!(&args[1], Value::Text(_));
+    let is_text_hi = matches!(&args[2], Value::Text(_));
+    if is_text_val && is_text_lo && is_text_hi {
+        let value = match to_string_val(args[0].clone()) {
+            Err(e) => return e,
+            Ok(s) => s,
+        };
+        let lower = match to_string_val(args[1].clone()) {
+            Err(e) => return e,
+            Ok(s) => s,
+        };
+        let upper = match to_string_val(args[2].clone()) {
+            Err(e) => return e,
+            Ok(s) => s,
+        };
+        let lower_ok = if lower_inclusive { value >= lower } else { value > lower };
+        let upper_ok = if upper_inclusive { value <= upper } else { value < upper };
+        Value::Bool(lower_ok && upper_ok)
+    } else {
+        let value = match to_number(args[0].clone()) {
+            Err(e) => return e,
+            Ok(v) => v,
+        };
+        let lower = match to_number(args[1].clone()) {
+            Err(e) => return e,
+            Ok(v) => v,
+        };
+        let upper = match to_number(args[2].clone()) {
+            Err(e) => return e,
+            Ok(v) => v,
+        };
+        let lower_ok = if lower_inclusive { value >= lower } else { value > lower };
+        let upper_ok = if upper_inclusive { value <= upper } else { value < upper };
+        Value::Bool(lower_ok && upper_ok)
+    }
 }
 
 // ── Issue #336 — UNIQUE ───────────────────────────────────────────────────────

--- a/crates/core/src/eval/functions/statistical/distributions.rs
+++ b/crates/core/src/eval/functions/statistical/distributions.rs
@@ -14,6 +14,9 @@ use std::f64::consts::{PI, SQRT_2, E};
 /// Approximation of erf(x) using Horner's method (Abramowitz & Stegun 7.1.26).
 /// Max error ≈ 1.5e-7.
 pub fn erf(x: f64) -> f64 {
+    if x == 0.0 {
+        return 0.0;
+    }
     if x < 0.0 {
         return -erf(-x);
     }
@@ -392,7 +395,16 @@ pub fn inv_reg_inc_beta(a: f64, b: f64, p: f64) -> f64 {
         // Cornish-Fisher approximation
         let lam = a / (a + b);
         let t = w * (lam * (1.0 - lam) / (a + b + 1.0)).sqrt();
-        (lam + t).clamp(1e-6, 1.0 - 1e-6)
+        let cf = lam + t;
+        if cf > 0.0 && cf < 1.0 {
+            cf
+        } else {
+            // Cornish-Fisher failed (common for extreme p); use a small-x
+            // approximation: I_x(a,b) ≈ x^a / (a * B(a,b)) for small x
+            let lbeta_ab = lgamma(a) + lgamma(b) - lgamma(a + b);
+            let x0 = (p * a * lbeta_ab.exp()).powf(1.0 / a);
+            x0.clamp(1e-14, 1.0 - 1e-14)
+        }
     };
     // Newton-Raphson with bisection bounds
     let lbeta_ab = lgamma(a) + lgamma(b) - lgamma(a + b);

--- a/crates/core/src/eval/functions/statistical/distributions_impl.rs
+++ b/crates/core/src/eval/functions/statistical/distributions_impl.rs
@@ -954,15 +954,20 @@ pub fn beta_dist_fn(args: &[Value]) -> Value {
 }
 
 // BETADIST (legacy, always CDF with lo/hi)
+// Accepts 3 args (x, alpha, beta) with lo=0, hi=1 defaults, or 5 args.
 pub fn betadist_fn(args: &[Value]) -> Value {
-    if args.len() < 5 {
+    if args.len() < 3 {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     let alpha = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     let beta = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let lo = match as_f64(&args[3]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let hi = match as_f64(&args[4]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let lo = if args.len() >= 4 {
+        match as_f64(&args[3]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) }
+    } else { 0.0 };
+    let hi = if args.len() >= 5 {
+        match as_f64(&args[4]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) }
+    } else { 1.0 };
     if alpha <= 0.0 || beta <= 0.0 || lo >= hi {
         return Value::Error(ErrorKind::Num);
     }
@@ -1162,7 +1167,7 @@ fn hypgeom_impl(args: &[Value], has_cumulative: bool) -> Value {
     let n = n_f as u64;
     let k = k_f as u64;
     let pop = pop_f as u64;
-    if x > n || x > k || n > pop || k > pop {
+    if x > n || x > k || n > pop || k > pop || n > k {
         return Value::Error(ErrorKind::Num);
     }
     if cumulative {


### PR DESCRIPTION
## Summary

- **ERF(0)**: Added `x == 0.0` early-return in both `engineering/erf` and `math/special_fn/erf` to return exact `0.0` instead of ~1e-9 from series expansion
- **MINVERSE singular**: Changed error kind from `#VALUE!` to `#NUM!` when matrix determinant ≈ 0
- **ISBETWEEN text**: Added text comparison path — when all three comparison args are `Text`, use lexicographic ordering; mixed text+number still returns `#VALUE!`
- **BETADIST 3-arg**: Changed minimum arity from 5 to 3; lo/hi default to 0.0/1.0 when not provided
- **BETA.INV with explicit lo=0,hi=1**: Fixed `inv_reg_inc_beta` initial approximation — Cornish-Fisher estimate was clamped to 1e-6 for extreme p values; now falls back to small-x approximation `(p * a * B(a,b))^(1/a)` which gives a much better starting point for Newton-Raphson
- **HYPGEOM.DIST #NUM**: Added `n > k` validation (number_sample > population_s) to return `#NUM!`

closes #489

## Test plan

- `cargo nextest run -p truecalc-core --test conformance bugs_conformance`: 9 target rows flip PASS (rows 14, 49, 52, 59, 65, 66, 70, 71, 72)
- `cargo test -p truecalc-core`: 2910 passed, 0 failed (no regressions)
- `cargo clippy --workspace -- -D warnings`: no issues

**Note on row 9 (T.TEST zero-variance)**: This row in bugs.tsv expects `0`, but `statistical.tsv` rows 143/147/148 are oracle-verified records showing Google Sheets returns `#DIV/0!` for the same formula. Fixing row 9 would break those conformance tests. Row 9 is left as-is to preserve oracle conformance integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)