### PR TITLE
chore: release v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "calamine",
  "chrono",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp", "xtask"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/truecalc/core/compare/truecalc-core-v0.6.0...truecalc-core-v0.6.2) - 2026-04-25
+
+### Fixed
+
+- *(clippy)* use RangeInclusive::contains for basis bounds check
+- *(ci)* move platform-sensitive complex trig rows back to bugs.tsv
+- *(financial)* EOM convention, clean price AI, CUMPRINC type normalization, date coercion
+- *(financial)* XIRR Brent fallback for hard-to-converge rates
+- *(financial)* DURATION/MDURATION negative coupon/yield, TBILLPRICE discount>=1, TBILLYIELD >1yr
+- *(financial)* validation fixes for RECEIVED, DISC, YIELDDISC, INTRATE, YIELDMAT
+- *(financial)* DDB factor<=0 and negative cost, DB period>life validation
+- *(financial)* rewrite VDB with correct fractional periods and input validation
+- *(financial)* rewrite AMORLINC with proper period 0, basis validation, and date proration
+- *(financial)* skip booleans/text in MIRR and NPV array cash flows
+- *(financial)* input validation for ACCRINT, PRICEDISC, PRICEMAT, CUMIPMT, CUMPRINC
+- *(financial)* TBILLEQ compound formula for DSM > 182 days + discount bounds
+- *(financial)* IRR ignores text strings in array literals (GS/Excel behaviour)
+- *(financial)* robust convergence for IRR and RATE via Brent fallback
+- *(financial)* remove .round() from DOLLARDE/DOLLARFR
+- *(conformance)* reclaim 1033 passing rows from bugs.tsv
+
+### Other
+
+- release v0.6.0
+- add lab staging area, CI separation guard, and drop "oracle" language
+- *(conformance)* restore immutable google_sheets fixtures, introduce lab/
+
 ## [0.6.1](https://github.com/truecalc/core/compare/truecalc-core-v0.6.0...truecalc-core-v0.6.1) - 2026-04-25
 
 ### Fixed

--- a/crates/mcp/CHANGELOG.md
+++ b/crates/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/truecalc/core/compare/truecalc-mcp-v0.6.1...truecalc-mcp-v0.6.2) - 2026-04-25
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.5.0](https://github.com/truecalc/core/compare/truecalc-mcp-v0.4.19...truecalc-mcp-v0.5.0) - 2026-04-22
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.6.0 -> 0.6.2
* `truecalc-mcp`: 0.6.1 -> 0.6.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.6.2](https://github.com/truecalc/core/compare/truecalc-core-v0.6.0...truecalc-core-v0.6.2) - 2026-04-25

### Fixed

- *(clippy)* use RangeInclusive::contains for basis bounds check
- *(ci)* move platform-sensitive complex trig rows back to bugs.tsv
- *(financial)* EOM convention, clean price AI, CUMPRINC type normalization, date coercion
- *(financial)* XIRR Brent fallback for hard-to-converge rates
- *(financial)* DURATION/MDURATION negative coupon/yield, TBILLPRICE discount>=1, TBILLYIELD >1yr
- *(financial)* validation fixes for RECEIVED, DISC, YIELDDISC, INTRATE, YIELDMAT
- *(financial)* DDB factor<=0 and negative cost, DB period>life validation
- *(financial)* rewrite VDB with correct fractional periods and input validation
- *(financial)* rewrite AMORLINC with proper period 0, basis validation, and date proration
- *(financial)* skip booleans/text in MIRR and NPV array cash flows
- *(financial)* input validation for ACCRINT, PRICEDISC, PRICEMAT, CUMIPMT, CUMPRINC
- *(financial)* TBILLEQ compound formula for DSM > 182 days + discount bounds
- *(financial)* IRR ignores text strings in array literals (GS/Excel behaviour)
- *(financial)* robust convergence for IRR and RATE via Brent fallback
- *(financial)* remove .round() from DOLLARDE/DOLLARFR
- *(conformance)* reclaim 1033 passing rows from bugs.tsv

### Other

- release v0.6.0
- add lab staging area, CI separation guard, and drop "oracle" language
- *(conformance)* restore immutable google_sheets fixtures, introduce lab/
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.6.2](https://github.com/truecalc/core/compare/truecalc-mcp-v0.6.1...truecalc-mcp-v0.6.2) - 2026-04-25

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).