### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.6.5"
+version = "0.7.0"
 dependencies = [
  "calamine",
  "chrono",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.6.5"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.6.5"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-workbook"
-version = "0.6.5"
+version = "0.7.0"
 dependencies = [
  "icu_casemap",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp", "crates/workbook", "xtask
 resolver = "2"
 
 [workspace.package]
-version = "0.6.5"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/truecalc/core/compare/truecalc-core-v0.6.5...truecalc-core-v0.7.0) - 2026-06-08
+
+### Added
+
+- *(core)* Resolver trait, evaluate_with_resolver, extract_refs (P1.3)
+- P1.2 reference grammar — Sheet1!A1, quoted sheets, cross-sheet ranges, named refs
+
+### Fixed
+
+- quote TRUE/FALSE sheet names in canonical display
+
+### Other
+
+- *(core)* fix EmptyResolver intra-doc link; clarify workbook.tsv report-only rationale
+- Merge branch 'main' into feat/526-value-completeness
+- Merge branch 'main' into feat/524-reference-grammar
+
 ## [0.6.5](https://github.com/truecalc/core/compare/truecalc-core-v0.6.4...truecalc-core-v0.6.5) - 2026-06-08
 
 ### Added

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -12,6 +12,6 @@ name = "truecalc-mcp"
 path = "src/main.rs"
 
 [dependencies]
-truecalc-core = { path = "../core", version = "0.6" }
+truecalc-core = { path = "../core", version = "0.7" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/workbook/CHANGELOG.md
+++ b/crates/workbook/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.7.0](https://github.com/truecalc/core/compare/truecalc-workbook-v0.6.5...truecalc-workbook-v0.7.0) - 2026-06-08
+
+### Added
+
+- *(workbook)* canonical JCS serializer + strict from_json (P2.3)
+- Workbook/Worksheet/Cell value types + serde
+
+### Fixed
+
+- *(workbook)* enable serde_json float_roundtrip for byte-stable round-trip
+- *(review)* enforce schema-version reader rule, reject null formula and 1x1 arrays
+
+### Other
+
+- *(workbook)* round-trip + schema-validation property tests + v1 schema (P2.4)


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.6.5 -> 0.7.0 (⚠ API breaking changes)
* `truecalc-mcp`: 0.6.5 -> 0.7.0
* `truecalc-workbook`: 0.6.5 -> 0.7.0 (✓ API compatible changes)

### ⚠ `truecalc-core` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type EvalCtx is no longer Send, in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/mod.rs:33
  type EvalCtx is no longer Sync, in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/mod.rs:33
  type EvalCtx is no longer UnwindSafe, in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/mod.rs:33
  type EvalCtx is no longer RefUnwindSafe, in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/mod.rs:33
  type EvalCtx is no longer Send, in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/mod.rs:33
  type EvalCtx is no longer Sync, in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/mod.rs:33
  type EvalCtx is no longer UnwindSafe, in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/mod.rs:33
  type EvalCtx is no longer RefUnwindSafe, in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/mod.rs:33

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field EvalCtx.resolver in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/mod.rs:39
  field EvalCtx.resolver in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/mod.rs:39
  field Context.now_serial in /tmp/.tmpq99etk/core/crates/core/src/eval/context/mod.rs:14
  field Context.now_serial in /tmp/.tmpq99etk/core/crates/core/src/eval/context/mod.rs:14

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant Expr:Reference in /tmp/.tmpq99etk/core/crates/core/src/parser/ast.rs:38
  variant Expr:Reference in /tmp/.tmpq99etk/core/crates/core/src/parser/ast.rs:38
  variant Expr:Reference in /tmp/.tmpq99etk/core/crates/core/src/parser/ast.rs:38

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/function_parameter_count_changed.ron

Failed in:
  truecalc_core::eval::functions::date::now::now_fn now takes 2 parameters instead of 1, in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/date/now/mod.rs:14
  truecalc_core::eval::functions::date::today::today_fn now takes 2 parameters instead of 1, in /tmp/.tmpq99etk/core/crates/core/src/eval/functions/date/today/mod.rs:13
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.7.0](https://github.com/truecalc/core/compare/truecalc-core-v0.6.5...truecalc-core-v0.7.0) - 2026-06-08

### Added

- *(core)* Resolver trait, evaluate_with_resolver, extract_refs (P1.3)
- P1.2 reference grammar — Sheet1!A1, quoted sheets, cross-sheet ranges, named refs

### Fixed

- quote TRUE/FALSE sheet names in canonical display

### Other

- *(core)* fix EmptyResolver intra-doc link; clarify workbook.tsv report-only rationale
- Merge branch 'main' into feat/526-value-completeness
- Merge branch 'main' into feat/524-reference-grammar
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.6.5](https://github.com/truecalc/core/compare/truecalc-mcp-v0.6.4...truecalc-mcp-v0.6.5) - 2026-06-08

### Added

- engine-explicit API — Engine::sheets()/excel() required entry points
</blockquote>

## `truecalc-workbook`

<blockquote>

## [0.7.0](https://github.com/truecalc/core/compare/truecalc-workbook-v0.6.5...truecalc-workbook-v0.7.0) - 2026-06-08

### Added

- *(workbook)* canonical JCS serializer + strict from_json (P2.3)
- Workbook/Worksheet/Cell value types + serde

### Fixed

- *(workbook)* enable serde_json float_roundtrip for byte-stable round-trip
- *(review)* enforce schema-version reader rule, reject null formula and 1x1 arrays

### Other

- *(workbook)* round-trip + schema-validation property tests + v1 schema (P2.4)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).