### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.4.19"
+version = "0.5.0"
 dependencies = [
  "calamine",
  "chrono",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.4.19"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.4.19"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp", "xtask"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.19"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/truecalc/core/compare/truecalc-core-v0.4.19...truecalc-core-v0.5.0) - 2026-04-22
+
+### Added
+
+- *(core)* add Engine::google_sheets() conformance factory
+
+### Fixed
+
+- match GS behavior for inline arrays in SUMIFS, AVERAGEIFS, MAXIFS, MINIFS, SUBTOTAL, and CONCAT
+
+### Other
+
+- separate test files from production code
+
 ## [0.4.19](https://github.com/truecalc/core/compare/truecalc-core-v0.4.17...truecalc-core-v0.4.19) - 2026-04-21
 
 ### Fixed

--- a/crates/mcp/CHANGELOG.md
+++ b/crates/mcp/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.19...truecalc-mcp-v0.5.0) - 2026-04-22
+
+### Added
+
+- *(mcp)* add --conformance flag and per-call conformance override
+
+### Other
+
+- separate test files from production code
+
 ## [0.4.19](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.18...truecalc-mcp-v0.4.19) - 2026-04-21
 
 ### Other

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -12,6 +12,6 @@ name = "truecalc-mcp"
 path = "src/main.rs"
 
 [dependencies]
-truecalc-core = { path = "../core", version = "0.4" }
+truecalc-core = { path = "../core", version = "0.5" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.4.19 -> 0.5.0 (⚠ API breaking changes)
* `truecalc-mcp`: 0.4.19 -> 0.5.0

### ⚠ `truecalc-core` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  truecalc_core::eval::functions::operator::concat_fn now takes 2 parameters instead of 1, in /tmp/.tmp9X5ohS/core/crates/core/src/eval/functions/operator/mod.rs:216
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.5.0](https://github.com/truecalc/core/compare/truecalc-core-v0.4.19...truecalc-core-v0.5.0) - 2026-04-22

### Added

- *(core)* add Engine::google_sheets() conformance factory

### Fixed

- match GS behavior for inline arrays in SUMIFS, AVERAGEIFS, MAXIFS, MINIFS, SUBTOTAL, and CONCAT

### Other

- separate test files from production code
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.5.0](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.19...truecalc-mcp-v0.5.0) - 2026-04-22

### Added

- *(mcp)* add --conformance flag and per-call conformance override

### Other

- separate test files from production code
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).