### PR TITLE
feat: engine-explicit API — Engine::sheets()/excel() required entry points

### DIFF
--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -27,13 +27,15 @@ cargo add truecalc-core
 
 ```rust
 use std::collections::HashMap;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::{Engine, Value};
+
+let engine = Engine::sheets();
 
 let mut vars = HashMap::new();
 vars.insert("A1".to_string(), Value::Number(100.0));
 vars.insert("B1".to_string(), Value::Number(200.0));
 
-let result = evaluate("SUM(A1, B1)", &vars);
+let result = engine.evaluate("SUM(A1, B1)", &vars);
 assert_eq!(result, Value::Number(300.0));
 ```
 
@@ -41,12 +43,12 @@ assert_eq!(result, Value::Number(300.0));
 
 ```rust
 use std::collections::HashMap;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::{Engine, Value};
 
 let mut vars = HashMap::new();
 vars.insert("score".to_string(), Value::Number(85.0));
 
-match evaluate("IF(score >= 60, \"pass\", \"fail\")", &vars) {
+match Engine::sheets().evaluate("IF(score >= 60, \"pass\", \"fail\")", &vars) {
     Value::Text(s)   => println!("{s}"),           // "pass"
     Value::Number(n) => println!("{n}"),
     Value::Bool(b)   => println!("{b}"),
@@ -59,9 +61,9 @@ match evaluate("IF(score >= 60, \"pass\", \"fail\")", &vars) {
 ### Validate without evaluating
 
 ```rust
-use truecalc_core::validate;
+use truecalc_core::Engine;
 
-match validate("SUM(A1, B1)") {
+match Engine::sheets().validate("SUM(A1, B1)") {
     Ok(_)  => println!("valid"),
     Err(e) => eprintln!("parse error at position {}: {}", e.position, e.message),
 }
@@ -70,9 +72,9 @@ match validate("SUM(A1, B1)") {
 ### Parse to an AST
 
 ```rust
-use truecalc_core::parse;
+use truecalc_core::Engine;
 
-let expr = parse("1 + 2 * 3").expect("valid formula");
+let expr = Engine::sheets().parse("1 + 2 * 3").expect("valid formula");
 // expr is an Expr tree you can walk yourself
 ```
 

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -1,21 +1,64 @@
 use std::collections::HashMap;
 
-use crate::eval::{evaluate_expr, Context, EvalCtx};
 use crate::eval::functions::Registry;
-use crate::parser::parse;
-use crate::types::{ErrorKind, Value};
+use crate::eval::{evaluate_expr, Context, EvalCtx};
+use crate::parser::{parse_formula, Expr};
+use crate::types::{ErrorKind, ParseError, Value};
+
+/// Which spreadsheet product's semantics the engine targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Flavor {
+    Sheets,
+    Excel,
+}
 
 pub struct Engine {
+    flavor: Flavor,
     registry: Registry,
 }
 
 impl Engine {
+    /// Engine targeting Google Sheets conformance.
+    pub fn sheets() -> Self {
+        Self { flavor: Flavor::Sheets, registry: Registry::new() }
+    }
+
+    /// Engine targeting Excel conformance.
+    ///
+    /// Excel evaluation semantics are not implemented yet (they land in a
+    /// later phase): [`Engine::evaluate`] returns
+    /// `Value::Error(ErrorKind::NA)` for every formula. [`Engine::parse`]
+    /// and [`Engine::validate`] work.
+    pub fn excel() -> Self {
+        Self { flavor: Flavor::Excel, registry: Registry::new() }
+    }
+
+    /// Deprecated alias for [`Engine::sheets`].
+    #[deprecated(note = "use Engine::sheets() — engine flavor is required; see ADR 2026-04-27")]
     pub fn google_sheets() -> Self {
-        Self { registry: Registry::new() }
+        Self::sheets()
+    }
+
+    /// Parse a formula string into an expression tree.
+    ///
+    /// The formula may start with `=`. Returns a [`ParseError`] if the input
+    /// is not a valid formula.
+    pub fn parse(&self, formula: &str) -> Result<Expr, ParseError> {
+        parse_formula(formula)
+    }
+
+    /// Validate that a formula string is syntactically correct without
+    /// returning the AST.
+    pub fn validate(&self, formula: &str) -> Result<(), ParseError> {
+        self.parse(formula).map(|_| ())
     }
 
     pub fn evaluate(&self, formula: &str, variables: &HashMap<String, Value>) -> Value {
-        match parse(formula) {
+        if self.flavor == Flavor::Excel {
+            // Excel evaluation semantics are not implemented yet.
+            return Value::Error(ErrorKind::NA);
+        }
+        match parse_formula(formula) {
             Err(_) => Value::Error(ErrorKind::Value),
             Ok(expr) => {
                 let ctx = Context::new(variables.clone());

--- a/crates/core/src/engine/tests.rs
+++ b/crates/core/src/engine/tests.rs
@@ -2,15 +2,15 @@ use super::*;
 use std::collections::HashMap;
 
 #[test]
-fn google_sheets_evaluates_sum() {
-    let engine = Engine::google_sheets();
+fn sheets_evaluates_sum() {
+    let engine = Engine::sheets();
     let result = engine.evaluate("=SUM(1,2)", &HashMap::new());
     assert_eq!(result, Value::Number(3.0));
 }
 
 #[test]
-fn google_sheets_evaluates_with_variables() {
-    let engine = Engine::google_sheets();
+fn sheets_evaluates_with_variables() {
+    let engine = Engine::sheets();
     let mut vars = HashMap::new();
     vars.insert("A".to_string(), Value::Number(10.0));
     let result = engine.evaluate("=A+5", &vars);
@@ -19,7 +19,51 @@ fn google_sheets_evaluates_with_variables() {
 
 #[test]
 fn parse_error_returns_value_error() {
-    let engine = Engine::google_sheets();
+    let engine = Engine::sheets();
     let result = engine.evaluate("not a formula", &HashMap::new());
     assert_eq!(result, Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn sheets_parses_valid_formula() {
+    let engine = Engine::sheets();
+    assert!(engine.parse("=SUM(1,2)").is_ok());
+}
+
+#[test]
+fn sheets_parse_rejects_invalid_formula() {
+    let engine = Engine::sheets();
+    assert!(engine.parse("=SUM(1,").is_err());
+}
+
+#[test]
+fn sheets_validates_formula() {
+    let engine = Engine::sheets();
+    assert!(engine.validate("=1+2").is_ok());
+    assert!(engine.validate("=1+").is_err());
+}
+
+#[test]
+fn excel_parses_and_validates() {
+    let engine = Engine::excel();
+    assert!(engine.parse("=SUM(1,2)").is_ok());
+    assert!(engine.validate("=SUM(1,2)").is_ok());
+    assert!(engine.validate("=SUM(1,").is_err());
+}
+
+#[test]
+fn excel_evaluate_returns_unsupported_error() {
+    // Excel evaluation semantics are not implemented yet — evaluate must
+    // return a clear error rather than silently using Sheets semantics.
+    let engine = Engine::excel();
+    let result = engine.evaluate("=SUM(1,2)", &HashMap::new());
+    assert_eq!(result, Value::Error(ErrorKind::NA));
+}
+
+#[test]
+#[allow(deprecated)]
+fn google_sheets_is_deprecated_alias_for_sheets() {
+    let engine = Engine::google_sheets();
+    let result = engine.evaluate("=SUM(1,2)", &HashMap::new());
+    assert_eq!(result, Value::Number(3.0));
 }

--- a/crates/core/src/eval/functions/logical/is_checks/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/tests/edge.rs
@@ -1,5 +1,5 @@
 use super::super::{is_valid_email, isblank_fn, iserror_fn, isna_fn, isnumber_fn, istext_fn};
-use crate::evaluate;
+use crate::Engine;
 use crate::types::{ErrorKind, Value};
 use std::collections::HashMap;
 
@@ -51,10 +51,10 @@ fn isemail_no_dot_in_domain() {
 
 #[test]
 fn isemail_number_arg_returns_false() {
-    assert_eq!(evaluate("=ISEMAIL(42)", &HashMap::new()), Value::Bool(false));
+    assert_eq!(Engine::sheets().evaluate("=ISEMAIL(42)", &HashMap::new()), Value::Bool(false));
 }
 
 #[test]
 fn isemail_bool_arg_returns_false() {
-    assert_eq!(evaluate("=ISEMAIL(TRUE)", &HashMap::new()), Value::Bool(false));
+    assert_eq!(Engine::sheets().evaluate("=ISEMAIL(TRUE)", &HashMap::new()), Value::Bool(false));
 }

--- a/crates/core/src/eval/functions/logical/is_checks/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/tests/failure.rs
@@ -1,5 +1,5 @@
 use super::super::{isblank_fn, iserror_fn, isna_fn, isnumber_fn, istext_fn};
-use crate::evaluate;
+use crate::Engine;
 use crate::types::{ErrorKind, Value};
 use std::collections::HashMap;
 
@@ -37,7 +37,7 @@ fn isna_no_args() {
 #[test]
 fn isemail_no_args_returns_na() {
     assert_eq!(
-        evaluate("=ISEMAIL()", &HashMap::new()),
+        Engine::sheets().evaluate("=ISEMAIL()", &HashMap::new()),
         Value::Error(ErrorKind::NA)
     );
 }

--- a/crates/core/src/eval/functions/logical/lambda/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/lambda/tests/edge.rs
@@ -1,9 +1,9 @@
-use crate::evaluate;
+use crate::Engine;
 use crate::types::Value;
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 #[test]

--- a/crates/core/src/eval/functions/logical/lambda/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/lambda/tests/failure.rs
@@ -1,9 +1,9 @@
-use crate::evaluate;
+use crate::Engine;
 use crate::types::{ErrorKind, Value};
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 #[test]

--- a/crates/core/src/eval/functions/logical/lambda/tests/success.rs
+++ b/crates/core/src/eval/functions/logical/lambda/tests/success.rs
@@ -1,9 +1,9 @@
-use crate::evaluate;
+use crate::Engine;
 use crate::types::Value;
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 #[test]

--- a/crates/core/src/eval/functions/logical/let_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/logical/let_fn/tests/edge.rs
@@ -1,9 +1,9 @@
-use crate::evaluate;
+use crate::Engine;
 use crate::types::Value;
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 #[test]
@@ -18,5 +18,5 @@ fn let_binding_shadows_outer() {
     let mut vars = HashMap::new();
     vars.insert("X".to_string(), crate::types::Value::Number(1.0));
     // LET(x, 10, x) should return 10, not the outer x=1
-    assert_eq!(evaluate("=LET(x, 10, x)", &vars), Value::Number(10.0));
+    assert_eq!(Engine::sheets().evaluate("=LET(x, 10, x)", &vars), Value::Number(10.0));
 }

--- a/crates/core/src/eval/functions/logical/let_fn/tests/failure.rs
+++ b/crates/core/src/eval/functions/logical/let_fn/tests/failure.rs
@@ -1,9 +1,9 @@
-use crate::evaluate;
+use crate::Engine;
 use crate::types::{ErrorKind, Value};
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 #[test]

--- a/crates/core/src/eval/functions/logical/let_fn/tests/success.rs
+++ b/crates/core/src/eval/functions/logical/let_fn/tests/success.rs
@@ -1,9 +1,9 @@
-use crate::evaluate;
+use crate::Engine;
 use crate::types::Value;
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 #[test]

--- a/crates/core/src/eval/functions/lookup/tests/edge.rs
+++ b/crates/core/src/eval/functions/lookup/tests/edge.rs
@@ -1,4 +1,4 @@
-use crate::evaluate;
+use crate::Engine;
 use crate::eval::functions::lookup::{
     index_match::match_fn,
     lookup_fn::{lookup_fn, xmatch_fn},
@@ -8,7 +8,7 @@ use crate::types::{ErrorKind, Value};
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 fn make_1d(vals: Vec<Value>) -> Value {

--- a/crates/core/src/eval/functions/lookup/tests/failure.rs
+++ b/crates/core/src/eval/functions/lookup/tests/failure.rs
@@ -1,4 +1,4 @@
-use crate::evaluate;
+use crate::Engine;
 use crate::eval::functions::lookup::{
     index_match::{index_fn, match_fn},
     lookup_fn::{lookup_fn, xlookup_fn, xmatch_fn},
@@ -24,7 +24,7 @@ fn t(s: &str) -> Value {
 }
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 // CHOOSE

--- a/crates/core/src/eval/functions/lookup/tests/success.rs
+++ b/crates/core/src/eval/functions/lookup/tests/success.rs
@@ -1,4 +1,4 @@
-use crate::evaluate;
+use crate::Engine;
 use crate::eval::functions::lookup::{
     index_match::{index_fn, match_fn},
     lookup_fn::{lookup_fn, xlookup_fn, xmatch_fn},
@@ -24,7 +24,7 @@ fn n(v: f64) -> Value {
 }
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 // CHOOSE

--- a/crates/core/src/eval/functions/math/sumif/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/sumif/tests/edge.rs
@@ -2,7 +2,7 @@ use crate::types::Value;
 use std::collections::HashMap;
 
 fn run(formula: &str, vars: HashMap<String, Value>) -> Value {
-    crate::evaluate(formula, &vars)
+    crate::Engine::sheets().evaluate(formula, &vars)
 }
 
 fn nums_var(name: &str, ns: &[f64]) -> (String, Value) {

--- a/crates/core/src/eval/functions/math/sumif/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/sumif/tests/failure.rs
@@ -2,7 +2,7 @@ use crate::types::{ErrorKind, Value};
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    crate::evaluate(formula, &HashMap::new())
+    crate::Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 #[test]

--- a/crates/core/src/eval/functions/math/sumif/tests/success.rs
+++ b/crates/core/src/eval/functions/math/sumif/tests/success.rs
@@ -2,7 +2,7 @@ use crate::types::Value;
 use std::collections::HashMap;
 
 fn run(formula: &str, vars: HashMap<String, Value>) -> Value {
-    crate::evaluate(formula, &vars)
+    crate::Engine::sheets().evaluate(formula, &vars)
 }
 
 fn nums_var(name: &str, ns: &[f64]) -> (String, Value) {

--- a/crates/core/src/eval/functions/math/sumifs/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/sumifs/tests/edge.rs
@@ -2,7 +2,7 @@ use crate::types::Value;
 use std::collections::HashMap;
 
 fn run(formula: &str, vars: HashMap<String, Value>) -> Value {
-    crate::evaluate(formula, &vars)
+    crate::Engine::sheets().evaluate(formula, &vars)
 }
 
 fn nums_var(name: &str, ns: &[f64]) -> (String, Value) {

--- a/crates/core/src/eval/functions/math/sumifs/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/sumifs/tests/failure.rs
@@ -2,7 +2,7 @@ use crate::types::{ErrorKind, Value};
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    crate::evaluate(formula, &HashMap::new())
+    crate::Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 #[test]

--- a/crates/core/src/eval/functions/math/sumifs/tests/success.rs
+++ b/crates/core/src/eval/functions/math/sumifs/tests/success.rs
@@ -2,7 +2,7 @@ use crate::types::Value;
 use std::collections::HashMap;
 
 fn run(formula: &str, vars: HashMap<String, Value>) -> Value {
-    crate::evaluate(formula, &vars)
+    crate::Engine::sheets().evaluate(formula, &vars)
 }
 
 fn nums_var(name: &str, ns: &[f64]) -> (String, Value) {

--- a/crates/core/src/eval/functions/operator/tests/concat.rs
+++ b/crates/core/src/eval/functions/operator/tests/concat.rs
@@ -1,9 +1,9 @@
-use crate::evaluate;
+use crate::Engine;
 use crate::types::{ErrorKind, Value};
 use std::collections::HashMap;
 
 fn run(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 // ── basic concatenation ───────────────────────────────────────────────────────

--- a/crates/core/src/eval/functions/statistical/count/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/count/tests/edge.rs
@@ -5,7 +5,7 @@ use crate::types::Value;
 use std::collections::HashMap;
 
 fn run(formula: &str, vars: HashMap<String, Value>) -> Value {
-    crate::evaluate(formula, &vars)
+    crate::Engine::sheets().evaluate(formula, &vars)
 }
 
 fn span() -> Span { Span::new(0, 1) }

--- a/crates/core/src/eval/tests/array_literal.rs
+++ b/crates/core/src/eval/tests/array_literal.rs
@@ -2,7 +2,7 @@ use crate::types::Value;
 use std::collections::HashMap;
 
 fn run_formula(formula: &str) -> Value {
-    crate::evaluate(formula, &HashMap::new())
+    crate::Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,7 +8,9 @@ pub mod types;
 
 pub use display::display_number;
 pub use engine::Engine;
-pub use parser::{parse, validate, Expr};
+#[allow(deprecated)]
+pub use parser::{parse, validate};
+pub use parser::Expr;
 pub use types::{ErrorKind, ParseError, Value};
 
 pub use eval::functions::{FunctionMeta, Registry};
@@ -18,6 +20,7 @@ use std::collections::HashMap;
 /// Evaluate a formula string with named variables, targeting Google Sheets conformance.
 ///
 /// Returns `Value::Error(ErrorKind::Value)` on parse failure.
+#[deprecated(note = "use Engine::sheets()/Engine::excel() and engine.evaluate() — engine flavor is required; see ADR 2026-04-27")]
 pub fn evaluate(formula: &str, variables: &HashMap<String, Value>) -> Value {
-    Engine::google_sheets().evaluate(formula, variables)
+    Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/src/parser/mod.rs
+++ b/crates/core/src/parser/mod.rs
@@ -373,7 +373,13 @@ fn is_cell_ref(name: &str) -> bool {
 ///
 /// The formula must start with `=`. Returns a [`ParseError`] if the input
 /// is not a valid formula.
+#[deprecated(note = "use Engine::sheets()/Engine::excel() and engine.parse() — engine flavor is required; see ADR 2026-04-27")]
 pub fn parse(formula: &str) -> Result<Expr, ParseError> {
+    parse_formula(formula)
+}
+
+/// Crate-internal parser entry point used by [`crate::Engine`].
+pub(crate) fn parse_formula(formula: &str) -> Result<Expr, ParseError> {
     let input = formula.strip_prefix('=').unwrap_or(formula).trim();
     let p = Parser::new(formula);
     match p.parse_comparison(input) {
@@ -400,13 +406,15 @@ pub fn parse(formula: &str) -> Result<Expr, ParseError> {
 }
 
 /// Validate that a formula string is syntactically correct without returning the AST.
+#[deprecated(note = "use Engine::sheets()/Engine::excel() and engine.validate() — engine flavor is required; see ADR 2026-04-27")]
 pub fn validate(formula: &str) -> Result<(), ParseError> {
-    parse(formula).map(|_| ())
+    parse_formula(formula).map(|_| ())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::parse_formula as parse;
     use crate::parser::ast::{BinaryOp, Expr, UnaryOp};
 
     #[test]
@@ -464,6 +472,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn validate_incomplete_fails() {
         let err = validate("=SUM(1,").unwrap_err();
         assert!(!err.message.is_empty());

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -24,7 +24,7 @@
 //! The test evaluates the formula with `truecalc_core::evaluate` and compares
 //! against the canonical value.  Number comparisons allow 1e-4 relative tolerance.
 
-use truecalc_core::{evaluate, ErrorKind, Value};
+use truecalc_core::{ErrorKind, Value};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use chrono::NaiveDate;
@@ -602,4 +602,10 @@ fn every_registered_function_has_conformance_coverage() {
         "Functions with no passing conformance row: {:?}",
         missing
     );
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/conformance_reporter.rs
+++ b/crates/core/tests/conformance_reporter.rs
@@ -3,7 +3,7 @@
 // Collects pass/fail counts per TSV fixture and writes target/conformance-report.json.
 // Called by the generate_conformance_report test in conformance.rs.
 
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -264,4 +264,10 @@ pub fn collect_tsv_fixture_results(path: &Path, category: &str, report: &mut Con
             ));
         }
     }
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/deprecated_api.rs
+++ b/crates/core/tests/deprecated_api.rs
@@ -1,0 +1,40 @@
+//! The deprecated engine-less free functions must keep working (with a
+//! deprecation warning at compile time) until they are removed.
+//! See ADR 2026-04-27-engine-flavor-explicit-everywhere.
+#![allow(deprecated)]
+
+use std::collections::HashMap;
+use truecalc_core::{Engine, Value};
+
+#[test]
+fn free_evaluate_still_works() {
+    let result = truecalc_core::evaluate("=SUM(1,2)", &HashMap::new());
+    assert_eq!(result, Value::Number(3.0));
+}
+
+#[test]
+fn free_evaluate_matches_sheets_engine() {
+    let mut vars = HashMap::new();
+    vars.insert("x".to_string(), Value::Number(4.0));
+    let free = truecalc_core::evaluate("=x*2+1", &vars);
+    let engine = Engine::sheets().evaluate("=x*2+1", &vars);
+    assert_eq!(free, engine);
+}
+
+#[test]
+fn free_parse_still_works() {
+    assert!(truecalc_core::parse("=1+2").is_ok());
+    assert!(truecalc_core::parse("=1+").is_err());
+}
+
+#[test]
+fn free_validate_still_works() {
+    assert!(truecalc_core::validate("=ROUND(1.23, 1)").is_ok());
+    assert!(truecalc_core::validate("=ROUND(1.23,").is_err());
+}
+
+#[test]
+fn engine_google_sheets_alias_still_works() {
+    let engine = Engine::google_sheets();
+    assert_eq!(engine.evaluate("=SUM(1,2)", &HashMap::new()), Value::Number(3.0));
+}

--- a/crates/core/tests/helpers.rs
+++ b/crates/core/tests/helpers.rs
@@ -1,10 +1,10 @@
 // Test helpers for truecalc-core integration tests.
-use truecalc_core::{evaluate, Value};
+use truecalc_core::{Engine, Value};
 use std::collections::HashMap;
 
 /// Convenience: evaluate a formula with no variables.
 pub fn eval(formula: &str) -> Value {
-    evaluate(formula, &HashMap::new())
+    Engine::sheets().evaluate(formula, &HashMap::new())
 }
 
 /// Convenience: evaluate a formula with string-keyed variables.
@@ -13,5 +13,5 @@ pub fn eval_with(formula: &str, vars: impl IntoIterator<Item = (&'static str, Va
     for (k, v) in vars {
         map.insert(k.to_string(), v);
     }
-    evaluate(formula, &map)
+    Engine::sheets().evaluate(formula, &map)
 }

--- a/crates/core/tests/property_array.rs
+++ b/crates/core/tests/property_array.rs
@@ -3,7 +3,7 @@
 // Property-based tests for array functions.
 // Verifies length-preservation and element-wise invariants.
 
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use proptest::prelude::*;
 use std::collections::HashMap;
 
@@ -51,4 +51,10 @@ fn sequence_values_start_at_one() {
         }
     });
     eprintln!("proptest: {CASES} cases (n ∈ [1, 10])");
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_conformance.rs
+++ b/crates/core/tests/property_conformance.rs
@@ -6,7 +6,7 @@
 // These tests complement the fixed-row conformance tests in conformance.rs.
 // They catch regressions for inputs that don't appear in the fixture files.
 
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use proptest::prelude::*;
 use std::collections::HashMap;
 
@@ -288,4 +288,10 @@ fn m2_abs_symmetry() {
         prop_assert_eq!(pos, neg, "ABS({}) != ABS({})", x, -x);
     });
     eprintln!("proptest: {CASES} cases (x ∈ [-1e6, 1e6])");
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_database.rs
+++ b/crates/core/tests/property_database.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -133,4 +133,10 @@ fn sanity_dsum() {
     vars.insert("db".to_string(), db);
     vars.insert("crit".to_string(), crit);
     assert_eq!(evaluate("=DSUM(db, 1, crit)", &vars), Value::Number(30.0));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_date.rs
+++ b/crates/core/tests/property_date.rs
@@ -3,7 +3,7 @@
 // Property-based tests for date functions.
 // Verifies mathematical invariants that hold for any valid date input.
 
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use proptest::prelude::*;
 use std::collections::HashMap;
 
@@ -121,4 +121,10 @@ fn day_in_valid_range() {
         }
     });
     eprintln!("proptest: {CASES} cases (y ∈ [1900, 2100], m ∈ [1, 12], d ∈ [1, 28])");
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_engineering.rs
+++ b/crates/core/tests/property_engineering.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -124,4 +124,10 @@ fn sanity_bitwise() {
     assert_eq!(run("=BITAND(12, 10)"), Value::Number(8.0));
     assert_eq!(run("=BITOR(12, 10)"), Value::Number(14.0));
     assert_eq!(run("=BITXOR(12, 10)"), Value::Number(6.0));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_error_propagation.rs
+++ b/crates/core/tests/property_error_propagation.rs
@@ -4,7 +4,7 @@
 // than silently resolving them. This is a correctness invariant derived from
 // Google Sheets behavior: errors are contagious.
 
-use truecalc_core::{evaluate, ErrorKind, Value};
+use truecalc_core::{ErrorKind, Value};
 use proptest::prelude::*;
 use std::collections::HashMap;
 
@@ -110,4 +110,10 @@ fn trim_propagates_error() {
         prop_assert!(is_error(&result), "TRIM did not propagate error, got {:?}", result);
     });
     eprintln!("proptest: {CASES} cases (e ∈ {{#VALUE!, #N/A, #DIV/0!, #NUM!}})");
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_filter.rs
+++ b/crates/core/tests/property_filter.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -125,4 +125,10 @@ fn sanity_unique() {
 #[test]
 fn sanity_rows() {
     assert_eq!(run("=ROWS({3;1;2})"), Value::Number(3.0));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_financial.rs
+++ b/crates/core/tests/property_financial.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -76,4 +76,10 @@ fn npv_zero_rate_sanity() {
     ].into_iter().collect();
     let result = evaluate("=NPV(0, v1, v2)", &vars);
     assert_eq!(result, Value::Number(300.0));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_info.rs
+++ b/crates/core/tests/property_info.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -104,4 +104,10 @@ fn sanity_isodd_iseven() {
     assert_eq!(run("=ISODD(4)"), Value::Bool(false));
     assert_eq!(run("=ISEVEN(4)"), Value::Bool(true));
     assert_eq!(run("=ISEVEN(3)"), Value::Bool(false));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_logical.rs
+++ b/crates/core/tests/property_logical.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -79,4 +79,10 @@ fn not_not_true() {
 #[test]
 fn not_not_false() {
     assert_eq!(run("=NOT(NOT(FALSE))"), Value::Bool(false));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_lookup.rs
+++ b/crates/core/tests/property_lookup.rs
@@ -4,7 +4,7 @@
 // Verifies invariants: out-of-range inputs produce errors, in-range inputs
 // produce values within the searched set.
 
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use proptest::prelude::*;
 use std::collections::HashMap;
 
@@ -56,4 +56,10 @@ fn choose_in_range_returns_value() {
         }
     });
     eprintln!("proptest: {CASES} cases (n_choices ∈ [1, 5], idx_minus_one ∈ [0, 5))");
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_math.rs
+++ b/crates/core/tests/property_math.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -221,4 +221,10 @@ fn rows_and_columns_report_correct_dimensions() {
         prop_assert_eq!(cols, Value::Number(c as f64));
     });
     eprintln!("proptest: {CASES} cases (r ∈ [1, 8], c ∈ [1, 8])");
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_operator.rs
+++ b/crates/core/tests/property_operator.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -155,4 +155,10 @@ fn sanity_multiply() {
 fn sanity_eq() {
     assert_eq!(run("=5 = 5"), Value::Bool(true));
     assert_eq!(run("=5 = 6"), Value::Bool(false));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_parser.rs
+++ b/crates/core/tests/property_parser.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -109,4 +109,10 @@ fn sanity_convert_km() {
 #[test]
 fn sanity_to_text() {
     assert_eq!(run("=TO_TEXT(42)"), Value::Text("42".to_string()));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_statistical.rs
+++ b/crates/core/tests/property_statistical.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -132,4 +132,10 @@ fn sanity_average() {
 fn sanity_min_max() {
     assert_eq!(run("=MIN(3, 7)"), Value::Number(3.0));
     assert_eq!(run("=MAX(3, 7)"), Value::Number(7.0));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_text.rs
+++ b/crates/core/tests/property_text.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -150,4 +150,10 @@ fn left_full_len_is_identity() {
 fn concatenate_sanity() {
     let result = run_text_vars("=CONCATENATE(a,b)", vec![("a", "hello"), ("b", " world")]);
     assert_eq!(result, Value::Text("hello world".to_string()));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_volatile.rs
+++ b/crates/core/tests/property_volatile.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 
 fn run(formula: &str) -> Value {
     evaluate(formula, &HashMap::new())
@@ -133,4 +133,10 @@ fn now_is_greater_than_today() {
         now,
         today + 1.0
     );
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/property_web.rs
+++ b/crates/core/tests/property_web.rs
@@ -1,5 +1,5 @@
 use proptest::prelude::*;
-use truecalc_core::{evaluate, Value};
+use truecalc_core::Value;
 use std::collections::HashMap;
 
 const CASES: u32 = 500;
@@ -169,4 +169,10 @@ fn sanity_hyperlink() {
         run_text("=HYPERLINK(url, label)", vec![("url", "https://x.com"), ("label", "Click")]),
         Value::Text("Click".to_string())
     );
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/tests/registry.rs
+++ b/crates/core/tests/registry.rs
@@ -39,7 +39,6 @@ fn registry_new_has_no_duplicates() {
 #[test]
 fn alias_resolves_to_same_result() {
     use std::collections::HashMap;
-    use truecalc_core::evaluate;
     // TTEST and T.TEST are aliases — same result
     let r1 = evaluate("TTEST({1,2,3},{4,5,6},2,1)", &HashMap::new());
     let r2 = evaluate("T.TEST({1,2,3},{4,5,6},2,1)", &HashMap::new());
@@ -60,7 +59,7 @@ fn alias_does_not_appear_in_metadata() {
 #[test]
 fn context_limited_functions_return_name_error() {
     use std::collections::HashMap;
-    use truecalc_core::{evaluate, Value, ErrorKind};
+    use truecalc_core::{Value, ErrorKind};
     // These functions require a cell grid — they should not be registered
     // in the standalone evaluator. Callers should get #NAME? not #N/A.
     let cases = [
@@ -84,9 +83,15 @@ fn context_limited_functions_return_name_error() {
 #[test]
 fn rows_and_columns_work_with_array_input() {
     use std::collections::HashMap;
-    use truecalc_core::{evaluate, Value};
+    use truecalc_core::Value;
     assert_eq!(evaluate("ROWS({1,2,3;4,5,6})", &HashMap::new()), Value::Number(2.0));
     assert_eq!(evaluate("ROWS({1,2,3})", &HashMap::new()),        Value::Number(1.0));
     assert_eq!(evaluate("COLUMNS({1,2,3;4,5,6})", &HashMap::new()), Value::Number(3.0));
     assert_eq!(evaluate("COLUMNS({1})", &HashMap::new()),             Value::Number(1.0));
+}
+
+/// Engine-explicit shim: the free `evaluate` is deprecated in favor of
+/// `Engine::sheets().evaluate` (ADR 2026-04-27).
+fn evaluate(formula: &str, variables: &std::collections::HashMap<String, Value>) -> Value {
+    truecalc_core::Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 
-use truecalc_core::{parse, validate, Engine, Expr, Registry, Value};
+use truecalc_core::{Engine, Expr, Registry, Value};
 use serde_json::{json, Value as JsonValue};
 
 // ─── Conformance ─────────────────────────────────────────────────────────────
@@ -14,7 +14,7 @@ struct Engines {
 
 impl Engines {
     fn new() -> Self {
-        Self { google_sheets: Engine::google_sheets() }
+        Self { google_sheets: Engine::sheets() }
     }
 
     fn select(&self, conformance: &str) -> Option<&Engine> {
@@ -147,8 +147,8 @@ fn handle_request(req: &JsonValue, default_conformance: &str, engines: &Engines)
 fn dispatch_tool(name: &str, args: &JsonValue, default_conformance: &str, engines: &Engines) -> JsonValue {
     match name {
         "evaluate" => tool_evaluate(args, default_conformance, engines),
-        "validate" => tool_validate(args),
-        "explain" => tool_explain(args),
+        "validate" => tool_validate(args, engines),
+        "explain" => tool_explain(args, engines),
         "batch_evaluate" => tool_batch_evaluate(args, default_conformance, engines),
         "list_functions" => tool_list_functions(),
         "get_stats" => tool_get_stats(),
@@ -173,23 +173,23 @@ fn tool_evaluate(args: &JsonValue, default_conformance: &str, engines: &Engines)
     value_to_json(&value)
 }
 
-fn tool_validate(args: &JsonValue) -> JsonValue {
+fn tool_validate(args: &JsonValue, engines: &Engines) -> JsonValue {
     let formula = match args["formula"].as_str() {
         Some(f) => f,
         None => return json!({ "error": "missing formula" }),
     };
-    match validate(formula) {
+    match engines.google_sheets.validate(formula) {
         Ok(_) => json!({ "valid": true }),
         Err(e) => json!({ "valid": false, "error": e.to_string() }),
     }
 }
 
-fn tool_explain(args: &JsonValue) -> JsonValue {
+fn tool_explain(args: &JsonValue, engines: &Engines) -> JsonValue {
     let formula = match args["formula"].as_str() {
         Some(f) => f,
         None => return json!({ "error": "missing formula" }),
     };
-    match parse(formula) {
+    match engines.google_sheets.parse(formula) {
         Ok(expr) => {
             let mut functions = Vec::new();
             collect_functions(&expr, &mut functions);

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -69,7 +69,7 @@ pub fn evaluate(formula: &str, variables: JsValue) -> EvalResult {
         None => HashMap::new(),
     };
 
-    match truecalc_core::evaluate(formula, &vars) {
+    match truecalc_core::Engine::sheets().evaluate(formula, &vars) {
         Value::Number(n) | Value::Date(n) => EvalResult::Number { value: n },
         Value::Text(s) => EvalResult::Text { value: s },
         Value::Bool(b) => EvalResult::Bool { value: b },
@@ -84,7 +84,7 @@ pub fn evaluate(formula: &str, variables: JsValue) -> EvalResult {
 /// Returns `{ valid: true }` on success or `{ valid: false, error: "..." }` on failure.
 #[wasm_bindgen]
 pub fn validate(formula: &str) -> ValidateResult {
-    match truecalc_core::validate(formula) {
+    match truecalc_core::Engine::sheets().validate(formula) {
         Ok(_) => ValidateResult { valid: true, error: None },
         Err(e) => ValidateResult { valid: false, error: Some(e.to_string()) },
     }
@@ -212,7 +212,7 @@ impl WasmEngine {
 #[wasm_bindgen(js_name = "createEngine")]
 pub fn create_engine(target: &str) -> Result<WasmEngine, JsValue> {
     match target {
-        "google-sheets" => Ok(WasmEngine { inner: truecalc_core::Engine::google_sheets() }),
+        "google-sheets" => Ok(WasmEngine { inner: truecalc_core::Engine::sheets() }),
         _ => Err(JsValue::from_str(&format!("Unknown conformance target: '{}'", target))),
     }
 }


### PR DESCRIPTION
closes #523

## Summary

Implements **ADR 2026-04-27-engine-flavor-explicit-everywhere**: engine flavor is now explicit and required on every public entry point of truecalc-core.

### API changes (truecalc-core)

- **`Engine::sheets()`** — new canonical constructor for the Google Sheets-conformant engine.
- **`Engine::excel()`** — new constructor; `parse`/`validate` work, `evaluate` returns `Value::Error(ErrorKind::NA)` until Excel evaluation semantics land (P1.4+). No silent fallback to Sheets semantics.
- **`engine.parse()` / `engine.validate()`** — new methods so the engine is the single entry point for parse/validate/evaluate.
- **Deprecated (not removed), with migration notes pointing at the ADR:**
  - free `truecalc_core::evaluate(formula, &vars)`
  - free `truecalc_core::parse(formula)` / `truecalc_core::validate(formula)` (and their `parser::` originals)
  - `Engine::google_sheets()` (alias for `Engine::sheets()`)

### Internal migration (no external behavior change)

- `crates/wasm`: free `evaluate`/`validate` and `createEngine('google-sheets')` now route through `Engine::sheets()` internally — **npm public API shape unchanged**.
- `crates/mcp`: `validate`/`explain` tools now use the engine API internally — **MCP tool schemas unchanged** (engine field on MCP tools lands with Phase 6 per the issue).
- All in-crate test modules and integration tests migrated off the deprecated free functions.

### Tests

- `crates/core/src/engine/tests.rs`: sheets evaluates as before; sheets/excel parse+validate; excel evaluate returns the unsupported error; `google_sheets()` alias still works.
- `crates/core/tests/deprecated_api.rs` (new): deprecated free functions still work and match the engine results (deprecation warning enforced at compile time by `#[deprecated]`; tests opt out via `#![allow(deprecated)]`).

### Verification

- `cargo clippy --workspace -- -D warnings` clean (xtask excluded locally only because the sandbox lacks OpenSSL headers; xtask is untouched and covered by CI)
- `cargo test -p truecalc-core`: 26 targets, 2888 passed, 0 failed — **all conformance fixture suites green, no fixture TSVs touched**
- `cargo test -p truecalc-mcp`: green (including the existing 'excel is an unknown conformance target' behavior, unchanged until Phase 6)

### Notes for review

- `Value::Error(ErrorKind::NA)` was chosen as the 'unsupported' signal for `Engine::excel().evaluate` because `evaluate` returns `Value` and `ErrorKind` has no message-carrying variant; documented on `Engine::excel()`. Happy to revisit when Excel semantics land.
- Repo is not currently `cargo fmt --check` clean on main (pre-existing); new code matches the existing style instead of reformatting.