### PR TITLE
feat: P1.2 reference grammar (Sheet1!A1, quoted sheets, cross-sheet ranges, named refs)

### DIFF
--- a/crates/core/src/eval/functions/logical/info/mod.rs
+++ b/crates/core/src/eval/functions/logical/info/mod.rs
@@ -11,7 +11,7 @@ pub fn sheets_fn(args: &[Expr], _ctx: &mut EvalCtx<'_>) -> Value {
     match args.len() {
         0 => Value::Number(1.0),
         1 => {
-            if matches!(args[0], Expr::Variable(_, _)) {
+            if matches!(args[0], Expr::Variable(_, _) | Expr::Reference(_, _)) {
                 Value::Number(1.0)
             } else {
                 Value::Error(ErrorKind::NA)

--- a/crates/core/src/eval/functions/logical/is_checks/mod.rs
+++ b/crates/core/src/eval/functions/logical/is_checks/mod.rs
@@ -121,7 +121,7 @@ pub fn isref_fn(args: &[Expr], _ctx: &mut EvalCtx<'_>) -> Value {
     if check_arity_len(args.len(), 1, 1).is_some() {
         return Value::Error(ErrorKind::NA);
     }
-    Value::Bool(matches!(args[0], Expr::Variable(_, _)))
+    Value::Bool(matches!(args[0], Expr::Variable(_, _) | Expr::Reference(_, _)))
 }
 
 /// `ISFORMULA(value)` — TRUE if the argument is a cell ref containing a formula.
@@ -131,7 +131,7 @@ pub fn isformula_fn(args: &[Expr], _ctx: &mut EvalCtx<'_>) -> Value {
     if check_arity_len(args.len(), 1, 1).is_some() {
         return Value::Error(ErrorKind::NA);
     }
-    if !matches!(args[0], Expr::Variable(_, _)) {
+    if !matches!(args[0], Expr::Variable(_, _) | Expr::Reference(_, _)) {
         return Value::Error(ErrorKind::NA);
     }
     Value::Bool(false)

--- a/crates/core/src/eval/functions/lookup/row_col.rs
+++ b/crates/core/src/eval/functions/lookup/row_col.rs
@@ -1,6 +1,7 @@
 use crate::eval::evaluate_expr;
 use crate::eval::functions::{check_arity_len, EvalCtx};
 use crate::parser::ast::Expr;
+use crate::parser::refs::Ref;
 use crate::types::{ErrorKind, Value};
 use super::cell_ref::{parse_cell_ref, parse_range_ref};
 
@@ -14,6 +15,12 @@ pub fn row_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
         return Value::Number(1.0);
     }
     match &args[0] {
+        Expr::Reference(r, _) => match r {
+            Ref::Cell { addr, .. } => Value::Number(addr.row as f64),
+            Ref::Range { start, .. } => Value::Number(start.row as f64),
+            // The parser never produces `Ref::Name` inside `Expr::Reference`.
+            Ref::Name(_) => Value::Error(ErrorKind::NA),
+        },
         Expr::Variable(name, _) => {
             // Try range first (A1:D4 → top row of range)
             if let Some((_sc, sr, _ec, _er)) = parse_range_ref(name) {
@@ -51,6 +58,12 @@ pub fn column_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
         return Value::Number(1.0);
     }
     match &args[0] {
+        Expr::Reference(r, _) => match r {
+            Ref::Cell { addr, .. } => Value::Number(addr.col as f64),
+            Ref::Range { start, .. } => Value::Number(start.col as f64),
+            // The parser never produces `Ref::Name` inside `Expr::Reference`.
+            Ref::Name(_) => Value::Error(ErrorKind::NA),
+        },
         Expr::Variable(name, _) => {
             // Try range first (A1:D4 → left column of range)
             if let Some((sc, _sr, _ec, _er)) = parse_range_ref(name) {

--- a/crates/core/src/eval/mod.rs
+++ b/crates/core/src/eval/mod.rs
@@ -30,6 +30,9 @@ pub fn evaluate_expr(expr: &Expr, ctx: &mut EvalCtx<'_>) -> Value {
         Expr::Text(s, _)   => Value::Text(s.clone()),
         Expr::Bool(b, _)   => Value::Bool(*b),
         Expr::Variable(name, _) => ctx.ctx.get(name),
+        // Sheet-qualified references resolve through the same delegated
+        // context, keyed by the canonical reference text (e.g. "DATA!A1").
+        Expr::Reference(r, _) => ctx.ctx.get(&r.to_string()),
 
         // ── Unary ops ───────────────────────────────────────────────────────
         Expr::UnaryOp { op, operand, .. } => {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@ pub use engine::Engine;
 #[allow(deprecated)]
 pub use parser::{parse, validate};
 pub use parser::Expr;
+pub use parser::{CellAddr, Ref};
 pub use types::{ErrorKind, ParseError, Value};
 
 pub use eval::functions::{FunctionMeta, Registry};

--- a/crates/core/src/parser/ast.rs
+++ b/crates/core/src/parser/ast.rs
@@ -1,3 +1,5 @@
+use super::refs::Ref;
+
 /// Byte range of a node within the original formula string.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Span {
@@ -30,6 +32,10 @@ pub enum Expr {
     Text(String, Span),
     Bool(bool, Span),
     Variable(String, Span),
+    /// Sheet-qualified reference: `Sheet1!A1`, `'Q2 Data'!A1:B2`.
+    /// Bare cell/range references (`A1`, `A1:D4`) and bare names remain
+    /// [`Expr::Variable`]; sheet-qualified forms always carry `sheet: Some(_)`.
+    Reference(Ref, Span),
     UnaryOp {
         op: UnaryOp,
         operand: Box<Expr>,
@@ -59,7 +65,7 @@ pub enum Expr {
 impl Expr {
     pub fn span(&self) -> &Span {
         match self {
-            Expr::Number(_, s) | Expr::Text(_, s) | Expr::Bool(_, s) | Expr::Variable(_, s) => s,
+            Expr::Number(_, s) | Expr::Text(_, s) | Expr::Bool(_, s) | Expr::Variable(_, s) | Expr::Reference(_, s) => s,
             Expr::UnaryOp { span, .. }
             | Expr::BinaryOp { span, .. }
             | Expr::FunctionCall { span, .. }

--- a/crates/core/src/parser/mod.rs
+++ b/crates/core/src/parser/mod.rs
@@ -1,7 +1,9 @@
 pub mod ast;
+pub mod refs;
 pub mod tokens;
 
 pub use ast::Expr;
+pub use refs::{CellAddr, Ref};
 use ast::{BinaryOp, Span, UnaryOp};
 use crate::types::ParseError;
 use nom::{IResult, character::complete::multispace0};
@@ -68,8 +70,18 @@ impl<'a> Parser<'a> {
             return Ok((rest, Expr::Bool(b, self.span(i, rest))));
         }
 
-        // Identifier: variable or function call
+        // Quoted-sheet reference: 'Sheet Name'!A1 / 'Sheet Name'!A1:B2
+        if i.starts_with('\'') {
+            return self.parse_quoted_sheet_ref(i);
+        }
+
+        // Identifier: sheet-qualified reference, variable, or function call
         if let Ok((rest, name)) = identifier(i) {
+            // Sheet-qualified reference: Sheet1!A1 / Sheet1!A1:B2 — `!` binds
+            // tightly to the sheet name (no whitespace on either side).
+            if let Some(after_bang) = rest.strip_prefix('!') {
+                return self.parse_ref_body(i, name.to_string(), after_bang);
+            }
             let rest_ws = multispace0(rest)?.0;
             if let Some(args_input) = rest_ws.strip_prefix('(') {
                 // Function call
@@ -120,6 +132,73 @@ impl<'a> Parser<'a> {
         }
 
         Err(nom::Err::Error(nom::error::Error::new(i, nom::error::ErrorKind::Alt)))
+    }
+
+    // ── sheet-qualified references ──────────────────────────────────────
+
+    /// Parse the part after `!`: a cell address, optionally `:cell` for a
+    /// range. `start` is where the whole reference began (for spans); `sheet`
+    /// is the unescaped sheet name.
+    fn parse_ref_body(&self, start: &'a str, sheet: String, i: &'a str) -> IResult<&'a str, Expr> {
+        let err = || nom::Err::Error(nom::error::Error::new(i, nom::error::ErrorKind::Tag));
+        let (rest, cell_text) = identifier(i).map_err(|_| err())?;
+        let addr = CellAddr::parse(cell_text).ok_or_else(err)?;
+        // Optional range tail, mirroring the bare `A1:D4` grammar below.
+        let rest_ws = multispace0(rest)?.0;
+        if let Some(after_colon) = rest_ws.strip_prefix(':') {
+            if let Ok((rest2, end_text)) = identifier(after_colon) {
+                if let Some(end) = CellAddr::parse(end_text) {
+                    let r = Ref::Range { sheet: Some(sheet), start: addr, end };
+                    return Ok((rest2, Expr::Reference(r, self.span(start, rest2))));
+                }
+            }
+        }
+        let r = Ref::Cell { sheet: Some(sheet), addr };
+        Ok((rest, Expr::Reference(r, self.span(start, rest))))
+    }
+
+    /// Parse `'Sheet Name'!A1` / `'Sheet Name'!A1:B2`. `i` starts at the
+    /// opening quote. `''` inside the quotes is an escaped single quote.
+    fn parse_quoted_sheet_ref(&self, i: &'a str) -> IResult<&'a str, Expr> {
+        let inner = &i[1..];
+        let mut sheet = String::new();
+        let mut idx = 0;
+        loop {
+            match inner[idx..].find('\'') {
+                // Unterminated quoted sheet name
+                None => {
+                    return Err(nom::Err::Error(nom::error::Error::new(
+                        i,
+                        nom::error::ErrorKind::Char,
+                    )));
+                }
+                Some(q) => {
+                    sheet.push_str(&inner[idx..idx + q]);
+                    let after = idx + q + 1;
+                    if inner[after..].starts_with('\'') {
+                        sheet.push('\'');
+                        idx = after + 1;
+                    } else {
+                        idx = after;
+                        break;
+                    }
+                }
+            }
+        }
+        let rest = &inner[idx..];
+        if sheet.is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                i,
+                nom::error::ErrorKind::Char,
+            )));
+        }
+        match rest.strip_prefix('!') {
+            Some(after_bang) => self.parse_ref_body(i, sheet, after_bang),
+            None => Err(nom::Err::Error(nom::error::Error::new(
+                rest,
+                nom::error::ErrorKind::Char,
+            ))),
+        }
     }
 
     fn parse_arg_list(&self, i: &'a str) -> IResult<&'a str, Vec<Expr>> {

--- a/crates/core/src/parser/refs.rs
+++ b/crates/core/src/parser/refs.rs
@@ -1,0 +1,162 @@
+//! Reference model for the workbook grammar (P1.2).
+//!
+//! A [`Ref`] is the parser-level description of *what a formula points at*:
+//! a single cell, a rectangular range, or a named reference. Resolution is
+//! delegated to the caller (core = language); the engine itself never knows
+//! what a sheet or a named range contains.
+
+use std::fmt;
+
+/// A1-style cell address with 1-based column and row.
+///
+/// `A1` → `CellAddr { col: 1, row: 1 }`, `BC42` → `CellAddr { col: 55, row: 42 }`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CellAddr {
+    /// 1-based column index (`A` = 1, `Z` = 26, `AA` = 27).
+    pub col: u32,
+    /// 1-based row index.
+    pub row: u32,
+}
+
+impl CellAddr {
+    /// Parse an A1-style address (case-insensitive): letters followed by digits.
+    ///
+    /// Returns `None` for anything else (empty column/row part, row `0`,
+    /// trailing characters, or out-of-range values).
+    pub fn parse(text: &str) -> Option<Self> {
+        let bytes = text.as_bytes();
+        let col_end = bytes.iter().take_while(|b| b.is_ascii_alphabetic()).count();
+        if col_end == 0 || col_end == bytes.len() {
+            return None;
+        }
+        let row_str = &text[col_end..];
+        if !row_str.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        let row: u32 = row_str.parse().ok()?;
+        if row == 0 {
+            return None;
+        }
+        let mut col: u32 = 0;
+        for b in &bytes[..col_end] {
+            let v = (b.to_ascii_uppercase() - b'A' + 1) as u32;
+            col = col.checked_mul(26)?.checked_add(v)?;
+        }
+        Some(Self { col, row })
+    }
+}
+
+impl fmt::Display for CellAddr {
+    /// Canonical A1 form: uppercase column letters followed by the row number.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut col = self.col;
+        let mut letters = [0u8; 8];
+        let mut n = 0;
+        while col > 0 {
+            let rem = ((col - 1) % 26) as u8;
+            letters[n] = b'A' + rem;
+            n += 1;
+            col = (col - 1) / 26;
+        }
+        for b in letters[..n].iter().rev() {
+            write!(f, "{}", *b as char)?;
+        }
+        write!(f, "{}", self.row)
+    }
+}
+
+/// A parsed reference. Resolution (what the reference evaluates to) is
+/// delegated to the embedding application; see the workbook v1 scope ADR.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Ref {
+    /// A single cell, optionally sheet-qualified: `A1`, `Sheet1!A1`, `'Q2 Data'!A1`.
+    Cell {
+        /// Sheet name without quoting/escaping; `None` for a bare `A1` reference.
+        sheet: Option<String>,
+        addr: CellAddr,
+    },
+    /// A rectangular range, optionally sheet-qualified: `A1:D4`, `Sheet1!A1:B2`.
+    Range {
+        /// Sheet name without quoting/escaping; `None` for a bare range.
+        sheet: Option<String>,
+        start: CellAddr,
+        end: CellAddr,
+    },
+    /// A named reference (named range, defined name): `TAX_RATE`.
+    Name(String),
+}
+
+impl Ref {
+    /// Classify a bare identifier or range string into a [`Ref`].
+    ///
+    /// `"A1"` → [`Ref::Cell`] (no sheet), `"A1:D4"` → [`Ref::Range`] (no sheet),
+    /// anything else → [`Ref::Name`]. This is the mapping used for bare
+    /// identifiers in formulas, which stay [`crate::Expr::Variable`] nodes in
+    /// the AST for compatibility.
+    pub fn classify(text: &str) -> Ref {
+        if let Some(addr) = CellAddr::parse(text) {
+            return Ref::Cell { sheet: None, addr };
+        }
+        if let Some((s, e)) = text.split_once(':') {
+            if let (Some(start), Some(end)) = (CellAddr::parse(s), CellAddr::parse(e)) {
+                return Ref::Range { sheet: None, start, end };
+            }
+        }
+        Ref::Name(text.to_string())
+    }
+}
+
+/// True if `name` looks like an in-grid A1 cell address (1-3 column
+/// letters followed by digits), so it must be quoted before `!` to
+/// disambiguate: a sheet named `A1` is written `'A1'!B2`, while `Sheet1`
+/// (five column letters - beyond any real grid) stays unquoted.
+fn looks_like_cell_addr(name: &str) -> bool {
+    let letters = name.bytes().take_while(|b| b.is_ascii_alphabetic()).count();
+    (1..=3).contains(&letters) && CellAddr::parse(name).is_some()
+}
+
+/// True if `name` cannot appear unquoted before `!` in canonical form.
+/// Unquoted sheet names must match `^[A-Za-z_][A-Za-z0-9_]*$` and must not
+/// look like an A1 cell address (see [`looks_like_cell_addr`]).
+fn sheet_needs_quoting(name: &str) -> bool {
+    let mut chars = name.chars();
+    let bare = match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {
+            chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+        }
+        _ => false,
+    };
+    !bare || looks_like_cell_addr(name)
+}
+
+fn write_sheet(f: &mut fmt::Formatter<'_>, sheet: &Option<String>) -> fmt::Result {
+    match sheet {
+        None => Ok(()),
+        Some(name) => {
+            if sheet_needs_quoting(name) {
+                write!(f, "'{}'!", name.replace('\'', "''"))
+            } else {
+                write!(f, "{}!", name)
+            }
+        }
+    }
+}
+
+impl fmt::Display for Ref {
+    /// Canonical text form per the workbook JSON schema v1 spec: sheet name
+    /// single-quoted iff it is not a bare identifier or would parse as an A1
+    /// address; embedded single quotes doubled (`''`).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Ref::Cell { sheet, addr } => {
+                write_sheet(f, sheet)?;
+                write!(f, "{}", addr)
+            }
+            Ref::Range { sheet, start, end } => {
+                write_sheet(f, sheet)?;
+                write!(f, "{}:{}", start, end)
+            }
+            Ref::Name(name) => write!(f, "{}", name),
+        }
+    }
+}

--- a/crates/core/src/parser/refs.rs
+++ b/crates/core/src/parser/refs.rs
@@ -116,8 +116,10 @@ fn looks_like_cell_addr(name: &str) -> bool {
 }
 
 /// True if `name` cannot appear unquoted before `!` in canonical form.
-/// Unquoted sheet names must match `^[A-Za-z_][A-Za-z0-9_]*$` and must not
-/// look like an A1 cell address (see [`looks_like_cell_addr`]).
+/// Unquoted sheet names must match `^[A-Za-z_][A-Za-z0-9_]*$`, must not
+/// look like an A1 cell address (see [`looks_like_cell_addr`]), and must
+/// not be the boolean literals `TRUE`/`FALSE` (which the parser recognizes
+/// before identifiers, so an unquoted `TRUE!A1` would not re-parse).
 fn sheet_needs_quoting(name: &str) -> bool {
     let mut chars = name.chars();
     let bare = match chars.next() {
@@ -126,7 +128,10 @@ fn sheet_needs_quoting(name: &str) -> bool {
         }
         _ => false,
     };
-    !bare || looks_like_cell_addr(name)
+    !bare
+        || looks_like_cell_addr(name)
+        || name.eq_ignore_ascii_case("TRUE")
+        || name.eq_ignore_ascii_case("FALSE")
 }
 
 fn write_sheet(f: &mut fmt::Formatter<'_>, sheet: &Option<String>) -> fmt::Result {

--- a/crates/core/tests/parser_refs.rs
+++ b/crates/core/tests/parser_refs.rs
@@ -374,6 +374,16 @@ fn display_quotes_a1_like_sheet_name() {
 }
 
 #[test]
+fn display_quotes_boolean_sheet_names() {
+    // TRUE/FALSE parse as boolean literals before identifiers, so a sheet
+    // with one of those names must be quoted in canonical form to re-parse.
+    let r = Ref::Cell { sheet: Some("TRUE".into()), addr: addr(1, 1) };
+    assert_eq!(r.to_string(), "'TRUE'!A1");
+    let r = Ref::Cell { sheet: Some("false".into()), addr: addr(1, 1) };
+    assert_eq!(r.to_string(), "'false'!A1");
+}
+
+#[test]
 fn display_quotes_leading_digit_sheet_name() {
     let r = Ref::Range {
         sheet: Some("2024".into()),
@@ -396,7 +406,7 @@ fn display_name() {
 
 #[test]
 fn display_round_trips_through_parser() {
-    for formula in ["='It''s'!A1:B2", "=Sheet1!A1", "='Q2 Données'!AA10"] {
+    for formula in ["='It''s'!A1:B2", "=Sheet1!A1", "='Q2 Données'!AA10", "='TRUE'!A1", "='FALSE'!B2:C3"] {
         let r1 = match parse(formula) {
             Expr::Reference(r, _) => r,
             other => panic!("expected Reference, got {other:?}"),

--- a/crates/core/tests/parser_refs.rs
+++ b/crates/core/tests/parser_refs.rs
@@ -1,0 +1,411 @@
+//! P1.2 reference grammar — parse-level tests (issue #524).
+//!
+//! Covers sheet-qualified cell refs (`Sheet1!A1`), quoted sheet names
+//! (`'Quoted Name'!A1:B2`), cross-sheet ranges, the `Ref` model, canonical
+//! display, and the zero-behavior-change guarantee for bare `A1` / `A1:D4` /
+//! named identifiers (which stay `Expr::Variable`).
+//!
+//! Evaluation semantics for these references (e.g. `#REF!` for a missing
+//! sheet) are pipeline-verified via the P1.5 workbook fixtures and land with
+//! the P1.3 resolver; nothing here self-confirms evaluation values.
+
+use truecalc_core::{CellAddr, Engine, Expr, Ref};
+
+fn parse(formula: &str) -> Expr {
+    Engine::sheets()
+        .parse(formula)
+        .unwrap_or_else(|e| panic!("expected {formula:?} to parse: {e}"))
+}
+
+fn parse_err(formula: &str) {
+    assert!(
+        Engine::sheets().parse(formula).is_err(),
+        "expected {formula:?} to fail to parse"
+    );
+}
+
+fn addr(col: u32, row: u32) -> CellAddr {
+    CellAddr { col, row }
+}
+
+// ── sheet-qualified cells ───────────────────────────────────────────────────
+
+#[test]
+fn sheet_qualified_cell() {
+    match parse("=Sheet1!A1") {
+        Expr::Reference(Ref::Cell { sheet, addr: a }, _) => {
+            assert_eq!(sheet.as_deref(), Some("Sheet1"));
+            assert_eq!(a, addr(1, 1));
+        }
+        other => panic!("expected Reference(Cell), got {other:?}"),
+    }
+}
+
+#[test]
+fn sheet_qualified_range() {
+    match parse("=Sheet1!A1:B2") {
+        Expr::Reference(Ref::Range { sheet, start, end }, _) => {
+            assert_eq!(sheet.as_deref(), Some("Sheet1"));
+            assert_eq!(start, addr(1, 1));
+            assert_eq!(end, addr(2, 2));
+        }
+        other => panic!("expected Reference(Range), got {other:?}"),
+    }
+}
+
+#[test]
+fn lowercase_sheet_and_cell() {
+    match parse("=data!a1") {
+        Expr::Reference(Ref::Cell { sheet, addr: a }, _) => {
+            // Sheet case is preserved as written; resolution is delegated.
+            assert_eq!(sheet.as_deref(), Some("data"));
+            assert_eq!(a, addr(1, 1));
+        }
+        other => panic!("expected Reference(Cell), got {other:?}"),
+    }
+}
+
+#[test]
+fn multi_letter_columns() {
+    match parse("=Sheet1!AA10:BC42") {
+        Expr::Reference(Ref::Range { start, end, .. }, _) => {
+            assert_eq!(start, addr(27, 10));
+            assert_eq!(end, addr(55, 42));
+        }
+        other => panic!("expected Reference(Range), got {other:?}"),
+    }
+}
+
+#[test]
+fn sheet_with_underscore_and_digits() {
+    match parse("=My_Sheet1!C3") {
+        Expr::Reference(Ref::Cell { sheet, addr: a }, _) => {
+            assert_eq!(sheet.as_deref(), Some("My_Sheet1"));
+            assert_eq!(a, addr(3, 3));
+        }
+        other => panic!("expected Reference(Cell), got {other:?}"),
+    }
+}
+
+#[test]
+fn sheet_name_that_looks_like_a_cell() {
+    // A sheet named "A1" is unambiguous before `!`.
+    match parse("=A1!B2") {
+        Expr::Reference(Ref::Cell { sheet, addr: a }, _) => {
+            assert_eq!(sheet.as_deref(), Some("A1"));
+            assert_eq!(a, addr(2, 2));
+        }
+        other => panic!("expected Reference(Cell), got {other:?}"),
+    }
+}
+
+#[test]
+fn missing_sheet_still_parses() {
+    // Whether the sheet exists is an evaluation concern (#REF! via the
+    // resolver, P1.3), not a parse error.
+    assert!(matches!(
+        parse("=MissingSheet!A1"),
+        Expr::Reference(Ref::Cell { .. }, _)
+    ));
+}
+
+// ── quoted sheet names ──────────────────────────────────────────────────────
+
+#[test]
+fn quoted_sheet_cell() {
+    match parse("='Quoted Name'!A1") {
+        Expr::Reference(Ref::Cell { sheet, addr: a }, _) => {
+            assert_eq!(sheet.as_deref(), Some("Quoted Name"));
+            assert_eq!(a, addr(1, 1));
+        }
+        other => panic!("expected Reference(Cell), got {other:?}"),
+    }
+}
+
+#[test]
+fn quoted_sheet_range() {
+    match parse("='Quoted Name'!A1:B2") {
+        Expr::Reference(Ref::Range { sheet, start, end }, _) => {
+            assert_eq!(sheet.as_deref(), Some("Quoted Name"));
+            assert_eq!(start, addr(1, 1));
+            assert_eq!(end, addr(2, 2));
+        }
+        other => panic!("expected Reference(Range), got {other:?}"),
+    }
+}
+
+#[test]
+fn quoted_single_word_sheet() {
+    // Quoting is optional for bare-identifier names but still valid.
+    match parse("='Data'!A1") {
+        Expr::Reference(Ref::Cell { sheet, .. }, _) => {
+            assert_eq!(sheet.as_deref(), Some("Data"));
+        }
+        other => panic!("expected Reference(Cell), got {other:?}"),
+    }
+}
+
+#[test]
+fn escaped_quote_in_sheet_name() {
+    match parse("='It''s'!A1") {
+        Expr::Reference(Ref::Cell { sheet, .. }, _) => {
+            assert_eq!(sheet.as_deref(), Some("It's"));
+        }
+        other => panic!("expected Reference(Cell), got {other:?}"),
+    }
+}
+
+#[test]
+fn unicode_quoted_sheet() {
+    match parse("='Q2 Données'!A1") {
+        Expr::Reference(Ref::Cell { sheet, .. }, _) => {
+            assert_eq!(sheet.as_deref(), Some("Q2 Données"));
+        }
+        other => panic!("expected Reference(Cell), got {other:?}"),
+    }
+}
+
+// ── references inside expressions ───────────────────────────────────────────
+
+#[test]
+fn refs_in_arithmetic() {
+    match parse("=Data!A1+Data!B1") {
+        Expr::BinaryOp { left, right, .. } => {
+            assert!(matches!(*left, Expr::Reference(Ref::Cell { .. }, _)));
+            assert!(matches!(*right, Expr::Reference(Ref::Cell { .. }, _)));
+        }
+        other => panic!("expected BinaryOp, got {other:?}"),
+    }
+}
+
+#[test]
+fn range_ref_as_function_arg() {
+    match parse("=SUM(Data!A1:A3)") {
+        Expr::FunctionCall { name, args, .. } => {
+            assert_eq!(name, "SUM");
+            assert_eq!(args.len(), 1);
+            assert!(matches!(args[0], Expr::Reference(Ref::Range { .. }, _)));
+        }
+        other => panic!("expected FunctionCall, got {other:?}"),
+    }
+}
+
+#[test]
+fn ref_in_if_condition() {
+    assert!(Engine::sheets().parse("=IF(Data!A1>5,\"big\",\"small\")").is_ok());
+}
+
+#[test]
+fn quoted_refs_in_arithmetic() {
+    assert!(Engine::sheets()
+        .parse("='Quoted Name'!A1+'Quoted Name'!B1")
+        .is_ok());
+}
+
+#[test]
+fn excel_engine_accepts_same_grammar() {
+    assert!(Engine::excel().parse("='Quoted Name'!A1:B2").is_ok());
+}
+
+// ── spans ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn span_covers_whole_sheet_qualified_range() {
+    let expr = parse("=Sheet1!A1:B2");
+    let span = expr.span();
+    assert_eq!(span.offset, 1);
+    assert_eq!(span.length, "Sheet1!A1:B2".len());
+}
+
+#[test]
+fn span_covers_whole_quoted_reference() {
+    let expr = parse("='My Sheet'!A1");
+    let span = expr.span();
+    assert_eq!(span.offset, 1);
+    assert_eq!(span.length, "'My Sheet'!A1".len());
+}
+
+// ── zero behavior change for bare identifiers ──────────────────────────────
+
+#[test]
+fn bare_cell_stays_variable() {
+    assert!(matches!(parse("=A1"), Expr::Variable(ref n, _) if n == "A1"));
+}
+
+#[test]
+fn bare_range_stays_variable() {
+    assert!(matches!(parse("=A1:D4"), Expr::Variable(ref n, _) if n == "A1:D4"));
+}
+
+#[test]
+fn bare_name_stays_variable() {
+    assert!(matches!(parse("=TAX_RATE"), Expr::Variable(ref n, _) if n == "TAX_RATE"));
+}
+
+#[test]
+fn dotted_function_names_still_parse() {
+    assert!(matches!(
+        parse("=ERROR.TYPE(1)"),
+        Expr::FunctionCall { ref name, .. } if name == "ERROR.TYPE"
+    ));
+}
+
+// ── parse errors ────────────────────────────────────────────────────────────
+
+#[test]
+fn error_missing_cell_after_bang() {
+    parse_err("=Sheet1!");
+}
+
+#[test]
+fn error_number_after_bang() {
+    parse_err("=Sheet1!123");
+}
+
+#[test]
+fn error_name_after_bang() {
+    // Sheet-scoped named references are not part of the v1 grammar.
+    parse_err("=Sheet1!foo");
+}
+
+#[test]
+fn error_row_zero_after_bang() {
+    parse_err("=Sheet1!A0");
+}
+
+#[test]
+fn error_empty_quoted_sheet() {
+    parse_err("=''!A1");
+}
+
+#[test]
+fn error_unterminated_quoted_sheet() {
+    parse_err("='Oops");
+}
+
+#[test]
+fn error_quoted_sheet_without_bang() {
+    parse_err("='Data'");
+}
+
+#[test]
+fn error_bad_range_second_endpoint() {
+    parse_err("=Data!A1:xyz");
+}
+
+#[test]
+fn error_whitespace_around_bang() {
+    parse_err("=Sheet1 !A1");
+    parse_err("=Sheet1! A1");
+}
+
+// ── CellAddr ───────────────────────────────────────────────────────────────
+
+#[test]
+fn celladdr_parse_and_display() {
+    for (text, col, row, canonical) in [
+        ("A1", 1, 1, "A1"),
+        ("z26", 26, 26, "Z26"),
+        ("AA1", 27, 1, "AA1"),
+        ("BC42", 55, 42, "BC42"),
+        ("zz1", 702, 1, "ZZ1"),
+    ] {
+        let a = CellAddr::parse(text).unwrap_or_else(|| panic!("{text} should parse"));
+        assert_eq!(a, addr(col, row), "{text}");
+        assert_eq!(a.to_string(), canonical, "{text}");
+    }
+}
+
+#[test]
+fn celladdr_rejects_non_addresses() {
+    for text in ["", "A", "1", "A0", "1A", "A1B", "A 1", "A1.5"] {
+        assert!(CellAddr::parse(text).is_none(), "{text:?} should not parse");
+    }
+}
+
+// ── Ref::classify (bare identifiers → named refs) ───────────────────────────
+
+#[test]
+fn classify_bare_cell() {
+    assert_eq!(
+        Ref::classify("A1"),
+        Ref::Cell { sheet: None, addr: addr(1, 1) }
+    );
+}
+
+#[test]
+fn classify_bare_range() {
+    assert_eq!(
+        Ref::classify("A1:D4"),
+        Ref::Range { sheet: None, start: addr(1, 1), end: addr(4, 4) }
+    );
+}
+
+#[test]
+fn classify_bare_identifier_is_name() {
+    assert_eq!(Ref::classify("TAX_RATE"), Ref::Name("TAX_RATE".into()));
+    assert_eq!(Ref::classify("A1:xyz"), Ref::Name("A1:xyz".into()));
+}
+
+// ── canonical display ───────────────────────────────────────────────────────
+
+#[test]
+fn display_unquoted_when_bare_identifier() {
+    let r = Ref::Cell { sheet: Some("Sheet1".into()), addr: addr(1, 1) };
+    assert_eq!(r.to_string(), "Sheet1!A1");
+}
+
+#[test]
+fn display_quotes_when_name_needs_it() {
+    let r = Ref::Cell { sheet: Some("Quoted Name".into()), addr: addr(1, 1) };
+    assert_eq!(r.to_string(), "'Quoted Name'!A1");
+}
+
+#[test]
+fn display_doubles_embedded_quotes() {
+    let r = Ref::Cell { sheet: Some("It's".into()), addr: addr(1, 1) };
+    assert_eq!(r.to_string(), "'It''s'!A1");
+}
+
+#[test]
+fn display_quotes_a1_like_sheet_name() {
+    let r = Ref::Cell { sheet: Some("A1".into()), addr: addr(2, 2) };
+    assert_eq!(r.to_string(), "'A1'!B2");
+}
+
+#[test]
+fn display_quotes_leading_digit_sheet_name() {
+    let r = Ref::Range {
+        sheet: Some("2024".into()),
+        start: addr(1, 1),
+        end: addr(2, 2),
+    };
+    assert_eq!(r.to_string(), "'2024'!A1:B2");
+}
+
+#[test]
+fn display_range_without_sheet() {
+    let r = Ref::Range { sheet: None, start: addr(1, 1), end: addr(4, 4) };
+    assert_eq!(r.to_string(), "A1:D4");
+}
+
+#[test]
+fn display_name() {
+    assert_eq!(Ref::Name("TAX_RATE".into()).to_string(), "TAX_RATE");
+}
+
+#[test]
+fn display_round_trips_through_parser() {
+    for formula in ["='It''s'!A1:B2", "=Sheet1!A1", "='Q2 Données'!AA10"] {
+        let r1 = match parse(formula) {
+            Expr::Reference(r, _) => r,
+            other => panic!("expected Reference, got {other:?}"),
+        };
+        let printed = format!("={r1}");
+        let r2 = match parse(&printed) {
+            Expr::Reference(r, _) => r,
+            other => panic!("expected Reference on round-trip, got {other:?}"),
+        };
+        assert_eq!(r1, r2, "round-trip of {formula}");
+    }
+}

--- a/crates/core/tests/refs_eval.rs
+++ b/crates/core/tests/refs_eval.rs
@@ -1,0 +1,140 @@
+//! P1.2 reference grammar — evaluation plumbing tests (issue #524).
+//!
+//! Resolution stays delegated (core = language): a sheet-qualified reference
+//! evaluates by looking up its canonical text (e.g. `Data!A1`,
+//! `'Quoted Name'!A1:B2`) in the caller-supplied variables, exactly as bare
+//! `A1` / `A1:D4` variables always have. Real workbook semantics (e.g.
+//! `#REF!` for a missing sheet) arrive with the P1.3 resolver and are
+//! pipeline-verified by the P1.5 workbook fixtures; nothing here
+//! self-confirms Google Sheets values.
+
+use std::collections::HashMap;
+use truecalc_core::{Engine, Value};
+
+fn eval(formula: &str, vars: &[(&str, Value)]) -> Value {
+    let map: HashMap<String, Value> = vars
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect();
+    Engine::sheets().evaluate(formula, &map)
+}
+
+#[test]
+fn sheet_qualified_cell_resolves_from_variables() {
+    let v = eval("=Data!A1", &[("Data!A1", Value::Number(10.0))]);
+    assert_eq!(v, Value::Number(10.0));
+}
+
+#[test]
+fn sheet_qualified_refs_in_arithmetic() {
+    let v = eval(
+        "=Data!A1+Data!B1",
+        &[
+            ("Data!A1", Value::Number(10.0)),
+            ("Data!B1", Value::Number(5.0)),
+        ],
+    );
+    assert_eq!(v, Value::Number(15.0));
+}
+
+#[test]
+fn lookup_is_case_insensitive_like_variables() {
+    let v = eval("=data!a1", &[("DATA!A1", Value::Number(10.0))]);
+    assert_eq!(v, Value::Number(10.0));
+}
+
+#[test]
+fn quoted_sheet_resolves_by_canonical_text() {
+    let v = eval(
+        "='Quoted Name'!A1",
+        &[("'Quoted Name'!A1", Value::Number(100.0))],
+    );
+    assert_eq!(v, Value::Number(100.0));
+}
+
+#[test]
+fn optional_quotes_normalize_to_unquoted_canonical_form() {
+    // 'Data' is a bare identifier, so its canonical form is unquoted: Data!A1.
+    let v = eval("='Data'!A1", &[("Data!A1", Value::Number(10.0))]);
+    assert_eq!(v, Value::Number(10.0));
+}
+
+#[test]
+fn sheet_qualified_range_resolves_to_bound_array() {
+    let arr = Value::Array(vec![
+        Value::Number(10.0),
+        Value::Number(20.0),
+        Value::Number(30.0),
+    ]);
+    let v = eval("=SUM(Data!A1:A3)", &[("Data!A1:A3", arr)]);
+    assert_eq!(v, Value::Number(60.0));
+}
+
+#[test]
+fn ref_in_if_condition() {
+    let v = eval(
+        "=IF(Data!A1>5,\"big\",\"small\")",
+        &[("Data!A1", Value::Number(10.0))],
+    );
+    assert_eq!(v, Value::Text("big".into()));
+}
+
+#[test]
+fn unbound_sheet_ref_is_empty_without_resolver() {
+    // Same delegation contract as bare variables today: unbound → Empty.
+    // Workbook semantics (#REF! for a missing sheet) land with the P1.3
+    // resolver, pipeline-verified by the P1.5 workbook fixtures.
+    let v = eval("=MissingSheet!A1", &[]);
+    assert_eq!(v, Value::Empty);
+}
+
+#[test]
+fn bare_variable_lookup_unchanged() {
+    let v = eval("=A1", &[("A1", Value::Number(5.0))]);
+    assert_eq!(v, Value::Number(5.0));
+}
+
+// ── structural functions on sheet-qualified refs ────────────────────────────
+
+#[test]
+fn isref_is_true_for_sheet_qualified_refs() {
+    assert_eq!(eval("=ISREF(Data!A1)", &[]), Value::Bool(true));
+    assert_eq!(eval("=ISREF('Quoted Name'!A1:B2)", &[]), Value::Bool(true));
+}
+
+#[test]
+fn row_and_column_read_the_address() {
+    assert_eq!(eval("=ROW(Sheet1!B7)", &[]), Value::Number(7.0));
+    assert_eq!(eval("=COLUMN(Sheet1!B7)", &[]), Value::Number(2.0));
+    assert_eq!(eval("=ROW(Data!A2:C5)", &[]), Value::Number(2.0));
+    assert_eq!(eval("=COLUMN(Data!B2:C5)", &[]), Value::Number(2.0));
+}
+
+#[test]
+fn rows_and_columns_match_bare_range_behavior() {
+    // ROWS/COLUMNS are eager (content-based) functions today; a
+    // sheet-qualified range behaves exactly like the equivalent bare range
+    // (zero behavior change). Extent-from-address semantics arrive with the
+    // P1.3 resolver and are pipeline-verified by the P1.5 fixtures.
+    let arr = || {
+        Value::Array(vec![
+            Value::Number(1.0),
+            Value::Number(2.0),
+            Value::Number(3.0),
+        ])
+    };
+    assert_eq!(
+        eval("=ROWS(Data!A1:A3)", &[("Data!A1:A3", arr())]),
+        eval("=ROWS(A1:A3)", &[("A1:A3", arr())]),
+    );
+    assert_eq!(
+        eval("=COLUMNS(Data!A1:A3)", &[("Data!A1:A3", arr())]),
+        eval("=COLUMNS(A1:A3)", &[("A1:A3", arr())]),
+    );
+    // Unbound refs also match bare-range behavior.
+    assert_eq!(eval("=ROWS(Data!A2:C5)", &[]), eval("=ROWS(A2:C5)", &[]));
+    assert_eq!(
+        eval("=COLUMNS(Data!A2:C5)", &[]),
+        eval("=COLUMNS(A2:C5)", &[]),
+    );
+}


### PR DESCRIPTION
## Summary

Implements **P1.2 — Reference grammar** from the workbook development plan: the parser now accepts sheet-qualified references while keeping reference *resolution* fully delegated (core = language).

### Grammar accepted

| Form | Example | AST |
|---|---|---|
| Sheet-qualified cell | `=Sheet1!A1` | `Expr::Reference(Ref::Cell { sheet: Some("Sheet1"), addr })` |
| Sheet-qualified range | `=Sheet1!A1:B2`, `=SUM(Data!A1:A3)` | `Expr::Reference(Ref::Range { sheet, start, end })` |
| Quoted sheet names | `='Quoted Name'!A1:B2`, `='It''s'!A1` (`''` escape) | same, sheet stored unescaped |
| Bare cell / range / name | `=A1`, `=A1:D4`, `=TAX_RATE` | **unchanged** — stays `Expr::Variable` |

`Ref::classify(text)` maps bare identifier text to `Ref::{Cell, Range, Name}` so callers (the P1.3 resolver, workbook dep graph) get the `Ref` model for named references without an AST change for existing formulas.

### Design

- **New module `crates/core/src/parser/refs.rs`**: `CellAddr` (A1 ↔ 1-based col/row with `Display` canonicalization), `Ref` enum per the plan (`Cell{sheet,addr}`, `Range{sheet,start,end}`, `Name(name)`), and canonical `Display` (quote a sheet name iff it is not a bare identifier or looks like an in-grid A1 address — `Sheet1!A1` stays unquoted, a sheet literally named `A1` prints as `'A1'!B2`; embedded quotes doubled).
- **Grammar rules**: `!` binds tightly to the sheet name (no whitespace on either side); `''` escapes a quote inside quoted names; `Sheet1!123`, `Sheet1!A0`, `''!A1`, sheet-scoped names (`Sheet1!foo`) and unterminated quotes are parse errors.
- **Resolution stays delegated** (per the v1 scope ADR): `Expr::Reference` evaluates through the same caller-supplied variables map as bare variables, keyed by the canonical reference text (e.g. `Data!A1`). The `Resolver` trait and `extract_refs` arrive with P1.3 (#525). Engine flavor remains explicit — the grammar is reachable only via `Engine::sheets()` / `Engine::excel()`.
- **Structural functions**: `ISREF`/`ISFORMULA`/`SHEETS` treat `Reference` like `Variable`; lazy `ROW`/`COLUMN` read the address straight from `Reference` nodes. Eager `ROWS`/`COLUMNS` are content-based today for bare ranges and behave identically for sheet-qualified ranges (extent-from-address semantics land with the P1.3 resolver).

### Acceptance criteria (issue #524)

- **Parse fixtures green** — 45 parse-level tests in `crates/core/tests/parser_refs.rs` cover every grammar form in the merged `workbook.tsv` (cross-sheet cells/ranges, quoted names, refs in arithmetic/IF/SUM, spans, parse errors, round-trip through canonical display). Evaluation-semantics cases (e.g. `#REF!` for a missing sheet) are pipeline-verified by the P1.5 `workbook.tsv` fixtures and are exercised once the P1.3 resolver lands — nothing here self-confirms Sheets values, and **no fixture TSVs are touched**.
- **Zero behavior change for existing `A1`/`A1:D4` fixtures** — bare cells, ranges and names still parse to `Expr::Variable`; all 15 category conformance TSVs plus the full suite (2,800+ tests) pass unchanged; `tests/refs_eval.rs` pins delegation behavior (bound/unbound lookups, case-insensitivity, quoted-name canonicalization) and asserts sheet-qualified ROWS/COLUMNS match bare-range behavior exactly.

### Verification

- `cargo test -p truecalc-core` — all green locally (incl. all conformance TSVs)
- `cargo clippy -p truecalc-core -p truecalc-wasm -- -D warnings` — clean
- No `#[cfg(test)]` blocks added to production files; tests live in `tests/parser_refs.rs` and `tests/refs_eval.rs`

### Out of scope (P1.3, #525)

Resolver trait, `evaluate_with_resolver`, `extract_refs`, `#REF!` semantics for missing sheets, and wiring `workbook.tsv` into the blocking conformance harness.

Closes #524