### PR TITLE
test: register workbook.tsv as report-only conformance category (P1.5 harness)

### DIFF
--- a/conformance.lock
+++ b/conformance.lock
@@ -1,2 +1,2 @@
 [google-sheets]
-data_as_of = "2026-04-23"
+data_as_of = "2026-06-08"

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -398,6 +398,18 @@ conformance_tsv_test!(filter_conformance,      "filter.tsv");
 conformance_tsv_test!(web_conformance,         "web.tsv");
 conformance_tsv_test!(financial_conformance,   "financial.tsv");
 
+/// P1.5 workbook fixtures — cross-sheet refs, named ranges, date-typed scalars
+/// (pipeline-generated, core issue #527).
+///
+/// Report-only (non-blocking) until the engine gains workbook support:
+/// P1.2 reference grammar (#524) + P1.3 resolver resolve cross-sheet/named
+/// refs, and P1.4 (#526) defines `date`-typed row handling.  Once those land,
+/// switch this to `conformance_tsv_test!` so every row blocks CI.
+#[test]
+fn workbook_conformance_report() {
+    run_tsv_fixture_report(&fixture("workbook.tsv"));
+}
+
 /// Known-bug regression baseline.
 ///
 /// Rows here are GS-captured cases where our engine does not yet produce the


### PR DESCRIPTION
Refs #527. Re-opened replacement for #560 (auto-closed when its stacked base `feat/527-p15-fixtures` was deleted after #559 merged — same branch, now against `main`).

- `workbook_conformance_report` test: runs `workbook.tsv` through the existing non-blocking report harness
- `conformance.lock` bump for the new category file

Split from #559 per the fixture/code separation gate.