### PR TITLE
test: register workbook.tsv as report-only conformance category (P1.5 harness)

### DIFF
--- a/conformance.lock
+++ b/conformance.lock
@@ -1,2 +1,2 @@
 [google-sheets]
-data_as_of = "2026-04-23"
+data_as_of = "2026-06-08"

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -398,6 +398,18 @@ conformance_tsv_test!(filter_conformance,      "filter.tsv");
 conformance_tsv_test!(web_conformance,         "web.tsv");
 conformance_tsv_test!(financial_conformance,   "financial.tsv");
 
+/// P1.5 workbook fixtures — cross-sheet refs, named ranges, date-typed scalars
+/// (pipeline-generated, core issue #527).
+///
+/// Report-only (non-blocking) until the engine gains workbook support:
+/// P1.2 reference grammar (#524) + P1.3 resolver resolve cross-sheet/named
+/// refs, and P1.4 (#526) defines `date`-typed row handling.  Once those land,
+/// switch this to `conformance_tsv_test!` so every row blocks CI.
+#[test]
+fn workbook_conformance_report() {
+    run_tsv_fixture_report(&fixture("workbook.tsv"));
+}
+
 /// Known-bug regression baseline.
 ///
 /// Rows here are GS-captured cases where our engine does not yet produce the


### PR DESCRIPTION
Refs #527. **Stacked on #559** — base is `feat/527-p15-fixtures`; merge #559 first (GitHub will retarget this PR to `main` when the base branch is deleted).

Split out from #559 because CI's fixture/code separation gate forbids mixing `google_sheets/*.tsv` with code changes in one PR.

## What

- `workbook_conformance_report` test: runs `workbook.tsv` through the existing non-blocking report harness (same pattern as `bugs.tsv`). Switch to the blocking `conformance_tsv_test!` once P1.2 (#524) reference grammar, P1.3 resolver, and P1.4 (#526) date-typed handling land.
- `conformance.lock`: bump `google-sheets` `data_as_of` to `2026-06-08` (export pipeline output — unchanged by the review-round re-export, which ran on the same date).

## Report numbers (regenerated fixture, post review round 1)

**21 passed, 52 open** against the regenerated `workbook.tsv` from #559. The totals happen to match the pre-fix run, but the composition is now honest: the 5 `=TEXT(...)` rows that previously passed as *false positives* (typed `date`, matching only as accidental Text==Text) are now correctly typed `string` — 4 of them pass as genuine text expectations, and the fifth (`=TEXT(DATE(1899,12,25),...)` → `3799-12-25`) is open because the engine does not implement Sheets' +1900 year rule. The open set is cross-sheet refs, named ranges, date-typed rows, and the +1900-rule rows — exactly the P1.2/P1.3/P1.4 surface.

Verified locally on the rebased branch: full `--test conformance` suite green (20 tests), including `every_registered_function_has_conformance_coverage` with `workbook.tsv` present.
