### PR TITLE
chore: release v0.4.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "calamine",
  "chrono",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "serde",
  "serde_json",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp", "xtask"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.19](https://github.com/truecalc/core/compare/truecalc-core-v0.4.17...truecalc-core-v0.4.19) - 2026-04-21
+
+### Fixed
+
+- update integration tests to expect Error(Ref) for FREQUENCY and MODE.MULT
+- resolve 7 conformance bugs (MARGINOFERROR, FREQUENCY, MODE.MULT, IMCOTH, IMTANH)
+- support inline array args for PRODUCT, SUBTOTAL, SUMIFS, AVERAGEIFS, MAXIFS, MINIFS, DSUM, DAVERAGE
+- unwrap array results to first element in scalar evaluation context
+
+### Other
+
+- Merge pull request #495 from truecalc/release-plz-2026-04-21T05-55-29Z
+- re-evaluate all fixtures against GAS oracle; restore 29 oracle-verified coverage rows
+- Merge pull request #497 from truecalc/feat/488-array-scalar-context
+
 ## [0.4.18](https://github.com/truecalc/core/compare/truecalc-core-v0.4.17...truecalc-core-v0.4.18) - 2026-04-21
 
 ### Fixed

--- a/crates/mcp/CHANGELOG.md
+++ b/crates/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.19](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.18...truecalc-mcp-v0.4.19) - 2026-04-21
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.4.16](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.15...truecalc-mcp-v0.4.16) - 2026-04-21
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.4.17 -> 0.4.19
* `truecalc-mcp`: 0.4.18 -> 0.4.19

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.4.19](https://github.com/truecalc/core/compare/truecalc-core-v0.4.17...truecalc-core-v0.4.19) - 2026-04-21

### Fixed

- update integration tests to expect Error(Ref) for FREQUENCY and MODE.MULT
- resolve 7 conformance bugs (MARGINOFERROR, FREQUENCY, MODE.MULT, IMCOTH, IMTANH)
- support inline array args for PRODUCT, SUBTOTAL, SUMIFS, AVERAGEIFS, MAXIFS, MINIFS, DSUM, DAVERAGE
- unwrap array results to first element in scalar evaluation context

### Other

- Merge pull request #495 from truecalc/release-plz-2026-04-21T05-55-29Z
- re-evaluate all fixtures against GAS oracle; restore 29 oracle-verified coverage rows
- Merge pull request #497 from truecalc/feat/488-array-scalar-context
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.4.19](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.18...truecalc-mcp-v0.4.19) - 2026-04-21

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).