### PR TITLE
chore: release v0.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "calamine",
  "chrono",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp", "xtask"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/truecalc/core/compare/truecalc-core-v0.6.2...truecalc-core-v0.6.4) - 2026-04-26
+
+### Fixed
+
+- *(ci)* explain nextest vs formula-eval counts; remove oracle terminology
+
+### Other
+
+- release v0.6.3
+- *(fixtures)* remove legacy m1-m4 xlsx fixtures and align lab with source-first layout
+
 ## [0.6.3](https://github.com/truecalc/core/compare/truecalc-core-v0.6.2...truecalc-core-v0.6.3) - 2026-04-25
 
 ### Fixed

--- a/crates/mcp/CHANGELOG.md
+++ b/crates/mcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/truecalc/core/compare/truecalc-mcp-v0.6.3...truecalc-mcp-v0.6.4) - 2026-04-26
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.6.2](https://github.com/truecalc/core/compare/truecalc-mcp-v0.6.1...truecalc-mcp-v0.6.2) - 2026-04-25
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.6.2 -> 0.6.4
* `truecalc-mcp`: 0.6.3 -> 0.6.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.6.4](https://github.com/truecalc/core/compare/truecalc-core-v0.6.2...truecalc-core-v0.6.4) - 2026-04-26

### Fixed

- *(ci)* explain nextest vs formula-eval counts; remove oracle terminology

### Other

- release v0.6.3
- *(fixtures)* remove legacy m1-m4 xlsx fixtures and align lab with source-first layout
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.6.4](https://github.com/truecalc/core/compare/truecalc-mcp-v0.6.3...truecalc-mcp-v0.6.4) - 2026-04-26

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).