### PR TITLE
fix(ci): robust wasm-pack install (drop flaky curl|sh installer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,9 @@ jobs:
         run: cargo deny check
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
 
       - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
 
       - name: Build WASM
         run: wasm-pack build crates/wasm --target bundler


### PR DESCRIPTION
## Problem
The `Install wasm-pack` step uses `curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh`, which downloads from GitHub Releases and **rate-limits intermittently**. It failed repeatedly today (PR #563 twice; `main`'s own CI red), and is the same step that broke the **v0.6.5 npm publish** job in the Release workflow.

## Fix
Replace all three occurrences (ci.yml web + release.yml bundler builds) with `taiki-e/install-action@v2` (`tool: wasm-pack`) — installs prebuilt binaries with built-in retries. This action is already trusted in `ci.yml` for `nextest` and `cargo-llvm-cov`, so no new supply-chain surface.

No source or test changes; workflow-only.