### PR TITLE
fix: COMPLEX and IM* always return Text; fix near-zero and precision formatting

### DIFF
--- a/crates/core/src/eval/functions/engineering/complex/mod.rs
+++ b/crates/core/src/eval/functions/engineering/complex/mod.rs
@@ -144,16 +144,14 @@ pub(super) fn parse_complex(s: &str) -> Option<Complex> {
 }
 
 /// Format a complex number back to a string using the given suffix ('i' or 'j').
+/// Always returns `Value::Text` — even for purely real results — to match
+/// the Google Sheets contract that all IM* functions return a text string.
 pub(super) fn format_complex(c: Complex, suffix: char) -> Value {
     let re = c.re;
     let im = c.im;
 
-    // Clean up near-zero values
-    let re = if re.abs() < 1e-10 { 0.0 } else { re };
-    let im = if im.abs() < 1e-10 { 0.0 } else { im };
-
     if im == 0.0 {
-        return Value::Number(re);
+        return Value::Text(format_num(re));
     }
 
     let re_str = if re == 0.0 {
@@ -172,7 +170,7 @@ pub(super) fn format_complex(c: Complex, suffix: char) -> Value {
 
     let result = if re == 0.0 {
         im_str
-    } else if im > 0.0 || im == 1.0 {
+    } else if im > 0.0 {
         format!("{}+{}", re_str, im_str)
     } else {
         format!("{}{}", re_str, im_str)
@@ -181,12 +179,57 @@ pub(super) fn format_complex(c: Complex, suffix: char) -> Value {
     Value::Text(result)
 }
 
+/// Format a float component using Google Sheets' 15-significant-figure rules:
+/// - Whole numbers are printed without a decimal point.
+/// - Very small (|x| < 1e-9) or very large (|x| >= 1e15) values use uppercase
+///   scientific notation with up to 15 sig figs (e.g. `6.12323399573677E-17`).
+/// - All other values use decimal notation with up to 15 sig figs, trailing
+///   zeros stripped.
 fn format_num(n: f64) -> String {
-    // Use integer if it's a whole number
+    if n == 0.0 {
+        return "0".to_string();
+    }
     if n.fract() == 0.0 && n.abs() < 1e15 {
-        format!("{}", n as i64)
+        return format!("{}", n as i64);
+    }
+
+    let abs = n.abs();
+
+    if !(1e-9..1e15).contains(&abs) {
+        // Scientific notation: 14 decimal places = 15 significant figures.
+        let s = format!("{:.14e}", n);
+        let (mantissa, exp_part) = s.split_once('e').unwrap();
+        let exp_num: i32 = exp_part.parse().unwrap();
+        let mantissa = mantissa.trim_end_matches('0').trim_end_matches('.');
+        // GS uses uppercase E with a sign and at least 2 digits in the exponent.
+        format!("{}E{:+03}", mantissa, exp_num)
     } else {
-        format!("{}", n)
+        // Convert via 15-sig-fig scientific notation, then render as decimal.
+        let s = format!("{:.14e}", n);
+        let (mantissa, exp_part) = s.split_once('e').unwrap();
+        let exp_num: i32 = exp_part.parse().unwrap();
+        let mantissa_stripped = mantissa.trim_end_matches('0').trim_end_matches('.');
+        let sign = if n < 0.0 { "-" } else { "" };
+        let mantissa_abs = mantissa_stripped.trim_start_matches('-');
+        let digits: String = mantissa_abs.chars().filter(|c| *c != '.').collect();
+
+        if exp_num < 0 {
+            let leading_zeros = (-exp_num - 1) as usize;
+            format!("{}0.{}{}", sign, "0".repeat(leading_zeros), digits)
+        } else {
+            let int_part_len = (exp_num + 1) as usize;
+            if int_part_len >= digits.len() {
+                format!(
+                    "{}{}{}",
+                    sign,
+                    digits,
+                    "0".repeat(int_part_len - digits.len())
+                )
+            } else {
+                let (int_part, frac_part) = digits.split_at(int_part_len);
+                format!("{}{}.{}", sign, int_part, frac_part)
+            }
+        }
     }
 }
 

--- a/crates/core/src/eval/functions/engineering/complex/tests/success.rs
+++ b/crates/core/src/eval/functions/engineering/complex/tests/success.rs
@@ -55,10 +55,10 @@ fn complex_0_1() {
 
 #[test]
 fn complex_pure_real() {
-    // COMPLEX(5, 0) → 5 (returns Number, no imaginary part)
+    // COMPLEX(5, 0) → "5" (always returns Text per Google Sheets contract)
     assert_eq!(
         complex_fn(&[Value::Number(5.0), Value::Number(0.0)]),
-        Value::Number(5.0)
+        Value::Text("5".to_string())
     );
 }
 
@@ -153,16 +153,16 @@ fn imdiv_basic() {
 
 #[test]
 fn imexp_zero() {
-    // exp(0) = 1
-    assert_eq!(imexp_fn(&[Value::Number(0.0)]), Value::Number(1.0));
+    // exp(0) = 1 — always returns Text per Google Sheets contract
+    assert_eq!(imexp_fn(&[Value::Number(0.0)]), Value::Text("1".to_string()));
 }
 
 // ── IMLN ─────────────────────────────────────────────────────────────────────
 
 #[test]
 fn imln_one() {
-    // ln(1) = 0
-    assert_eq!(imln_fn(&[Value::Number(1.0)]), Value::Number(0.0));
+    // ln(1) = 0 — always returns Text per Google Sheets contract
+    assert_eq!(imln_fn(&[Value::Number(1.0)]), Value::Text("0".to_string()));
 }
 
 // ── IMPOWER ──────────────────────────────────────────────────────────────────
@@ -170,8 +170,10 @@ fn imln_one() {
 #[test]
 fn impower_square() {
     // (1+i)^2 = 1 + 2i - 1 = 2i
+    // Due to floating-point, the real part is a tiny near-zero value which is
+    // included in the result (Google Sheets also includes near-zero components).
     let result = impower_fn(&[t("1+i"), Value::Number(2.0)]);
-    assert_eq!(result, Value::Text("2i".to_string()));
+    assert_eq!(result, Value::Text("1.22464679914735E-16+2i".to_string()));
 }
 
 // ── IMPRODUCT ─────────────────────────────────────────────────────────────────
@@ -196,9 +198,10 @@ fn improduct_1_2i_times_3_4i() {
 
 #[test]
 fn imsqrt_neg1() {
-    // sqrt(-1) = i
+    // sqrt(-1): principal square root has a tiny-but-nonzero real part due to
+    // floating-point representation of cos(π/2). Google Sheets includes it.
     let result = imsqrt_fn(&[Value::Number(-1.0)]);
-    assert_eq!(result, Value::Text("i".to_string()));
+    assert_eq!(result, Value::Text("6.12323399573677E-17+i".to_string()));
 }
 
 // ── IMSUB ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- All `IM*` functions and `COMPLEX` now always return `Value::Text`, even when the imaginary part is zero — matching the Google Sheets contract that complex-number functions always return text strings
- Removed the near-zero epsilon suppression from `format_complex` so `IMSQRT("-1")` correctly returns `"6.12323399573677E-17+i"` instead of `"i"`
- Replaced the simplistic `format_num` with a 15-significant-figure formatter that matches GS output: decimal for normal-range values, uppercase scientific notation (`E±XX`) for very small/large values

## Test plan

- [ ] `cargo nextest run -p truecalc-core --test conformance bugs_conformance --no-capture` shows 17 rows flipping from FAIL to PASS (rows 15–26, 28–30, 32, 74)
- [ ] `cargo test -p truecalc-core` — all 2910 tests pass
- [ ] `cargo clippy --workspace -- -D warnings` — clean

closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)