### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "calamine",
  "chrono",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp", "xtask"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/truecalc/core/compare/truecalc-core-v0.5.0...truecalc-core-v0.6.0) - 2026-04-25
+
+### Added
+
+- *(fixtures)* google_sheets snapshot 2026-04-23 (~11K test cases)
+
+### Fixed
+
+- *(conformance)* enable financial_conformance, remove google fixtures
+- *(conformance)* move 6 complex-number precision rows to bugs.tsv
+- *(conformance)* strip spurious header rows, fix 3 panics, move unimplemented rows to bugs.tsv, add google_conformance test
+- remove CELL from standalone evaluator and dead stubs from filter/operator
+
+### Other
+
+- Merge pull request #506 from truecalc/feat/446-447-remove-cell-and-dead-stubs
+
 ## [0.5.0](https://github.com/truecalc/core/compare/truecalc-core-v0.4.19...truecalc-core-v0.5.0) - 2026-04-22
 
 ### Added

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -12,6 +12,6 @@ name = "truecalc-mcp"
 path = "src/main.rs"
 
 [dependencies]
-truecalc-core = { path = "../core", version = "0.5" }
+truecalc-core = { path = "../core", version = "0.6" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `truecalc-mcp`: 0.5.0 -> 0.6.0

### ⚠ `truecalc-core` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function truecalc_core::eval::functions::filter::rows_fn, previously in file /tmp/.tmpNKEVg8/truecalc-core/src/eval/functions/filter/mod.rs:316
  function truecalc_core::eval::functions::logical::cell_fn::cell_fn, previously in file /tmp/.tmpNKEVg8/truecalc-core/src/eval/functions/logical/cell_fn/mod.rs:13
  function truecalc_core::eval::functions::operator::unique_fn, previously in file /tmp/.tmpNKEVg8/truecalc-core/src/eval/functions/operator/mod.rs:349
  function truecalc_core::eval::functions::filter::index_fn, previously in file /tmp/.tmpNKEVg8/truecalc-core/src/eval/functions/filter/mod.rs:208
  function truecalc_core::eval::functions::filter::columns_fn, previously in file /tmp/.tmpNKEVg8/truecalc-core/src/eval/functions/filter/mod.rs:328
  function truecalc_core::eval::functions::filter::unique_fn, previously in file /tmp/.tmpNKEVg8/truecalc-core/src/eval/functions/filter/mod.rs:193
  function truecalc_core::eval::functions::filter::sort_fn, previously in file /tmp/.tmpNKEVg8/truecalc-core/src/eval/functions/filter/mod.rs:77

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod truecalc_core::eval::functions::logical::cell_fn, previously in file /tmp/.tmpNKEVg8/truecalc-core/src/eval/functions/logical/cell_fn/mod.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.6.0](https://github.com/truecalc/core/compare/truecalc-core-v0.5.0...truecalc-core-v0.6.0) - 2026-04-25

### Added

- *(fixtures)* google_sheets snapshot 2026-04-23 (~11K test cases)

### Fixed

- *(conformance)* enable financial_conformance, remove google fixtures
- *(conformance)* move 6 complex-number precision rows to bugs.tsv
- *(conformance)* strip spurious header rows, fix 3 panics, move unimplemented rows to bugs.tsv, add google_conformance test
- remove CELL from standalone evaluator and dead stubs from filter/operator

### Other

- Merge pull request #506 from truecalc/feat/446-447-remove-cell-and-dead-stubs
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.5.0](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.19...truecalc-mcp-v0.5.0) - 2026-04-22

### Added

- *(mcp)* add --conformance flag and per-call conformance override

### Other

- separate test files from production code
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).