### PR TITLE
feat: P1.4 value-level completeness — unspilled arrays, date serial semantics per flavor

### DIFF
--- a/conformance.lock
+++ b/conformance.lock
@@ -1,2 +1,2 @@
 [google-sheets]
-data_as_of = "2026-04-23"
+data_as_of = "2026-06-08"

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -6,6 +6,16 @@ use crate::parser::{parse_formula, Expr};
 use crate::types::{ErrorKind, ParseError, Value};
 
 /// Which spreadsheet product's semantics the engine targets.
+///
+/// The engine flavor also locks the **date serial system** (P1.4, issue #526):
+///
+/// - `Sheets`: day 0 = 1899-12-30; no leap-year bug (1900-02-28 = serial 60,
+///   1900-03-01 = serial 61, no serial for the nonexistent 1900-02-29).
+/// - `Excel`: 1900 date system — serial 1 = 1900-01-01, **including** the
+///   historical Lotus 1-2-3 leap-year bug (serial 60 = the fictitious
+///   1900-02-29). Conversion helpers live in
+///   `eval::functions::date::serial`; Excel evaluation itself is still
+///   stubbed (`evaluate` returns `#N/A`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Flavor {
     Sheets,
@@ -53,7 +63,51 @@ impl Engine {
         self.parse(formula).map(|_| ())
     }
 
+    /// Evaluate a formula string with named variables.
+    ///
+    /// Array results flow through **unspilled**: a formula producing an array
+    /// returns the full [`Value::Array`] — spilling it across cells (or
+    /// collapsing it for a single-cell view) is the workbook/surface layer's
+    /// job, not the evaluator's (P1.4, issue #526).
+    ///
+    /// Volatile date functions (`NOW`, `TODAY`) read the ambient local clock.
+    /// Use [`Engine::evaluate_at`] to pin them for deterministic evaluation.
     pub fn evaluate(&self, formula: &str, variables: &HashMap<String, Value>) -> Value {
+        self.evaluate_inner(formula, variables, None)
+    }
+
+    /// Evaluate a formula with the volatile date functions (`NOW`, `TODAY`)
+    /// pinned to `now_serial`, a local-time spreadsheet serial datetime
+    /// (integer part = day serial in this engine's date system, fractional
+    /// part = time of day).
+    ///
+    /// Same formula + same variables + same `now_serial` ⇒ identical result.
+    /// This is the core-level hook the workbook layer's `RecalcContext`
+    /// (timestamp + IANA timezone, scope ADR 2026-06-07 Decision 3) builds on:
+    /// the caller converts its UTC instant + timezone to a local serial and
+    /// passes it here. Conformance fixture rows for volatile formulas are
+    /// verified by pinning `now_serial` to the fixture's recorded
+    /// `meta.evaluatedAt`.
+    ///
+    /// Returns `Value::Error(ErrorKind::Num)` if `now_serial` is not finite.
+    pub fn evaluate_at(
+        &self,
+        formula: &str,
+        variables: &HashMap<String, Value>,
+        now_serial: f64,
+    ) -> Value {
+        if !now_serial.is_finite() {
+            return Value::Error(ErrorKind::Num);
+        }
+        self.evaluate_inner(formula, variables, Some(now_serial))
+    }
+
+    fn evaluate_inner(
+        &self,
+        formula: &str,
+        variables: &HashMap<String, Value>,
+        now_serial: Option<f64>,
+    ) -> Value {
         if self.flavor == Flavor::Excel {
             // Excel evaluation semantics are not implemented yet.
             return Value::Error(ErrorKind::NA);
@@ -61,20 +115,12 @@ impl Engine {
         match parse_formula(formula) {
             Err(_) => Value::Error(ErrorKind::Value),
             Ok(expr) => {
-                let ctx = Context::new(variables.clone());
+                let mut ctx = Context::new(variables.clone());
+                ctx.now_serial = now_serial;
                 let mut eval_ctx = EvalCtx::new(ctx, &self.registry);
-                first_of_array(evaluate_expr(&expr, &mut eval_ctx))
+                evaluate_expr(&expr, &mut eval_ctx)
             }
         }
-    }
-}
-
-fn first_of_array(v: Value) -> Value {
-    match v {
-        Value::Array(elems) if !elems.is_empty() => {
-            first_of_array(elems.into_iter().next().unwrap())
-        }
-        other => other,
     }
 }
 

--- a/crates/core/src/eval/context/mod.rs
+++ b/crates/core/src/eval/context/mod.rs
@@ -7,6 +7,11 @@ use crate::types::Value;
 /// case-insensitive (`A1`, `a1`, and `A1` all refer to the same binding).
 pub struct Context {
     pub vars: HashMap<String, Value>,
+    /// Pinned "now" for volatile date functions (`NOW`, `TODAY`), as a
+    /// local-time spreadsheet serial datetime (integer part = day serial,
+    /// fraction = time of day). `None` ⇒ the functions read the ambient
+    /// local clock. Set via [`crate::Engine::evaluate_at`] (P1.4, issue #526).
+    pub now_serial: Option<f64>,
 }
 
 impl Context {
@@ -16,12 +21,12 @@ impl Context {
         let normalized = vars.into_iter()
             .map(|(k, v)| (k.to_uppercase(), v))
             .collect();
-        Self { vars: normalized }
+        Self { vars: normalized, now_serial: None }
     }
 
     /// Create an empty `Context` with no variable bindings.
     pub fn empty() -> Self {
-        Self { vars: HashMap::new() }
+        Self { vars: HashMap::new(), now_serial: None }
     }
 
     /// Look up a variable by name (case-insensitive). Returns `Value::Empty` if not found.

--- a/crates/core/src/eval/functions/date/date_fn/mod.rs
+++ b/crates/core/src/eval/functions/date/date_fn/mod.rs
@@ -11,6 +11,10 @@ use crate::types::{ErrorKind, Value};
 /// - Month 0 of 2024 → December 2023
 /// - Day 0 of March → last day of February
 ///
+/// Year arguments 0–1899 get **1900 added** (Sheets' +1900 year rule;
+/// pipeline-verified: workbook.tsv `=DATE(1899,12,31)` → serial 693962 =
+/// 3799-12-31, bugs.tsv `=DATE(119,2,1)` → 2019-02-01).
+///
 /// All inputs are truncated to integer before use.
 pub fn date_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 3, 3) {
@@ -22,6 +26,11 @@ pub fn date_fn(args: &[Value]) -> Value {
 
     // Truncate to integers (Google Sheets truncates, not rounds)
     let mut year_i  = year.trunc() as i64;
+    // Sheets' +1900 year rule: year arguments 0–1899 are offsets from 1900.
+    // Applied to the year *argument*, before month normalization.
+    if (0..=1899).contains(&year_i) {
+        year_i += 1900;
+    }
     let month_i = month.trunc() as i64;
     let day_i   = day.trunc() as i64;
 

--- a/crates/core/src/eval/functions/date/eomonth/mod.rs
+++ b/crates/core/src/eval/functions/date/eomonth/mod.rs
@@ -4,7 +4,7 @@ use crate::eval::functions::check_arity;
 use crate::eval::functions::date::serial::{date_to_serial, serial_to_date};
 use crate::types::{ErrorKind, Value};
 
-/// `EOMONTH(start_date, months)` — serial of the last day of the month N months away.
+/// `EOMONTH(start_date, months)` — date-typed serial of the last day of the month N months away.
 ///
 /// Same month arithmetic as EDATE, but always returns the last day of the target month.
 pub fn eomonth_fn(args: &[Value]) -> Value {
@@ -34,7 +34,8 @@ pub fn eomonth_fn(args: &[Value]) -> Value {
     };
 
     let last_day = last_day_of_month(target_date.year(), target_date.month());
-    Value::Number(date_to_serial(last_day))
+    // Date-typed: pipeline-verified (workbook.tsv `=ISDATE(EOMONTH(...))` → TRUE).
+    Value::Date(date_to_serial(last_day))
 }
 
 fn last_day_of_month(year: i32, month: u32) -> NaiveDate {

--- a/crates/core/src/eval/functions/date/eomonth/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/eomonth/tests/edge.rs
@@ -5,7 +5,7 @@ use crate::types::Value;
 #[test]
 fn plus_one_dec_to_jan_next_year() {
     let args = [Value::Number(45627.0), Value::Number(1.0)];
-    assert_eq!(eomonth_fn(&args), Value::Number(45688.0));
+    assert_eq!(eomonth_fn(&args), Value::Date(45688.0));
 }
 
 // gs: EOMONTH(DATE(2024,6,15), -12) = 45107 = Jun 30, 2023
@@ -13,7 +13,7 @@ fn plus_one_dec_to_jan_next_year() {
 fn minus_twelve_months_back_one_year() {
     // DATE(2024,6,15) = 45458, end of Jun 2023 = 45107
     let args = [Value::Number(45458.0), Value::Number(-12.0)];
-    assert_eq!(eomonth_fn(&args), Value::Number(45107.0));
+    assert_eq!(eomonth_fn(&args), Value::Date(45107.0));
 }
 
 // Always returns last day: mid-month input still gives last day
@@ -22,12 +22,12 @@ fn mid_month_input_gives_last_day() {
     // DATE(2024,2,15) -> end of Feb 2024 = 45351 (Feb 29, leap)
     // DATE(2024,2,15) = 45337
     let args = [Value::Number(45337.0), Value::Number(0.0)];
-    assert_eq!(eomonth_fn(&args), Value::Number(45351.0));
+    assert_eq!(eomonth_fn(&args), Value::Date(45351.0));
 }
 
 // Negative months: Feb 2024 - 1 month = Jan 2024 end = 45322
 #[test]
 fn minus_one_from_feb_to_jan() {
     let args = [Value::Number(45323.0), Value::Number(-1.0)];
-    assert_eq!(eomonth_fn(&args), Value::Number(45322.0));
+    assert_eq!(eomonth_fn(&args), Value::Date(45322.0));
 }

--- a/crates/core/src/eval/functions/date/eomonth/tests/success.rs
+++ b/crates/core/src/eval/functions/date/eomonth/tests/success.rs
@@ -5,40 +5,40 @@ use crate::types::Value;
 #[test]
 fn zero_months_end_of_jan() {
     let args = [Value::Number(45306.0), Value::Number(0.0)];
-    assert_eq!(eomonth_fn(&args), Value::Number(45322.0));
+    assert_eq!(eomonth_fn(&args), Value::Date(45322.0));
 }
 
 // gs: EOMONTH(DATE(2024,2,1), 0) = 45351 = Feb 29, 2024 (leap)
 #[test]
 fn zero_months_end_of_feb_leap() {
     let args = [Value::Number(45323.0), Value::Number(0.0)];
-    assert_eq!(eomonth_fn(&args), Value::Number(45351.0));
+    assert_eq!(eomonth_fn(&args), Value::Date(45351.0));
 }
 
 // gs: EOMONTH(DATE(2023,2,1), 0) = 44985 = Feb 28, 2023 (non-leap)
 #[test]
 fn zero_months_end_of_feb_non_leap() {
     let args = [Value::Number(44958.0), Value::Number(0.0)];
-    assert_eq!(eomonth_fn(&args), Value::Number(44985.0));
+    assert_eq!(eomonth_fn(&args), Value::Date(44985.0));
 }
 
 // gs: EOMONTH(DATE(2024,1,15), 1) = 45351 = Feb 29, 2024
 #[test]
 fn plus_one_jan_to_end_feb_leap() {
     let args = [Value::Number(45306.0), Value::Number(1.0)];
-    assert_eq!(eomonth_fn(&args), Value::Number(45351.0));
+    assert_eq!(eomonth_fn(&args), Value::Date(45351.0));
 }
 
 // gs: EOMONTH(DATE(2024,3,15), -1) = 45351 = Feb 29, 2024
 #[test]
 fn minus_one_mar_to_end_feb_leap() {
     let args = [Value::Number(45366.0), Value::Number(-1.0)];
-    assert_eq!(eomonth_fn(&args), Value::Number(45351.0));
+    assert_eq!(eomonth_fn(&args), Value::Date(45351.0));
 }
 
 // gs: EOMONTH(DATE(2024,12,1), 0) = 45657 = Dec 31, 2024
 #[test]
 fn zero_months_end_of_dec() {
     let args = [Value::Number(45627.0), Value::Number(0.0)];
-    assert_eq!(eomonth_fn(&args), Value::Number(45657.0));
+    assert_eq!(eomonth_fn(&args), Value::Date(45657.0));
 }

--- a/crates/core/src/eval/functions/date/mod.rs
+++ b/crates/core/src/eval/functions/date/mod.rs
@@ -1,4 +1,6 @@
 pub mod serial;
+#[cfg(test)]
+mod serial_tests;
 pub mod weekend;
 
 pub mod date_fn;
@@ -46,11 +48,11 @@ pub fn register_date(registry: &mut Registry) {
     registry.register_eager("MONTH",            month::month_fn,                    FunctionMeta { category: "date", signature: "MONTH(date)",                                description: "Month number from a date serial number" });
     registry.register_eager("NETWORKDAYS",      networkdays::networkdays_fn,        FunctionMeta { category: "date", signature: "NETWORKDAYS(start,end,[holidays])",          description: "Number of working days between two dates" });
     registry.register_eager("NETWORKDAYS.INTL", networkdays_intl::networkdays_intl_fn, FunctionMeta { category: "date", signature: "NETWORKDAYS.INTL(start,end,[weekend],[holidays])", description: "Working days between dates with custom weekends" });
-    registry.register_eager("NOW",              now::now_fn,                        FunctionMeta { category: "date", signature: "NOW()",                                      description: "Current date and time as a serial number" });
+    registry.register_lazy("NOW",               now::now_fn,                        FunctionMeta { category: "date", signature: "NOW()",                                      description: "Current date and time as a serial number" });
     registry.register_eager("SECOND",           second::second_fn,                  FunctionMeta { category: "date", signature: "SECOND(time)",                               description: "Second component of a time serial number" });
     registry.register_eager("TIME",             time_fn::time_fn,                   FunctionMeta { category: "date", signature: "TIME(hour,minute,second)",                   description: "Creates a time serial number from components" });
     registry.register_eager("TIMEVALUE",        timevalue::timevalue_fn,            FunctionMeta { category: "date", signature: "TIMEVALUE(time_text)",                       description: "Converts a time string to a fractional serial number" });
-    registry.register_eager("TODAY",            today::today_fn,                    FunctionMeta { category: "date", signature: "TODAY()",                                    description: "Current date as a serial number" });
+    registry.register_lazy("TODAY",             today::today_fn,                    FunctionMeta { category: "date", signature: "TODAY()",                                    description: "Current date as a serial number" });
     registry.register_eager("WEEKDAY",          weekday::weekday_fn,                FunctionMeta { category: "date", signature: "WEEKDAY(date,[type])",                       description: "Day of week as a number" });
     registry.register_eager("WEEKNUM",          weeknum::weeknum_fn,                FunctionMeta { category: "date", signature: "WEEKNUM(date,[type])",                       description: "Week number of the year for a date" });
     registry.register_eager("WORKDAY",          workday::workday_fn,                FunctionMeta { category: "date", signature: "WORKDAY(start,days,[holidays])",             description: "Date N working days from start date" });

--- a/crates/core/src/eval/functions/date/now/mod.rs
+++ b/crates/core/src/eval/functions/date/now/mod.rs
@@ -1,18 +1,28 @@
 use chrono::{Local, Timelike};
-use crate::eval::functions::check_arity;
+use crate::eval::functions::{check_arity_len, EvalCtx};
 use crate::eval::functions::date::serial::{date_to_serial, time_to_serial};
+use crate::parser::ast::Expr;
 use crate::types::Value;
 
 /// `NOW()` — returns the current local datetime as a spreadsheet serial number.
 /// Integer part = date serial; fractional part = time-of-day.
-pub fn now_fn(args: &[Value]) -> Value {
-    if let Some(e) = check_arity(args, 0, 0) {
+///
+/// Volatile. Registered lazy so it can read the evaluation context: when the
+/// context carries a pinned `now_serial` (set via `Engine::evaluate_at`,
+/// P1.4 issue #526) it returns that serial verbatim — deterministic.
+/// Without a pin it falls back to the ambient local clock.
+pub fn now_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if let Some(e) = check_arity_len(args.len(), 0, 0) {
         return e;
     }
-    let now = Local::now().naive_local();
-    let date_serial = date_to_serial(now.date());
-    let time_frac = time_to_serial(now.hour(), now.minute(), now.second());
-    Value::Number(date_serial + time_frac)
+    let serial = match ctx.ctx.now_serial {
+        Some(now) => now,
+        None => {
+            let now = Local::now().naive_local();
+            date_to_serial(now.date()) + time_to_serial(now.hour(), now.minute(), now.second())
+        }
+    };
+    Value::Number(serial)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/now/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/now/tests/edge.rs
@@ -1,10 +1,20 @@
 use super::super::*;
+use crate::eval::functions::{EvalCtx, Registry};
+use crate::eval::Context;
 use crate::types::Value;
+
+fn call(now_serial: Option<f64>) -> Value {
+    let registry = Registry::new();
+    let mut ctx = Context::empty();
+    ctx.now_serial = now_serial;
+    let mut eval_ctx = EvalCtx::new(ctx, &registry);
+    now_fn(&[], &mut eval_ctx)
+}
 
 #[test]
 fn integer_part_equals_today_floor() {
     // The integer portion of NOW() must match the date (no fractional spillover).
-    if let Value::Number(n) = now_fn(&[]) {
+    if let Value::Number(n) = call(None) {
         assert!(n.floor() >= 45292.0, "date portion {} seems too small", n.floor());
     } else {
         panic!("expected Number");

--- a/crates/core/src/eval/functions/date/now/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/now/tests/failure.rs
@@ -1,7 +1,13 @@
 use super::super::*;
+use crate::eval::functions::{EvalCtx, Registry};
+use crate::eval::Context;
+use crate::parser::ast::{Expr, Span};
 use crate::types::{ErrorKind, Value};
 
 #[test]
 fn too_many_args() {
-    assert_eq!(now_fn(&[Value::Number(0.0)]), Value::Error(ErrorKind::NA));
+    let registry = Registry::new();
+    let mut eval_ctx = EvalCtx::new(Context::empty(), &registry);
+    let arg = Expr::Number(0.0, Span::new(0, 0));
+    assert_eq!(now_fn(&[arg], &mut eval_ctx), Value::Error(ErrorKind::NA));
 }

--- a/crates/core/src/eval/functions/date/now/tests/success.rs
+++ b/crates/core/src/eval/functions/date/now/tests/success.rs
@@ -1,17 +1,27 @@
 use super::super::*;
+use crate::eval::functions::{EvalCtx, Registry};
+use crate::eval::Context;
 use crate::types::Value;
+
+fn call(now_serial: Option<f64>) -> Value {
+    let registry = Registry::new();
+    let mut ctx = Context::empty();
+    ctx.now_serial = now_serial;
+    let mut eval_ctx = EvalCtx::new(ctx, &registry);
+    now_fn(&[], &mut eval_ctx)
+}
 
 /// Serial for 2024-01-01 = 45292.
 const MIN_SERIAL: f64 = 45292.0;
 
 #[test]
 fn returns_a_number() {
-    assert!(matches!(now_fn(&[]), Value::Number(_)));
+    assert!(matches!(call(None), Value::Number(_)));
 }
 
 #[test]
 fn result_is_after_2024_jan_01() {
-    if let Value::Number(n) = now_fn(&[]) {
+    if let Value::Number(n) = call(None) {
         assert!(n >= MIN_SERIAL, "now serial {n} should be >= {MIN_SERIAL}");
     } else {
         panic!("expected Number");
@@ -20,10 +30,15 @@ fn result_is_after_2024_jan_01() {
 
 #[test]
 fn fractional_part_is_between_0_and_1() {
-    if let Value::Number(n) = now_fn(&[]) {
+    if let Value::Number(n) = call(None) {
         let frac = n.fract();
         assert!(frac >= 0.0 && frac < 1.0, "fractional part {frac} out of range");
     } else {
         panic!("expected Number");
     }
+}
+
+#[test]
+fn pinned_context_returns_now_serial_verbatim() {
+    assert_eq!(call(Some(46180.5)), Value::Number(46180.5));
 }

--- a/crates/core/src/eval/functions/date/serial.rs
+++ b/crates/core/src/eval/functions/date/serial.rs
@@ -1,6 +1,8 @@
 use chrono::{Duration, NaiveDate, NaiveTime, Timelike};
 
-/// Base date for serial number 0 (December 30, 1899).
+/// Base date for serial number 0 in the **Sheets** date system
+/// (December 30, 1899). Locked per engine flavor — see `engine::Flavor`
+/// and P1.4 (issue #526).
 fn base() -> NaiveDate {
     NaiveDate::from_ymd_opt(1899, 12, 30).unwrap()
 }
@@ -62,4 +64,56 @@ pub fn text_to_time_serial(text: &str) -> Option<f64> {
         }
     }
     None
+}
+
+// ── Excel 1900 date system (flavor-locked, P1.4 issue #526) ─────────────────
+//
+// Excel's 1900 date system: serial 1 = 1900-01-01, **including** the
+// historical Lotus 1-2-3 leap-year bug — serial 60 is the fictitious
+// 1900-02-29. Consequences:
+//   - serials 1..=59  map to 1900-01-01..=1900-02-28 (= Sheets serial − 1),
+//   - serial  60      maps to the nonexistent 1900-02-29,
+//   - serials ≥ 61    coincide with Sheets serials (1900-03-01 onward).
+//
+// These helpers lock the semantics behind the `Engine::excel()` flavor.
+// Excel *evaluation* is still stubbed (`Engine::evaluate` returns `#N/A`
+// for the Excel flavor), as issue #526 explicitly allows.
+
+/// Convert a calendar date to an Excel 1900-system serial.
+///
+/// `(1900, 2, 29)` — the fictitious leap-bug date — returns `Some(60.0)`.
+/// Dates before 1900-01-01 are not representable in the Excel 1900 system
+/// and return `None`.
+pub fn excel_ymd_to_serial(year: i32, month: u32, day: u32) -> Option<f64> {
+    if (year, month, day) == (1900, 2, 29) {
+        return Some(60.0);
+    }
+    let date = NaiveDate::from_ymd_opt(year, month, day)?;
+    let sheets_serial = date_to_serial(date);
+    // Sheets serial 2 = 1900-01-01 = Excel serial 1.
+    if sheets_serial < 2.0 {
+        return None;
+    }
+    // Before the (Sheets) serial of 1900-03-01 (= 61), Excel is one behind
+    // Sheets; from 1900-03-01 on, the fictitious Feb 29 makes them coincide.
+    Some(if sheets_serial < 61.0 { sheets_serial - 1.0 } else { sheets_serial })
+}
+
+/// Convert an Excel 1900-system serial (integer part) to `(year, month, day)`.
+///
+/// Serial 60 returns `Some((1900, 2, 29))` — the fictitious leap-bug date,
+/// which is why this returns a tuple rather than a `NaiveDate`.
+/// Serials below 1 return `None`.
+pub fn excel_serial_to_ymd(serial: f64) -> Option<(i32, u32, u32)> {
+    use chrono::Datelike;
+    let days = serial.floor();
+    if days < 1.0 {
+        return None;
+    }
+    if days == 60.0 {
+        return Some((1900, 2, 29));
+    }
+    let sheets_serial = if days < 60.0 { days + 1.0 } else { days };
+    let date = serial_to_date(sheets_serial)?;
+    Some((date.year(), date.month(), date.day()))
 }

--- a/crates/core/src/eval/functions/date/serial_tests.rs
+++ b/crates/core/src/eval/functions/date/serial_tests.rs
@@ -1,0 +1,94 @@
+//! Tests for the flavor-locked date serial systems (P1.4, issue #526).
+//!
+//! Sheets system: day 0 = 1899-12-30, no leap-year bug.
+//! Excel 1900 system: serial 1 = 1900-01-01, serial 60 = fictitious 1900-02-29.
+
+use chrono::NaiveDate;
+use super::serial::{
+    date_to_serial, excel_serial_to_ymd, excel_ymd_to_serial, serial_to_date,
+};
+
+fn ymd(y: i32, m: u32, d: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(y, m, d).unwrap()
+}
+
+// ── Sheets epoch (pipeline-verified anchors, workbook.tsv PR #559) ──────────
+
+#[test]
+fn sheets_serial_zero_is_1899_12_30() {
+    // workbook.tsv: =TEXT(0,"yyyy-mm-dd") → 1899-12-30
+    assert_eq!(date_to_serial(ymd(1899, 12, 30)), 0.0);
+    assert_eq!(serial_to_date(0.0), Some(ymd(1899, 12, 30)));
+}
+
+#[test]
+fn sheets_serial_one_is_1899_12_31() {
+    // workbook.tsv: =TEXT(1,"yyyy-mm-dd") → 1899-12-31
+    assert_eq!(date_to_serial(ymd(1899, 12, 31)), 1.0);
+}
+
+#[test]
+fn sheets_has_no_leap_year_bug() {
+    // workbook.tsv: =N(DATE(1900,2,28)) → 60, =N(DATE(1900,3,1)) → 61.
+    // 1900 is not a leap year; 60 and 61 are adjacent days.
+    assert_eq!(date_to_serial(ymd(1900, 2, 28)), 60.0);
+    assert_eq!(date_to_serial(ymd(1900, 3, 1)), 61.0);
+}
+
+#[test]
+fn sheets_negative_serials_are_pre_1900_dates() {
+    assert_eq!(date_to_serial(ymd(1899, 12, 29)), -1.0);
+    assert_eq!(serial_to_date(-1.0), Some(ymd(1899, 12, 29)));
+}
+
+// ── Excel 1900 system (flavor-locked; evaluation still stubbed) ─────────────
+
+#[test]
+fn excel_serial_one_is_1900_01_01() {
+    assert_eq!(excel_ymd_to_serial(1900, 1, 1), Some(1.0));
+    assert_eq!(excel_serial_to_ymd(1.0), Some((1900, 1, 1)));
+}
+
+#[test]
+fn excel_serial_59_is_1900_02_28() {
+    assert_eq!(excel_ymd_to_serial(1900, 2, 28), Some(59.0));
+    assert_eq!(excel_serial_to_ymd(59.0), Some((1900, 2, 28)));
+}
+
+#[test]
+fn excel_serial_60_is_the_fictitious_leap_day() {
+    // The Lotus 1-2-3 leap-year bug: 1900-02-29 does not exist, but the
+    // Excel 1900 system assigns it serial 60.
+    assert_eq!(excel_ymd_to_serial(1900, 2, 29), Some(60.0));
+    assert_eq!(excel_serial_to_ymd(60.0), Some((1900, 2, 29)));
+}
+
+#[test]
+fn excel_serial_61_is_1900_03_01_and_coincides_with_sheets() {
+    assert_eq!(excel_ymd_to_serial(1900, 3, 1), Some(61.0));
+    assert_eq!(excel_serial_to_ymd(61.0), Some((1900, 3, 1)));
+    // From 1900-03-01 onward the two systems share serials.
+    assert_eq!(date_to_serial(ymd(1900, 3, 1)), 61.0);
+}
+
+#[test]
+fn excel_and_sheets_diverge_only_before_1900_03_01() {
+    // Divergence zone: Excel = Sheets − 1 for 1900-01-01..=1900-02-28.
+    for (y, m, d) in [(1900, 1, 1), (1900, 1, 31), (1900, 2, 28)] {
+        let sheets = date_to_serial(ymd(y, m, d));
+        let excel = excel_ymd_to_serial(y, m, d).unwrap();
+        assert_eq!(excel, sheets - 1.0, "{y}-{m}-{d}");
+    }
+    // Coincidence zone: a modern date (2026-06-07, Sheets serial 46180).
+    let sheets = date_to_serial(ymd(2026, 6, 7));
+    assert_eq!(sheets, 46180.0);
+    assert_eq!(excel_ymd_to_serial(2026, 6, 7), Some(46180.0));
+    assert_eq!(excel_serial_to_ymd(46180.0), Some((2026, 6, 7)));
+}
+
+#[test]
+fn excel_rejects_dates_before_1900() {
+    assert_eq!(excel_ymd_to_serial(1899, 12, 31), None);
+    assert_eq!(excel_serial_to_ymd(0.0), None);
+    assert_eq!(excel_serial_to_ymd(-5.0), None);
+}

--- a/crates/core/src/eval/functions/date/today/mod.rs
+++ b/crates/core/src/eval/functions/date/today/mod.rs
@@ -1,15 +1,24 @@
 use chrono::Local;
-use crate::eval::functions::check_arity;
+use crate::eval::functions::{check_arity_len, EvalCtx};
 use crate::eval::functions::date::serial::date_to_serial;
+use crate::parser::ast::Expr;
 use crate::types::Value;
 
-/// `TODAY()` — returns the current local date as a spreadsheet serial number.
-pub fn today_fn(args: &[Value]) -> Value {
-    if let Some(e) = check_arity(args, 0, 0) {
+/// `TODAY()` — returns the current local date as a date-typed serial number.
+///
+/// Volatile. Registered lazy so it can read the evaluation context: when the
+/// context carries a pinned `now_serial` (set via `Engine::evaluate_at`,
+/// P1.4 issue #526), the date is `now_serial.floor()` — deterministic.
+/// Without a pin it falls back to the ambient local clock.
+pub fn today_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if let Some(e) = check_arity_len(args.len(), 0, 0) {
         return e;
     }
-    let today = Local::now().date_naive();
-    Value::Date(date_to_serial(today))
+    let serial = match ctx.ctx.now_serial {
+        Some(now) => now.floor(),
+        None => date_to_serial(Local::now().date_naive()),
+    };
+    Value::Date(serial)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/today/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/today/tests/edge.rs
@@ -1,10 +1,20 @@
 use super::super::*;
+use crate::eval::functions::{EvalCtx, Registry};
+use crate::eval::Context;
 use crate::types::Value;
+
+fn call(now_serial: Option<f64>) -> Value {
+    let registry = Registry::new();
+    let mut ctx = Context::empty();
+    ctx.now_serial = now_serial;
+    let mut eval_ctx = EvalCtx::new(ctx, &registry);
+    today_fn(&[], &mut eval_ctx)
+}
 
 #[test]
 fn result_is_reasonable_upper_bound() {
     // Sanity: the result should not be unreasonably large (e.g., > serial for 2100-01-01 ≈ 73051).
-    if let Value::Date(n) = today_fn(&[]) {
+    if let Value::Date(n) = call(None) {
         assert!(n < 73051.0, "today serial {n} seems unreasonably large");
     } else {
         panic!("expected Date");

--- a/crates/core/src/eval/functions/date/today/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/today/tests/failure.rs
@@ -1,7 +1,13 @@
 use super::super::*;
+use crate::eval::functions::{EvalCtx, Registry};
+use crate::eval::Context;
+use crate::parser::ast::{Expr, Span};
 use crate::types::{ErrorKind, Value};
 
 #[test]
 fn too_many_args() {
-    assert_eq!(today_fn(&[Value::Number(0.0)]), Value::Error(ErrorKind::NA));
+    let registry = Registry::new();
+    let mut eval_ctx = EvalCtx::new(Context::empty(), &registry);
+    let arg = Expr::Number(0.0, Span::new(0, 0));
+    assert_eq!(today_fn(&[arg], &mut eval_ctx), Value::Error(ErrorKind::NA));
 }

--- a/crates/core/src/eval/functions/date/today/tests/success.rs
+++ b/crates/core/src/eval/functions/date/today/tests/success.rs
@@ -1,17 +1,27 @@
 use super::super::*;
+use crate::eval::functions::{EvalCtx, Registry};
+use crate::eval::Context;
 use crate::types::Value;
 
-/// Serial for 2024-01-01 = 45292. TODAY() must be at or above that.
+fn call(now_serial: Option<f64>) -> Value {
+    let registry = Registry::new();
+    let mut ctx = Context::empty();
+    ctx.now_serial = now_serial;
+    let mut eval_ctx = EvalCtx::new(ctx, &registry);
+    today_fn(&[], &mut eval_ctx)
+}
+
+/// Serial for 2024-01-01 = 45292. Ambient TODAY() must be at or above that.
 const MIN_SERIAL: f64 = 45292.0;
 
 #[test]
-fn returns_a_number() {
-    assert!(matches!(today_fn(&[]), Value::Date(_)));
+fn returns_a_date() {
+    assert!(matches!(call(None), Value::Date(_)));
 }
 
 #[test]
 fn result_is_after_2024_jan_01() {
-    if let Value::Date(n) = today_fn(&[]) {
+    if let Value::Date(n) = call(None) {
         assert!(n >= MIN_SERIAL, "today serial {n} should be >= {MIN_SERIAL}");
     } else {
         panic!("expected Date");
@@ -20,9 +30,22 @@ fn result_is_after_2024_jan_01() {
 
 #[test]
 fn result_has_no_fractional_part() {
-    if let Value::Date(n) = today_fn(&[]) {
+    if let Value::Date(n) = call(None) {
         assert_eq!(n.fract(), 0.0, "TODAY() should be a whole number, got {n}");
     } else {
         panic!("expected Date");
     }
+}
+
+#[test]
+fn pinned_context_returns_floor_of_now_serial() {
+    // workbook.tsv volatile row: =TODAY() → 46180 (date) under
+    // meta.evaluatedAt 2026-06-07T23:50:56.808Z, Etc/GMT (PR #559).
+    let evaluated_at_serial = 46180.0 + (23.0 * 3600.0 + 50.0 * 60.0 + 56.0) / 86400.0;
+    assert_eq!(call(Some(evaluated_at_serial)), Value::Date(46180.0));
+}
+
+#[test]
+fn pinned_context_is_deterministic() {
+    assert_eq!(call(Some(46180.25)), call(Some(46180.25)));
 }

--- a/crates/core/src/eval/mod.rs
+++ b/crates/core/src/eval/mod.rs
@@ -193,6 +193,15 @@ fn eval_binary(op: &BinaryOp, lv: Value, rv: Value) -> Value {
     match op {
         // ── Arithmetic ──────────────────────────────────────────────────────
         BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Pow => {
+            // Date-type production (schema spec §6: date-typed iff the fixtures
+            // pipeline observes Sheets producing a Date). Observed: date ± offset
+            // via `+` stays date-typed (workbook.tsv `=DATE(2026,6,7)+1` → date);
+            // date − date is a plain number (`=DATE(2026,6,7)-DATE(2026,6,1)` → 6,
+            // `=TODAY()-TODAY()` → 0, both typed number). Everything else —
+            // including date − number, ×, ÷, ^ — stays a plain number until a
+            // fixture observes otherwise.
+            let date_typed_add = matches!(op, BinaryOp::Add)
+                && matches!(lv, Value::Date(_)) != matches!(rv, Value::Date(_));
             let ln = match to_number(lv) { Ok(n) => n, Err(e) => return e };
             let rn = match to_number(rv) { Ok(n) => n, Err(e) => return e };
             let result = match op {
@@ -212,7 +221,11 @@ fn eval_binary(op: &BinaryOp, lv: Value, rv: Value) -> Value {
             if !result.is_finite() {
                 return Value::Error(ErrorKind::Num);
             }
-            Value::Number(result)
+            if date_typed_add {
+                Value::Date(result)
+            } else {
+                Value::Number(result)
+            }
         }
 
         // ── Concatenation ───────────────────────────────────────────────────

--- a/crates/core/src/eval/tests/array_literal.rs
+++ b/crates/core/src/eval/tests/array_literal.rs
@@ -7,16 +7,25 @@ fn run_formula(formula: &str) -> Value {
 
 #[test]
 fn array_literal_evaluates_to_array() {
-    // In Google Sheets scalar context, an array literal returns its first element.
+    // P1.4 (issue #526): array values flow through evaluation unspilled —
+    // the engine returns the full array; spilling (or collapsing to the
+    // top-left element for a single-cell view) is the workbook/surface
+    // layer's job, not the evaluator's.
     let result = run_formula("={1,2,3}");
-    assert_eq!(result, Value::Number(1.0));
+    assert!(matches!(result, Value::Array(_)));
 }
 
 #[test]
 fn array_literal_values_are_correct() {
-    // In Google Sheets scalar context, ={1,2,3} → 1 (top-left element).
     let result = run_formula("={1,2,3}");
-    assert_eq!(result, Value::Number(1.0));
+    assert_eq!(
+        result,
+        Value::Array(vec![
+            Value::Number(1.0),
+            Value::Number(2.0),
+            Value::Number(3.0),
+        ])
+    );
 }
 
 #[test]
@@ -27,9 +36,15 @@ fn array_literal_empty() {
 
 #[test]
 fn array_literal_mixed_types() {
-    // In Google Sheets scalar context, ={1,"hello",TRUE} → 1 (top-left element).
     let result = run_formula("={1,\"hello\",TRUE}");
-    assert_eq!(result, Value::Number(1.0));
+    assert_eq!(
+        result,
+        Value::Array(vec![
+            Value::Number(1.0),
+            Value::Text("hello".to_string()),
+            Value::Bool(true),
+        ])
+    );
 }
 
 #[test]

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -19,7 +19,7 @@
 //!   formula_text    formula string (may or may not have leading `=`)
 //!   expected_value  canonical expected value as a string
 //!   test_category   basic / edge / coercion / error / nested
-//!   expected_type   number / string / boolean / error / array
+//!   expected_type   number / string / boolean / error / array / date
 //!
 //! The test evaluates the formula with `truecalc_core::evaluate` and compares
 //! against the canonical value.  Number comparisons allow 1e-4 relative tolerance.
@@ -140,6 +140,12 @@ pub fn parse_expected(value: &str, expected_type: &str) -> Option<Value> {
             // Store the array literal string as-is; comparison handled in values_match
             Some(Value::Text(value.to_string()))
         }
+        "date" => {
+            // P1.4 (#526): `date`-typed rows — the pipeline observed Sheets
+            // producing a Date; the engine must produce Value::Date with
+            // this serial (schema spec §6 date-type production rule).
+            value.parse::<f64>().ok().map(Value::Date)
+        }
         _ => Some(Value::Text(value.to_string())),
     }
 }
@@ -172,6 +178,20 @@ fn gas_iso_date_to_serial(s: &str) -> Option<f64> {
     Some(date.signed_duration_since(epoch).num_days() as f64)
 }
 
+/// Top-left element of a (possibly nested) array value.
+///
+/// P1.4 (#526): the engine returns array results unspilled.  The fixtures
+/// pipeline, however, observes the *anchor cell* of the spilled range in
+/// Google Sheets, so a scalar-typed expected value corresponds to the
+/// top-left element of an array actual — the same collapse the workbook /
+/// surface layer applies for a single-cell view.
+fn top_left(v: &Value) -> &Value {
+    match v {
+        Value::Array(items) if !items.is_empty() => top_left(&items[0]),
+        other => other,
+    }
+}
+
 pub fn values_match(actual: &Value, expected: &Value, expected_type: &str) -> bool {
     if expected_type == "array" {
         // expected is stored as Text(array_literal)
@@ -192,8 +212,19 @@ pub fn values_match(actual: &Value, expected: &Value, expected_type: &str) -> bo
         });
     }
 
+    // Scalar expected type: compare against the top-left element of an
+    // unspilled array actual (anchor-cell view, see `top_left`).
+    let actual = top_left(actual);
+
     match (actual, expected) {
         (Value::Number(a), Value::Number(b)) => {
+            (a - b).abs() <= b.abs() * 1e-4 + 1e-10
+        }
+        // P1.4 (#526) date-type production rule: a `date`-typed expected
+        // value only matches a Value::Date actual.  A plain Number actual
+        // against a Date expected falls through to the catch-all arm and
+        // fails -- losing the date type is a conformance failure.
+        (Value::Date(a), Value::Date(b)) => {
             (a - b).abs() <= b.abs() * 1e-4 + 1e-10
         }
         (Value::Date(a), Value::Number(b)) => {
@@ -244,6 +275,22 @@ fn is_volatile_formula(formula: &str) -> bool {
     upper.contains("RAND()") || upper.contains("RANDBETWEEN(") || upper.contains("RANDARRAY(")
 }
 
+/// Pinned "now" serial for fixture files whose volatile rows (`NOW`, `TODAY`)
+/// were captured at a recorded instant (P1.4, issue #526).
+///
+/// workbook.tsv (P1.5, PR #559): the DATE_TYPE block's meta sidecar in the
+/// truecalc/fixtures snapshot `snapshots/2026-06-08/google_sheets/workbook/`
+/// records `evaluatedAt = 2026-06-07T23:50:56.808Z` with the sheet timezone
+/// pinned to `Etc/GMT`, so local time == UTC: day serial 46180 (2026-06-07)
+/// plus the time-of-day fraction.  Rows in pinned files are evaluated through
+/// `Engine::evaluate_at` so volatile date functions are deterministic.
+fn pinned_now_serial(path: &Path) -> Option<f64> {
+    match path.file_name().and_then(|n| n.to_str()) {
+        Some("workbook.tsv") => Some(46180.0 + (23.0 * 3600.0 + 50.0 * 60.0 + 56.808) / 86400.0),
+        _ => None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // TSV runner
 // ---------------------------------------------------------------------------
@@ -251,6 +298,7 @@ fn is_volatile_formula(formula: &str) -> bool {
 fn run_tsv_fixture(path: &Path) {
     assert!(path.exists(), "fixture not found: {:?}", path);
 
+    let pinned_now = pinned_now_serial(path);
     let vars: HashMap<String, Value> = HashMap::new();
     let mut failures: Vec<String> = Vec::new();
     let mut total = 0usize;
@@ -290,7 +338,10 @@ fn run_tsv_fixture(path: &Path) {
         };
 
         total += 1;
-        let actual = evaluate(formula, &vars);
+        let actual = match pinned_now {
+            Some(now) => truecalc_core::Engine::sheets().evaluate_at(formula, &vars, now),
+            None => evaluate(formula, &vars),
+        };
 
         if !values_match(&actual, &expected, expected_type) {
             failures.push(format!(
@@ -316,6 +367,7 @@ fn run_tsv_fixture(path: &Path) {
 fn run_tsv_fixture_report(path: &Path) {
     assert!(path.exists(), "fixture not found: {:?}", path);
 
+    let pinned_now = pinned_now_serial(path);
     let vars: HashMap<String, Value> = HashMap::new();
     let mut pass = 0usize;
     let mut fail = 0usize;
@@ -352,7 +404,10 @@ fn run_tsv_fixture_report(path: &Path) {
             None => continue,
         };
 
-        let actual = evaluate(formula, &vars);
+        let actual = match pinned_now {
+            Some(now) => truecalc_core::Engine::sheets().evaluate_at(formula, &vars, now),
+            None => evaluate(formula, &vars),
+        };
 
         if values_match(&actual, &expected, expected_type) {
             pass += 1;
@@ -397,6 +452,19 @@ conformance_tsv_test!(array_conformance,       "array.tsv");
 conformance_tsv_test!(filter_conformance,      "filter.tsv");
 conformance_tsv_test!(web_conformance,         "web.tsv");
 conformance_tsv_test!(financial_conformance,   "financial.tsv");
+
+/// P1.5 workbook fixtures — cross-sheet refs, named ranges, date-typed scalars
+/// (pipeline-generated, core issue #527; registration also proposed in PR #562).
+///
+/// Report-only (non-blocking) until the engine gains workbook support:
+/// P1.2 reference grammar (#524) + P1.3 resolver resolve cross-sheet/named
+/// refs.  P1.4 (#526) adds `date`-typed row handling and volatile-row pinning
+/// via `Engine::evaluate_at` (see `pinned_now_serial`).  Once P1.2/P1.3 land,
+/// switch this to `conformance_tsv_test!` so every row blocks CI.
+#[test]
+fn workbook_conformance_report() {
+    run_tsv_fixture_report(&fixture("workbook.tsv"));
+}
 
 /// Known-bug regression baseline.
 ///

--- a/crates/core/tests/conformance_reporter.rs
+++ b/crates/core/tests/conformance_reporter.rs
@@ -94,6 +94,15 @@ fn infer_type(v: &Value) -> &'static str {
     }
 }
 
+/// Top-left element of a (possibly nested) array value — the anchor-cell
+/// view of an unspilled array result (P1.4, #526); mirrors conformance.rs.
+fn top_left(v: &Value) -> &Value {
+    match v {
+        Value::Array(items) if !items.is_empty() => top_left(&items[0]),
+        other => other,
+    }
+}
+
 fn values_match(actual: &Value, expected: &Value, expected_type: &str) -> bool {
     if expected_type == "array" {
         let literal = match expected {
@@ -112,6 +121,8 @@ fn values_match(actual: &Value, expected: &Value, expected_type: &str) -> bool {
             values_match(a, e, infer_type(e))
         });
     }
+
+    let actual = top_left(actual);
 
     match (actual, expected) {
         (Value::Number(a), Value::Number(b)) => (a - b).abs() <= b.abs() * 1e-4 + 1e-10,

--- a/crates/core/tests/integration.rs
+++ b/crates/core/tests/integration.rs
@@ -1,4 +1,20 @@
 mod helpers;
+
+/// Top-left (anchor-cell) element of a possibly-array result.
+///
+/// P1.4 (#526): the engine returns array results unspilled.  These tests
+/// were verified against the Google Sheets anchor cell (the top-left
+/// element of the spilled range), which is what the workbook/surface
+/// layer's single-cell view shows -- so they assert on the top-left
+/// element of the unspilled array.
+fn top_left(v: Value) -> Value {
+    match v {
+        Value::Array(items) if !items.is_empty() => {
+            top_left(items.into_iter().next().unwrap())
+        }
+        other => other,
+    }
+}
 use truecalc_core::{Value, ErrorKind};
 use helpers::{eval, eval_with};
 
@@ -131,20 +147,20 @@ fn debug_counta_array() {
 
 #[test]
 fn choosecols_select_single_column() {
-    // GS scalar context: first element of [[2],[5]] -> 2
-    assert_eq!(helpers::eval("=CHOOSECOLS({1,2,3;4,5,6},2)"), Value::Number(2.0));
+    // anchor-cell (top-left) view of [[2],[5]] -> 2
+    assert_eq!(top_left(helpers::eval("=CHOOSECOLS({1,2,3;4,5,6},2)")), Value::Number(2.0));
 }
 
 #[test]
 fn choosecols_select_multiple_columns() {
-    // GS scalar context: first element of [[1,3],[4,6]] -> 1
-    assert_eq!(helpers::eval("=CHOOSECOLS({1,2,3;4,5,6},1,3)"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1,3],[4,6]] -> 1
+    assert_eq!(top_left(helpers::eval("=CHOOSECOLS({1,2,3;4,5,6},1,3)")), Value::Number(1.0));
 }
 
 #[test]
 fn choosecols_negative_index_from_end() {
-    // GS scalar context: first element of [[3],[6]] -> 3
-    assert_eq!(helpers::eval("=CHOOSECOLS({1,2,3;4,5,6},-1)"), Value::Number(3.0));
+    // anchor-cell (top-left) view of [[3],[6]] -> 3
+    assert_eq!(top_left(helpers::eval("=CHOOSECOLS({1,2,3;4,5,6},-1)")), Value::Number(3.0));
 }
 
 #[test]
@@ -161,20 +177,20 @@ fn choosecols_out_of_bounds_returns_value_error() {
 
 #[test]
 fn chooserows_select_single_row() {
-    // GS scalar context: first element of [3,4] -> 3
-    assert_eq!(helpers::eval("=CHOOSEROWS({1,2;3,4;5,6},2)"), Value::Number(3.0));
+    // anchor-cell (top-left) view of [3,4] -> 3
+    assert_eq!(top_left(helpers::eval("=CHOOSEROWS({1,2;3,4;5,6},2)")), Value::Number(3.0));
 }
 
 #[test]
 fn chooserows_select_multiple_rows_reorder() {
-    // GS scalar context: first element of [[5,6],[1,2]] -> 5
-    assert_eq!(helpers::eval("=CHOOSEROWS({1,2;3,4;5,6},3,1)"), Value::Number(5.0));
+    // anchor-cell (top-left) view of [[5,6],[1,2]] -> 5
+    assert_eq!(top_left(helpers::eval("=CHOOSEROWS({1,2;3,4;5,6},3,1)")), Value::Number(5.0));
 }
 
 #[test]
 fn chooserows_negative_index_from_end() {
-    // GS scalar context: first element of [5,6] -> 5
-    assert_eq!(helpers::eval("=CHOOSEROWS({1,2;3,4;5,6},-1)"), Value::Number(5.0));
+    // anchor-cell (top-left) view of [5,6] -> 5
+    assert_eq!(top_left(helpers::eval("=CHOOSEROWS({1,2;3,4;5,6},-1)")), Value::Number(5.0));
 }
 
 #[test]
@@ -191,106 +207,106 @@ fn chooserows_out_of_bounds_returns_value_error() {
 
 #[test]
 fn hstack_two_column_vectors() {
-    // GS scalar context: first element of [[1,3],[2,4]] -> 1
-    assert_eq!(helpers::eval("=HSTACK({1;2},{3;4})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1,3],[2,4]] -> 1
+    assert_eq!(top_left(helpers::eval("=HSTACK({1;2},{3;4})")), Value::Number(1.0));
 }
 
 #[test]
 fn hstack_two_row_arrays() {
-    // GS scalar context: first element of [1,2,3,4] -> 1
-    assert_eq!(helpers::eval("=HSTACK({1,2},{3,4})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [1,2,3,4] -> 1
+    assert_eq!(top_left(helpers::eval("=HSTACK({1,2},{3,4})")), Value::Number(1.0));
 }
 
 #[test]
 fn hstack_three_scalars() {
-    // GS scalar context: first element of [1,2,3] -> 1
-    assert_eq!(helpers::eval("=HSTACK({1},{2},{3})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [1,2,3] -> 1
+    assert_eq!(top_left(helpers::eval("=HSTACK({1},{2},{3})")), Value::Number(1.0));
 }
 
 #[test]
 fn hstack_2d_arrays() {
-    // GS scalar context: first element of [[1,2,5],[3,4,6]] -> 1
-    assert_eq!(helpers::eval("=HSTACK({1,2;3,4},{5;6})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1,2,5],[3,4,6]] -> 1
+    assert_eq!(top_left(helpers::eval("=HSTACK({1,2;3,4},{5;6})")), Value::Number(1.0));
 }
 
 // ── VSTACK ────────────────────────────────────────────────────────────────────
 
 #[test]
 fn vstack_two_row_arrays() {
-    // GS scalar context: first element of [[1,2],[3,4]] -> 1
-    assert_eq!(helpers::eval("=VSTACK({1,2},{3,4})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1,2],[3,4]] -> 1
+    assert_eq!(top_left(helpers::eval("=VSTACK({1,2},{3,4})")), Value::Number(1.0));
 }
 
 #[test]
 fn vstack_three_rows() {
-    // GS scalar context: first element of [[1,2],[3,4],[5,6]] -> 1
-    assert_eq!(helpers::eval("=VSTACK({1,2},{3,4},{5,6})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1,2],[3,4],[5,6]] -> 1
+    assert_eq!(top_left(helpers::eval("=VSTACK({1,2},{3,4},{5,6})")), Value::Number(1.0));
 }
 
 #[test]
 fn vstack_2d_on_top_of_row() {
-    // GS scalar context: first element of [[1,2],[3,4],[5,6]] -> 1
-    assert_eq!(helpers::eval("=VSTACK({1,2;3,4},{5,6})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1,2],[3,4],[5,6]] -> 1
+    assert_eq!(top_left(helpers::eval("=VSTACK({1,2;3,4},{5,6})")), Value::Number(1.0));
 }
 
 // ── TOCOL ─────────────────────────────────────────────────────────────────────
 
 #[test]
 fn tocol_flattens_row_to_column() {
-    // GS scalar context: first element of [[1],[2],[3]] -> 1
-    assert_eq!(helpers::eval("=TOCOL({1,2,3})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1],[2],[3]] -> 1
+    assert_eq!(top_left(helpers::eval("=TOCOL({1,2,3})")), Value::Number(1.0));
 }
 
 #[test]
 fn tocol_flattens_2d_array() {
-    // GS scalar context: first element of [[1],[2],[3],[4]] -> 1
-    assert_eq!(helpers::eval("=TOCOL({1,2;3,4})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1],[2],[3],[4]] -> 1
+    assert_eq!(top_left(helpers::eval("=TOCOL({1,2;3,4})")), Value::Number(1.0));
 }
 
 #[test]
 fn tocol_single_element() {
-    // GS scalar context: TOCOL({5}) -> single-element array [5] -> first -> 5
-    assert_eq!(helpers::eval("=TOCOL({5})"), Value::Number(5.0));
+    // anchor-cell (top-left) view: TOCOL({5}) -> single-element array [5] -> first -> 5
+    assert_eq!(top_left(helpers::eval("=TOCOL({5})")), Value::Number(5.0));
 }
 
 // ── TOROW ─────────────────────────────────────────────────────────────────────
 
 #[test]
 fn torow_flattens_column_to_row() {
-    // GS scalar context: first element of [1,2,3] -> 1
-    assert_eq!(helpers::eval("=TOROW({1;2;3})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [1,2,3] -> 1
+    assert_eq!(top_left(helpers::eval("=TOROW({1;2;3})")), Value::Number(1.0));
 }
 
 #[test]
 fn torow_flattens_2d_array() {
-    // GS scalar context: first element of [1,2,3,4] -> 1
-    assert_eq!(helpers::eval("=TOROW({1,2;3,4})"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [1,2,3,4] -> 1
+    assert_eq!(top_left(helpers::eval("=TOROW({1,2;3,4})")), Value::Number(1.0));
 }
 
 #[test]
 fn torow_single_element() {
-    // GS scalar context: TOROW({7}) -> [7] -> first -> 7
-    assert_eq!(helpers::eval("=TOROW({7})"), Value::Number(7.0));
+    // anchor-cell (top-left) view: TOROW({7}) -> [7] -> first -> 7
+    assert_eq!(top_left(helpers::eval("=TOROW({7})")), Value::Number(7.0));
 }
 
 // ── WRAPCOLS ──────────────────────────────────────────────────────────────────
 
 #[test]
 fn wrapcols_evenly_divisible() {
-    // GS scalar context: first element of [[1,3,5],[2,4,6]] -> 1
-    assert_eq!(helpers::eval("=WRAPCOLS({1,2,3,4,5,6},2)"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1,3,5],[2,4,6]] -> 1
+    assert_eq!(top_left(helpers::eval("=WRAPCOLS({1,2,3,4,5,6},2)")), Value::Number(1.0));
 }
 
 #[test]
 fn wrapcols_with_padding() {
-    // GS scalar context: first element of [[1,3,5],[2,4,Empty]] -> 1
-    assert_eq!(helpers::eval("=WRAPCOLS({1,2,3,4,5},2)"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1,3,5],[2,4,Empty]] -> 1
+    assert_eq!(top_left(helpers::eval("=WRAPCOLS({1,2,3,4,5},2)")), Value::Number(1.0));
 }
 
 #[test]
 fn wrapcols_wrap_count_equals_length() {
-    // GS scalar context: first element of [[1],[2],[3]] -> 1
-    assert_eq!(helpers::eval("=WRAPCOLS({1,2,3},3)"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1],[2],[3]] -> 1
+    assert_eq!(top_left(helpers::eval("=WRAPCOLS({1,2,3},3)")), Value::Number(1.0));
 }
 
 #[test]
@@ -302,20 +318,20 @@ fn wrapcols_invalid_wrap_count_returns_value_error() {
 
 #[test]
 fn wraprows_evenly_divisible() {
-    // GS scalar context: first element of [[1,2,3],[4,5,6]] -> 1
-    assert_eq!(helpers::eval("=WRAPROWS({1,2,3,4,5,6},3)"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1,2,3],[4,5,6]] -> 1
+    assert_eq!(top_left(helpers::eval("=WRAPROWS({1,2,3,4,5,6},3)")), Value::Number(1.0));
 }
 
 #[test]
 fn wraprows_with_padding() {
-    // GS scalar context: first element of [[1,2,3],[4,5,Empty]] -> 1
-    assert_eq!(helpers::eval("=WRAPROWS({1,2,3,4,5},3)"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [[1,2,3],[4,5,Empty]] -> 1
+    assert_eq!(top_left(helpers::eval("=WRAPROWS({1,2,3,4,5},3)")), Value::Number(1.0));
 }
 
 #[test]
 fn wraprows_wrap_count_equals_length() {
-    // GS scalar context: first element of [1,2,3] -> 1
-    assert_eq!(helpers::eval("=WRAPROWS({1,2,3},3)"), Value::Number(1.0));
+    // anchor-cell (top-left) view of [1,2,3] -> 1
+    assert_eq!(top_left(helpers::eval("=WRAPROWS({1,2,3},3)")), Value::Number(1.0));
 }
 
 #[test]
@@ -327,20 +343,20 @@ fn wraprows_invalid_wrap_count_returns_value_error() {
 
 #[test]
 fn sortby_ascending_by_key() {
-    // Sort {10;20;30} by key {3;1;2} ascending -> {20;30;10}; GS scalar context: 20
-    assert_eq!(helpers::eval("=SORTBY({10;20;30},{3;1;2},1)"), Value::Number(20.0));
+    // Sort {10;20;30} by key {3;1;2} ascending -> {20;30;10}; anchor-cell (top-left) view: 20
+    assert_eq!(top_left(helpers::eval("=SORTBY({10;20;30},{3;1;2},1)")), Value::Number(20.0));
 }
 
 #[test]
 fn sortby_descending_by_key() {
-    // Sort {10;20;30} by key {3;1;2} descending -> {10;30;20}; GS scalar context: 10
-    assert_eq!(helpers::eval("=SORTBY({10;20;30},{3;1;2},-1)"), Value::Number(10.0));
+    // Sort {10;20;30} by key {3;1;2} descending -> {10;30;20}; anchor-cell (top-left) view: 10
+    assert_eq!(top_left(helpers::eval("=SORTBY({10;20;30},{3;1;2},-1)")), Value::Number(10.0));
 }
 
 #[test]
 fn sortby_default_ascending() {
-    // GS scalar context: first element of [[10],[20],[30]] -> 10
-    assert_eq!(helpers::eval("=SORTBY({30;10;20},{3;1;2})"), Value::Number(10.0));
+    // anchor-cell (top-left) view of [[10],[20],[30]] -> 10
+    assert_eq!(top_left(helpers::eval("=SORTBY({30;10;20},{3;1;2})")), Value::Number(10.0));
 }
 
 #[test]
@@ -355,20 +371,20 @@ fn sortby_mismatched_key_length_returns_value_error() {
 
 #[test]
 fn mmult_2x2_identity() {
-    // GS scalar context: first element of [[5,6],[7,8]] -> 5
-    assert_eq!(helpers::eval("=MMULT({1,0;0,1},{5,6;7,8})"), Value::Number(5.0));
+    // anchor-cell (top-left) view of [[5,6],[7,8]] -> 5
+    assert_eq!(top_left(helpers::eval("=MMULT({1,0;0,1},{5,6;7,8})")), Value::Number(5.0));
 }
 
 #[test]
 fn mmult_2x2_matrices() {
-    // {1,2;3,4} * {5,6;7,8} = {19,22;43,50}; GS scalar context: 19
-    assert_eq!(helpers::eval("=MMULT({1,2;3,4},{5,6;7,8})"), Value::Number(19.0));
+    // {1,2;3,4} * {5,6;7,8} = {19,22;43,50}; anchor-cell (top-left) view: 19
+    assert_eq!(top_left(helpers::eval("=MMULT({1,2;3,4},{5,6;7,8})")), Value::Number(19.0));
 }
 
 #[test]
 fn mmult_1x2_by_2x1() {
-    // {1,2} * {3;4} = 11; GS scalar context: [11] -> 11
-    assert_eq!(helpers::eval("=MMULT({1,2},{3;4})"), Value::Number(11.0));
+    // {1,2} * {3;4} = 11; anchor-cell (top-left) view: [11] -> 11
+    assert_eq!(top_left(helpers::eval("=MMULT({1,2},{3;4})")), Value::Number(11.0));
 }
 
 #[test]
@@ -433,20 +449,20 @@ fn frequency_all_above_bin() {
 
 #[test]
 fn index_returns_whole_row() {
-    // INDEX({1,2,3;4,5,6}, 1) -> [1,2,3]; GS scalar context: 1
-    assert_eq!(helpers::eval("=INDEX({1,2,3;4,5,6},1)"), Value::Number(1.0));
+    // INDEX({1,2,3;4,5,6}, 1) -> [1,2,3]; anchor-cell (top-left) view: 1
+    assert_eq!(top_left(helpers::eval("=INDEX({1,2,3;4,5,6},1)")), Value::Number(1.0));
 }
 
 #[test]
 fn index_returns_second_row() {
-    // GS scalar context: first element of [4,5,6] -> 4
-    assert_eq!(helpers::eval("=INDEX({1,2,3;4,5,6},2)"), Value::Number(4.0));
+    // anchor-cell (top-left) view of [4,5,6] -> 4
+    assert_eq!(top_left(helpers::eval("=INDEX({1,2,3;4,5,6},2)")), Value::Number(4.0));
 }
 
 #[test]
 fn index_returns_whole_column() {
-    // INDEX({1,2;3,4}, 0, 1) -> [[1],[3]]; GS scalar context: 1
-    assert_eq!(helpers::eval("=INDEX({1,2;3,4},0,1)"), Value::Number(1.0));
+    // INDEX({1,2;3,4}, 0, 1) -> [[1],[3]]; anchor-cell (top-left) view: 1
+    assert_eq!(top_left(helpers::eval("=INDEX({1,2;3,4},0,1)")), Value::Number(1.0));
 }
 
 #[test]
@@ -463,6 +479,6 @@ fn index_out_of_bounds_col_returns_ref_error() {
 
 #[test]
 fn transpose_single_element_passthrough() {
-    // TRANSPOSE({1}) -> [1]; GS scalar context: first -> 1
-    assert_eq!(helpers::eval("=TRANSPOSE({1})"), Value::Number(1.0));
+    // TRANSPOSE({1}) -> [1]; anchor-cell (top-left) view: first -> 1
+    assert_eq!(top_left(helpers::eval("=TRANSPOSE({1})")), Value::Number(1.0));
 }

--- a/crates/core/tests/property_volatile.rs
+++ b/crates/core/tests/property_volatile.rs
@@ -75,16 +75,30 @@ fn randarray_cells_are_independent() {
     // If result isn't an array of numbers, skip — function may not be implemented
 }
 
-// 4. RANDARRAY(2,3) in scalar context returns the first element (a number in [0,1))
+// 4. RANDARRAY(2,3) returns the full 2x3 array, unspilled (P1.4, #526),
+//    with every element a number in [0,1)
 #[test]
 fn randarray_shape_is_correct() {
     let v = run("=RANDARRAY(2,3)");
-    // GS scalar context: array-returning formulas yield first element.
-    let n = match &v {
-        Value::Number(n) => *n,
-        other => panic!("RANDARRAY(2,3) did not return a scalar number in GS scalar context: {:?}", other),
+    let rows = match &v {
+        Value::Array(rows) => rows,
+        other => panic!("RANDARRAY(2,3) did not return an array: {:?}", other),
     };
-    assert!(n >= 0.0 && n < 1.0, "RANDARRAY(2,3) first element out of [0,1): {}", n);
+    assert_eq!(rows.len(), 2, "RANDARRAY(2,3) should have 2 rows: {:?}", v);
+    for row in rows {
+        let cols = match row {
+            Value::Array(cols) => cols,
+            other => panic!("RANDARRAY(2,3) row is not an array: {:?}", other),
+        };
+        assert_eq!(cols.len(), 3, "RANDARRAY(2,3) row should have 3 columns: {:?}", v);
+        for cell in cols {
+            let n = match cell {
+                Value::Number(n) => *n,
+                other => panic!("RANDARRAY(2,3) element is not a number: {:?}", other),
+            };
+            assert!((0.0..1.0).contains(&n), "RANDARRAY(2,3) element out of [0,1): {}", n);
+        }
+    }
 }
 
 // 5. RANDBETWEEN(1,10) returns an integer in [1, 10] on each of 100 calls

--- a/crates/core/tests/value_completeness.rs
+++ b/crates/core/tests/value_completeness.rs
@@ -1,0 +1,229 @@
+//! P1.4 (issue #526) — value-level completeness.
+//!
+//! Blocking coverage for the two P1.4 concerns:
+//!
+//! 1. **Date serial semantics per engine flavor** — the Sheets date system
+//!    (day 0 = 1899-12-30, no 1900 leap-year bug, +1900 year rule) and the
+//!    date-type production rule (JSON schema spec §6: a value is date-typed
+//!    iff the fixtures pipeline observed Google Sheets producing a Date).
+//! 2. **Unspilled arrays** — array values flow through evaluation whole;
+//!    spilling (or collapsing to the top-left element for a single-cell
+//!    view) is the workbook/surface layer's job.
+//!
+//! Every expected value in the date tests below is pipeline-verified: it is
+//! taken verbatim from `tests/fixtures/google_sheets/workbook.tsv` (DATE_TYPE
+//! block, PR #559) — none are self-confirmed.  The full fixture file also runs
+//! through the non-blocking `workbook_conformance_report` harness; these
+//! assertions make the P1.4 subset blocking without waiting for the
+//! cross-sheet/named-range support (P1.2/P1.3) the rest of the file needs.
+
+use std::collections::HashMap;
+use truecalc_core::{Engine, ErrorKind, Value};
+
+/// Pinned "now" for volatile rows: workbook.tsv DATE_TYPE meta
+/// `evaluatedAt = 2026-06-07T23:50:56.808Z`, sheet timezone `Etc/GMT`
+/// (= UTC), i.e. local day serial 46180 plus the time-of-day fraction.
+const PINNED_NOW: f64 = 46180.0 + (23.0 * 3600.0 + 50.0 * 60.0 + 56.808) / 86400.0;
+
+fn eval(formula: &str) -> Value {
+    Engine::sheets().evaluate(formula, &HashMap::new())
+}
+
+fn eval_at(formula: &str, now_serial: f64) -> Value {
+    Engine::sheets().evaluate_at(formula, &HashMap::new(), now_serial)
+}
+
+// ── Date-type production (workbook.tsv DATE_TYPE rows) ──────────────────────
+
+#[test]
+fn date_returns_a_date_typed_value() {
+    // workbook.tsv: =DATE(2026,6,7) → 46180 (date)
+    assert_eq!(eval("=DATE(2026,6,7)"), Value::Date(46180.0));
+}
+
+#[test]
+fn n_of_date_is_a_plain_number() {
+    // workbook.tsv: =N(DATE(2026,6,7)) → 46180 (number)
+    assert_eq!(eval("=N(DATE(2026,6,7))"), Value::Number(46180.0));
+}
+
+#[test]
+fn date_plus_one_day_stays_date_typed() {
+    // workbook.tsv: =DATE(2026,6,7)+1 → 46181 (date)
+    assert_eq!(eval("=DATE(2026,6,7)+1"), Value::Date(46181.0));
+}
+
+#[test]
+fn date_arithmetic_across_month_boundary_stays_date_typed() {
+    // workbook.tsv: =DATE(2026,6,30)+1 → 46204 (date)
+    assert_eq!(eval("=DATE(2026,6,30)+1"), Value::Date(46204.0));
+}
+
+#[test]
+fn date_minus_date_is_a_plain_number() {
+    // workbook.tsv: =DATE(2026,6,7)-DATE(2026,6,1) → 6 (number)
+    assert_eq!(eval("=DATE(2026,6,7)-DATE(2026,6,1)"), Value::Number(6.0));
+}
+
+#[test]
+fn isdate_observations() {
+    // workbook.tsv: =ISDATE(DATE(2026,6,7)) → TRUE,
+    // =ISDATE(DATE(2026,6,7)+1) → TRUE, =ISDATE(N(DATE(2026,6,7))) → FALSE
+    assert_eq!(eval("=ISDATE(DATE(2026,6,7))"), Value::Bool(true));
+    assert_eq!(eval("=ISDATE(DATE(2026,6,7)+1)"), Value::Bool(true));
+    assert_eq!(eval("=ISDATE(N(DATE(2026,6,7)))"), Value::Bool(false));
+}
+
+#[test]
+fn plain_serial_literal_stays_number_typed() {
+    // workbook.tsv: =45000 → 45000 (number)
+    assert_eq!(eval("=45000"), Value::Number(45000.0));
+}
+
+#[test]
+fn date_compares_equal_to_its_own_serial() {
+    // workbook.tsv: =DATE(2026,6,7)=N(DATE(2026,6,7)) → TRUE (coercion)
+    assert_eq!(eval("=DATE(2026,6,7)=N(DATE(2026,6,7))"), Value::Bool(true));
+}
+
+#[test]
+fn datevalue_is_number_typed() {
+    // workbook.tsv: =DATEVALUE("2026-06-07") → 46180 (number),
+    // =ISDATE(DATEVALUE("2026-06-07")) → FALSE
+    assert_eq!(eval("=DATEVALUE(\"2026-06-07\")"), Value::Number(46180.0));
+    assert_eq!(eval("=ISDATE(DATEVALUE(\"2026-06-07\"))"), Value::Bool(false));
+}
+
+#[test]
+fn eomonth_is_date_typed() {
+    // workbook.tsv: =ISDATE(EOMONTH(DATE(2026,6,7),0)) → TRUE
+    assert_eq!(eval("=ISDATE(EOMONTH(DATE(2026,6,7),0))"), Value::Bool(true));
+}
+
+// ── Sheets date serial system (epoch, divergence zone, +1900 rule) ──────────
+
+#[test]
+fn sheets_epoch_anchor_serials() {
+    // workbook.tsv: =TEXT(0,"yyyy-mm-dd") → 1899-12-30,
+    //               =TEXT(1,"yyyy-mm-dd") → 1899-12-31
+    assert_eq!(eval("=TEXT(0,\"yyyy-mm-dd\")"), Value::Text("1899-12-30".into()));
+    assert_eq!(eval("=TEXT(1,\"yyyy-mm-dd\")"), Value::Text("1899-12-31".into()));
+}
+
+#[test]
+fn sheets_has_no_1900_leap_year_bug() {
+    // workbook.tsv: =N(DATE(1900,1,1)) → 2, =N(DATE(1900,2,28)) → 60,
+    // =N(DATE(1900,3,1)) → 61 — 60 and 61 are adjacent days; there is no
+    // serial for the nonexistent 1900-02-29 in the Sheets system.
+    assert_eq!(eval("=N(DATE(1900,1,1))"), Value::Number(2.0));
+    assert_eq!(eval("=N(DATE(1900,2,28))"), Value::Number(60.0));
+    assert_eq!(eval("=N(DATE(1900,3,1))"), Value::Number(61.0));
+}
+
+#[test]
+fn nonexistent_1900_02_29_rolls_over_to_march_first() {
+    // workbook.tsv: =N(DATE(1900,2,29)) → 61,
+    //               =TEXT(DATE(1900,2,29),"yyyy-mm-dd") → 1900-03-01
+    assert_eq!(eval("=N(DATE(1900,2,29))"), Value::Number(61.0));
+    assert_eq!(
+        eval("=TEXT(DATE(1900,2,29),\"yyyy-mm-dd\")"),
+        Value::Text("1900-03-01".into())
+    );
+}
+
+#[test]
+fn plus_1900_year_rule_for_year_arguments_below_1900() {
+    // workbook.tsv: =N(DATE(1899,12,31)) → 693962 (3799-12-31),
+    // =N(DATE(1899,12,30)) → 693961, =N(DATE(1899,12,25)) → 693956,
+    // =TEXT(DATE(1899,12,25),"yyyy-mm-dd") → 3799-12-25
+    assert_eq!(eval("=N(DATE(1899,12,31))"), Value::Number(693962.0));
+    assert_eq!(eval("=N(DATE(1899,12,30))"), Value::Number(693961.0));
+    assert_eq!(eval("=N(DATE(1899,12,25))"), Value::Number(693956.0));
+    assert_eq!(
+        eval("=TEXT(DATE(1899,12,25),\"yyyy-mm-dd\")"),
+        Value::Text("3799-12-25".into())
+    );
+}
+
+// ── Volatile pinning via Engine::evaluate_at (RecalcContext hook) ────────────
+
+#[test]
+fn pinned_today_matches_fixture_row() {
+    // workbook.tsv (volatile, pinned by meta.evaluatedAt): =TODAY() → 46180 (date)
+    assert_eq!(eval_at("=TODAY()", PINNED_NOW), Value::Date(46180.0));
+}
+
+#[test]
+fn pinned_today_is_date_typed() {
+    // workbook.tsv: =ISDATE(TODAY()) → TRUE
+    assert_eq!(eval_at("=ISDATE(TODAY())", PINNED_NOW), Value::Bool(true));
+}
+
+#[test]
+fn today_minus_today_within_one_recalc_is_zero() {
+    // workbook.tsv: =TODAY()-TODAY() → 0 (number)
+    assert_eq!(eval_at("=TODAY()-TODAY()", PINNED_NOW), Value::Number(0.0));
+}
+
+#[test]
+fn pinned_now_returns_the_pinned_serial() {
+    assert_eq!(eval_at("=NOW()", PINNED_NOW), Value::Number(PINNED_NOW));
+}
+
+#[test]
+fn evaluate_at_is_deterministic() {
+    assert_eq!(
+        eval_at("=TODAY()&\"|\"&NOW()", PINNED_NOW),
+        eval_at("=TODAY()&\"|\"&NOW()", PINNED_NOW)
+    );
+}
+
+#[test]
+fn evaluate_at_rejects_non_finite_now() {
+    assert_eq!(
+        eval_at("=TODAY()", f64::NAN),
+        Value::Error(ErrorKind::Num)
+    );
+    assert_eq!(
+        eval_at("=TODAY()", f64::INFINITY),
+        Value::Error(ErrorKind::Num)
+    );
+}
+
+// ── Unspilled arrays ─────────────────────────────────────────────────────────
+
+#[test]
+fn array_literal_flows_through_unspilled() {
+    // The engine returns the whole array; collapsing to the top-left element
+    // (the old behavior) or spilling is the workbook/surface layer's job.
+    assert_eq!(
+        eval("={1,2,3}"),
+        Value::Array(vec![
+            Value::Number(1.0),
+            Value::Number(2.0),
+            Value::Number(3.0),
+        ])
+    );
+}
+
+#[test]
+fn array_through_function_result_is_unspilled() {
+    // An array produced inside a larger expression also survives whole.
+    assert_eq!(
+        eval("=IF(TRUE,{1,2},0)"),
+        Value::Array(vec![Value::Number(1.0), Value::Number(2.0)])
+    );
+}
+
+// ── Excel flavor stays stubbed behind the flavor enum (allowed by #526) ─────
+
+#[test]
+fn excel_evaluation_is_still_stubbed() {
+    // The Excel 1900 date system (incl. leap-bug serial 60) is locked behind
+    // the flavor enum in `eval::functions::date::serial`; Excel *evaluation*
+    // remains a stub returning an error (exact kind tracked by #556).
+    assert!(matches!(
+        Engine::excel().evaluate("=DATE(2026,6,7)", &HashMap::new()),
+        Value::Error(_)
+    ));
+}


### PR DESCRIPTION
## What

Implements P1.4 (workbook development plan §P1.4; scope ADR 2026-06-07): value-level completeness for the evaluator — unspilled arrays and date serial semantics per engine flavor, verified against the new pipeline-generated `workbook.tsv` fixtures (PR #559).

### Unspilled arrays
- `Engine::evaluate` no longer collapses `Value::Array` to its first element (`first_of_array` removed). Arrays flow through evaluation whole; spilling — or collapsing to the top-left element for a single-cell view — is the workbook/surface layer's job.
- Test harnesses (`conformance.rs`, `conformance_reporter.rs`, `integration.rs` via a `top_left` helper) compare scalar-typed fixture rows against the **anchor-cell (top-left) element** of array actuals, which is exactly what the fixtures pipeline observes in the Google Sheets anchor cell. No fixture TSVs were touched.
- Surface note: `crates/wasm` maps top-level arrays to its existing `array not supported` error (previously it saw the collapsed first element); `crates/mcp` already serialises arrays. Left as-is per surface-owned presentation policy — flagging for owner visibility.

### Date-type production (JSON schema spec §6: date-typed iff fixtures observe a Date)
- `DATE`, `EOMONTH`, `TODAY` return `Value::Date`; `date + number` stays date-typed (`=DATE(2026,6,7)+1` → date 46181); `date − date` is a plain number; `N()`/`DATEVALUE` results stay plain numbers; comparisons coerce `Date` ↔ `Number` (`=DATE(2026,6,7)=N(DATE(2026,6,7))` → TRUE). All per workbook.tsv DATE_TYPE rows.
- `DATE` now applies Sheets' **+1900 year rule** for year arguments 0–1899 (pipeline-verified: `=N(DATE(1899,12,31))` → 693962).

### Date serial systems per engine flavor
- Sheets: day 0 = 1899-12-30, no 1900 leap-year bug (serial 60 = 1900-02-28; `DATE(1900,2,29)` rolls over to serial 61).
- Excel: 1900 system **including** the Lotus 1-2-3 leap-bug serial 60 (fictitious 1900-02-29), locked behind the flavor enum as `excel_ymd_to_serial` / `excel_serial_to_ymd` in `eval::functions::date::serial`. Excel *evaluation* stays stubbed, as #526 explicitly allows (the stub's error kind is tracked separately in #556 — not changed here to avoid scope creep; the new test only asserts `Value::Error(_)`).

### Volatile pinning (RecalcContext hook)
- New `Engine::evaluate_at(formula, vars, now_serial)` pins `NOW()`/`TODAY()` to a local-time spreadsheet serial (rejects non-finite with `#NUM!`). Same formula + variables + `now_serial` ⇒ identical result. This is the core-level hook the workbook layer's `RecalcContext` (timestamp + IANA tz, scope ADR Decision 3) builds on.
- `NOW`/`TODAY` are now lazy-registered so they can read the pinned context; unpinned behavior (ambient local clock) is unchanged.
- The conformance harness evaluates `workbook.tsv` through `evaluate_at`, pinned to the DATE_TYPE meta `evaluatedAt = 2026-06-07T23:50:56.808Z` (`Etc/GMT`, per the fixtures-repo snapshot `snapshots/2026-06-08/google_sheets/workbook/` meta sidecars documented in #559), making the volatile `=TODAY()` rows deterministic.

### Harness + fixtures wiring
- `expected_type = date` now parses to `Value::Date` and **only** matches a `Value::Date` actual — losing the date type is a conformance failure (production rule enforced). The lenient `Date`-actual vs `number`-expected arm is kept for legacy `date.tsv` rows.
- `workbook.tsv` registered as a **report-only** category. This overlaps with open PR #562 (same test name and intent, trivially resolvable either merge order); the registration here additionally needs the `date`/pinning support introduced in this PR for the DATE_TYPE rows to pass. `conformance.lock` `data_as_of` bumped to `2026-06-08` (also mirrors #562).
- Report result: **`workbook.tsv: 31 passed, 42 open`** — all 30 DATE_TYPE rows pass (incl. the 3 pinned volatile rows); the 42 open rows are cross-sheet refs and named ranges, which need P1.2 (#524) / P1.3.

### Tests
- New blocking `crates/core/tests/value_completeness.rs` (23 tests): every expected value taken verbatim from pipeline-verified workbook.tsv rows (none self-confirmed) + `evaluate_at` determinism/rejection + unspilled-array shape.
- New `crates/core/src/eval/functions/date/serial_tests.rs`: Sheets epoch anchors and the flavor-locked Excel 1900 system (serials 59/60/61, divergence zone, pre-1900 rejection).
- Updated to the new contracts: `eomonth` unit tests (`Value::Date`), `array_literal` tests (unspilled), `integration.rs` array-shape tests (anchor-cell view via `top_left`), `property_volatile.rs` `RANDARRAY(2,3)` (asserts full 2×3 shape).
- Full run: `cargo test -p truecalc-core` — **2925 passed, 0 failed**; `cargo clippy -p truecalc-core -p truecalc-wasm -- -D warnings` clean; `cargo check -p truecalc-wasm` clean.

## Notes for reviewer
- Date-typed propagation is deliberately **minimal/conservative**: only `+` with exactly one `Date` operand produces a `Date` (the only propagation the fixtures observe). `−`, `×`, `÷`, `^`, and `date + date` produce plain numbers until a fixture observes otherwise.
- `evaluate_at` takes a pre-converted local serial rather than a timestamp+tz pair; the tz conversion (vendored tzdata per the scope ADR) belongs to the workbook crate's `RecalcContext`, keeping core dependency-free.

Closes #526