### PR TITLE
feat(core): Resolver trait, evaluate_with_resolver, extract_refs (P1.3, #525)

### DIFF
--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::eval::functions::Registry;
-use crate::eval::{evaluate_expr, Context, EvalCtx};
+use crate::eval::{evaluate_expr, Context, EvalCtx, Resolver};
 use crate::parser::{parse_formula, Expr};
 use crate::types::{ErrorKind, ParseError, Value};
 
@@ -100,6 +100,74 @@ impl Engine {
             return Value::Error(ErrorKind::Num);
         }
         self.evaluate_inner(formula, variables, Some(now_serial))
+    }
+
+    /// Evaluate a formula string, resolving references through `resolver`.
+    ///
+    /// This is the workbook-facing entry point: unlike [`Engine::evaluate`]
+    /// (which reads references from a variable map and treats anything unbound
+    /// as [`Value::Empty`]), every cell, range, and name reference that is not
+    /// shadowed by a LAMBDA parameter is read through `resolver`. The resolver
+    /// owns workbook semantics -- `#REF!` for a missing sheet, `#NAME?` for an
+    /// undefined name, ranges materialized to [`Value::Array`]. See
+    /// [`Resolver`].
+    ///
+    /// The engine flavor stays explicit: `Engine::excel().evaluate_with_resolver`
+    /// returns `#N/A` until Excel evaluation lands, exactly like
+    /// [`Engine::evaluate`].
+    ///
+    /// ```
+    /// use truecalc_core::{Engine, ErrorKind, Ref, Resolver, Value};
+    ///
+    /// struct OneSheet;
+    /// impl Resolver for OneSheet {
+    ///     fn resolve(&mut self, r: &Ref) -> Value {
+    ///         match r {
+    ///             Ref::Cell { sheet: Some(s), .. } if s == "Data" => Value::Number(10.0),
+    ///             Ref::Cell { sheet: Some(_), .. } => Value::Error(ErrorKind::Ref),
+    ///             _ => Value::Empty,
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// let engine = Engine::sheets();
+    /// assert_eq!(engine.evaluate_with_resolver("=Data!A1", &mut OneSheet), Value::Number(10.0));
+    /// assert_eq!(
+    ///     engine.evaluate_with_resolver("=Gone!A1", &mut OneSheet),
+    ///     Value::Error(ErrorKind::Ref),
+    /// );
+    /// ```
+    pub fn evaluate_with_resolver(&self, formula: &str, resolver: &mut impl Resolver) -> Value {
+        self.evaluate_with_resolver_at(formula, resolver, None)
+    }
+
+    /// Like [`Engine::evaluate_with_resolver`], but with the volatile date
+    /// functions (`NOW`, `TODAY`) pinned to `now_serial` (see
+    /// [`Engine::evaluate_at`]). Returns `Value::Error(ErrorKind::Num)` if
+    /// `now_serial` is not finite.
+    pub fn evaluate_with_resolver_at(
+        &self,
+        formula: &str,
+        resolver: &mut impl Resolver,
+        now_serial: Option<f64>,
+    ) -> Value {
+        if let Some(n) = now_serial {
+            if !n.is_finite() {
+                return Value::Error(ErrorKind::Num);
+            }
+        }
+        if self.flavor == Flavor::Excel {
+            return Value::Error(ErrorKind::NA);
+        }
+        match parse_formula(formula) {
+            Err(_) => Value::Error(ErrorKind::Value),
+            Ok(expr) => {
+                let mut ctx = Context::empty();
+                ctx.now_serial = now_serial;
+                let mut eval_ctx = EvalCtx::with_resolver(ctx, &self.registry, resolver);
+                evaluate_expr(&expr, &mut eval_ctx)
+            }
+        }
     }
 
     fn evaluate_inner(

--- a/crates/core/src/eval/context/mod.rs
+++ b/crates/core/src/eval/context/mod.rs
@@ -37,6 +37,14 @@ impl Context {
             .unwrap_or(Value::Empty)
     }
 
+    /// Look up a binding by name (case-insensitive), distinguishing an absent
+    /// binding (`None`) from one explicitly bound to [`Value::Empty`]
+    /// (`Some(Value::Empty)`). Used by the evaluator to decide whether a
+    /// reference should fall through to the resolver.
+    pub fn lookup(&self, name: &str) -> Option<Value> {
+        self.vars.get(&name.to_uppercase()).cloned()
+    }
+
     /// Insert or overwrite a binding. Returns the previous value if one existed.
     pub fn set(&mut self, name: String, value: Value) -> Option<Value> {
         self.vars.insert(name.to_uppercase(), value)

--- a/crates/core/src/eval/functions/mod.rs
+++ b/crates/core/src/eval/functions/mod.rs
@@ -15,21 +15,54 @@ pub mod web;
 
 use std::collections::HashMap;
 use crate::eval::context::Context;
+use crate::eval::resolver::Resolver;
 use crate::parser::ast::Expr;
 use crate::types::{ErrorKind, Value};
 
 // ── EvalCtx ───────────────────────────────────────────────────────────────
 
-/// Bundles the variable context and function registry for use during evaluation.
-/// Passed to lazy functions so they can recursively evaluate sub-expressions.
+/// Bundles the variable context, function registry, and reference resolver
+/// for use during evaluation. Passed to lazy functions so they can recursively
+/// evaluate sub-expressions.
+///
+/// References that are not bound as local variables (e.g. a LAMBDA parameter)
+/// are read through `resolver`; see [`crate::Resolver`]. The default resolver
+/// ([`EmptyResolver`]) maps every reference to [`Value::Empty`], preserving the
+/// historical contract of [`crate::Engine::evaluate`].
 pub struct EvalCtx<'r> {
     pub ctx: Context,
     pub registry: &'r Registry,
+    /// Resolver for references not bound as local variables. `None` ⇒ such
+    /// references read as [`Value::Empty`] (the historical
+    /// [`crate::Engine::evaluate`] contract).
+    pub resolver: Option<&'r mut dyn Resolver>,
 }
 
 impl<'r> EvalCtx<'r> {
+    /// Build an `EvalCtx` with no resolver: unbound references read as
+    /// [`Value::Empty`]. Use [`EvalCtx::with_resolver`] to supply real
+    /// workbook semantics.
     pub fn new(ctx: Context, registry: &'r Registry) -> Self {
-        Self { ctx, registry }
+        Self { ctx, registry, resolver: None }
+    }
+
+    /// Build an `EvalCtx` that resolves references through `resolver`.
+    pub fn with_resolver(
+        ctx: Context,
+        registry: &'r Registry,
+        resolver: &'r mut dyn Resolver,
+    ) -> Self {
+        Self { ctx, registry, resolver: Some(resolver) }
+    }
+
+    /// Resolve a reference that was not bound as a local variable, delegating
+    /// to [`EvalCtx::resolver`] when present and falling back to
+    /// [`Value::Empty`] otherwise.
+    pub fn resolve_ref(&mut self, r: &crate::parser::refs::Ref) -> Value {
+        match self.resolver {
+            Some(ref mut res) => res.resolve(r),
+            None => Value::Empty,
+        }
     }
 }
 

--- a/crates/core/src/eval/functions/mod.rs
+++ b/crates/core/src/eval/functions/mod.rs
@@ -26,9 +26,10 @@ use crate::types::{ErrorKind, Value};
 /// evaluate sub-expressions.
 ///
 /// References that are not bound as local variables (e.g. a LAMBDA parameter)
-/// are read through `resolver`; see [`crate::Resolver`]. The default resolver
-/// ([`EmptyResolver`]) maps every reference to [`Value::Empty`], preserving the
-/// historical contract of [`crate::Engine::evaluate`].
+/// are read through `resolver`; see [`crate::Resolver`]. When `resolver` is
+/// `None` (the default, via [`EvalCtx::new`]) every such reference reads as
+/// [`Value::Empty`], preserving the historical contract of
+/// [`crate::Engine::evaluate`].
 pub struct EvalCtx<'r> {
     pub ctx: Context,
     pub registry: &'r Registry,

--- a/crates/core/src/eval/mod.rs
+++ b/crates/core/src/eval/mod.rs
@@ -1,9 +1,11 @@
 pub mod context;
 pub mod coercion;
 pub mod functions;
+pub mod resolver;
 
 pub use context::Context;
 pub use functions::{EvalCtx, FunctionMeta, Registry};
+pub use resolver::{extract_refs, Resolver};
 
 use crate::parser::ast::{BinaryOp, Expr, UnaryOp};
 use crate::types::{ErrorKind, Value};
@@ -29,10 +31,20 @@ pub fn evaluate_expr(expr: &Expr, ctx: &mut EvalCtx<'_>) -> Value {
         }
         Expr::Text(s, _)   => Value::Text(s.clone()),
         Expr::Bool(b, _)   => Value::Bool(*b),
-        Expr::Variable(name, _) => ctx.ctx.get(name),
-        // Sheet-qualified references resolve through the same delegated
-        // context, keyed by the canonical reference text (e.g. "DATA!A1").
-        Expr::Reference(r, _) => ctx.ctx.get(&r.to_string()),
+        // Bare identifiers: a local binding (LAMBDA parameter, caller-supplied
+        // variable, or canonical-text variable) wins; otherwise the name is
+        // classified into a `Ref` and read through the resolver (P1.3, #525).
+        Expr::Variable(name, _) => match ctx.ctx.lookup(name) {
+            Some(v) => v,
+            None => ctx.resolve_ref(&crate::parser::refs::Ref::classify(name)),
+        },
+        // Sheet-qualified references: a binding under the canonical reference
+        // text wins (back-compat with variable-supplied refs); otherwise the
+        // reference is read through the resolver.
+        Expr::Reference(r, _) => match ctx.ctx.lookup(&r.to_string()) {
+            Some(v) => v,
+            None => ctx.resolve_ref(r),
+        },
 
         // ── Unary ops ───────────────────────────────────────────────────────
         Expr::UnaryOp { op, operand, .. } => {

--- a/crates/core/src/eval/resolver.rs
+++ b/crates/core/src/eval/resolver.rs
@@ -1,0 +1,127 @@
+//! Reference resolution (P1.3, issue #525).
+//!
+//! Core is the *language*: it parses formulas and evaluates them, but it has
+//! no notion of a sheet, a grid, or a named range. [`Resolver`] is the seam
+//! through which an embedding application (the workbook crate, a host app, a
+//! test harness) supplies the *value* a [`Ref`] points at.
+//!
+//! The evaluator calls [`Resolver::resolve`] every time a formula reads a
+//! reference that is not already bound as a local variable (e.g. a LAMBDA
+//! parameter). The resolver owns all workbook semantics:
+//!
+//! - a cross-sheet cell ref to a missing sheet -> [`ErrorKind::Ref`] (`#REF!`),
+//! - a bare name that is not a defined name -> [`ErrorKind::Name`] (`#NAME?`),
+//! - an empty cell -> [`Value::Empty`],
+//! - a range -> [`Value::Array`] of the cells in reading order.
+//!
+//! Core never invents these; it simply forwards the [`Ref`] and returns
+//! whatever the resolver decides.
+//!
+//! [`ErrorKind::Ref`]: crate::ErrorKind::Ref
+//! [`ErrorKind::Name`]: crate::ErrorKind::Name
+//!
+//! ```
+//! use std::collections::HashMap;
+//! use truecalc_core::{Engine, Ref, Resolver, Value};
+//!
+//! /// A resolver backed by a flat map keyed by canonical reference text.
+//! struct MapResolver(HashMap<String, Value>);
+//!
+//! impl Resolver for MapResolver {
+//!     fn resolve(&mut self, r: &Ref) -> Value {
+//!         self.0.get(&r.to_string()).cloned().unwrap_or(Value::Empty)
+//!     }
+//! }
+//!
+//! let mut cells = HashMap::new();
+//! cells.insert("Data!A1".to_string(), Value::Number(10.0));
+//! cells.insert("Data!B1".to_string(), Value::Number(5.0));
+//! let mut resolver = MapResolver(cells);
+//!
+//! let engine = Engine::sheets();
+//! let result = engine.evaluate_with_resolver("=Data!A1+Data!B1", &mut resolver);
+//! assert_eq!(result, Value::Number(15.0));
+//! ```
+
+use crate::parser::ast::Expr;
+use crate::parser::refs::Ref;
+use crate::types::Value;
+
+/// Resolves a [`Ref`] to the [`Value`] it points at.
+///
+/// Implementors own all workbook semantics: missing sheets, undefined names,
+/// empty cells, and range materialization. See the module docs for the
+/// expected error mapping (`#REF!` for missing sheets, `#NAME?` for undefined
+/// names). The evaluator only calls this for references that are not shadowed
+/// by a local binding such as a LAMBDA parameter.
+pub trait Resolver {
+    /// Return the value of `r`. The receiver is `&mut self` so resolvers may
+    /// memoize, count reads, or lazily materialize ranges.
+    fn resolve(&mut self, r: &Ref) -> Value;
+}
+
+/// Collect every [`Ref`] a formula reads, in left-to-right source order,
+/// without re-parsing -- the input that lets the workbook build a dependency
+/// graph (plan section 3.2).
+///
+/// Both reference shapes are reported as a [`Ref`]:
+///
+/// - sheet-qualified references ([`Expr::Reference`]) are returned verbatim;
+/// - bare identifiers ([`Expr::Variable`]) -- which the parser keeps as
+///   variable nodes for compatibility -- are classified with
+///   [`Ref::classify`], so `A1` becomes [`Ref::Cell`], `A1:D4` becomes
+///   [`Ref::Range`], and `TAX_RATE` becomes [`Ref::Name`].
+///
+/// Refs appearing in *any* argument position of a function call are found,
+/// because the walk descends into every child expression. Duplicates are
+/// preserved (a formula that reads `A1` twice yields two entries); callers
+/// that want a dependency set deduplicate themselves.
+///
+/// ```
+/// use truecalc_core::{extract_refs, CellAddr, Engine, Ref};
+///
+/// let expr = Engine::sheets().parse("=SUM(A1, Data!B2, TAX_RATE)").unwrap();
+/// let refs = extract_refs(&expr);
+/// assert_eq!(
+///     refs,
+///     vec![
+///         Ref::Cell { sheet: None, addr: CellAddr { col: 1, row: 1 } },
+///         Ref::Cell { sheet: Some("Data".to_string()), addr: CellAddr { col: 2, row: 2 } },
+///         Ref::Name("TAX_RATE".to_string()),
+///     ],
+/// );
+/// ```
+pub fn extract_refs(expr: &Expr) -> Vec<Ref> {
+    let mut refs = Vec::new();
+    collect_refs(expr, &mut refs);
+    refs
+}
+
+fn collect_refs(expr: &Expr, out: &mut Vec<Ref>) {
+    match expr {
+        Expr::Reference(r, _) => out.push(r.clone()),
+        Expr::Variable(name, _) => out.push(Ref::classify(name)),
+        Expr::Number(..) | Expr::Text(..) | Expr::Bool(..) => {}
+        Expr::UnaryOp { operand, .. } => collect_refs(operand, out),
+        Expr::BinaryOp { left, right, .. } => {
+            collect_refs(left, out);
+            collect_refs(right, out);
+        }
+        Expr::FunctionCall { args, .. } => {
+            for arg in args {
+                collect_refs(arg, out);
+            }
+        }
+        Expr::Array(elems, _) => {
+            for elem in elems {
+                collect_refs(elem, out);
+            }
+        }
+        Expr::Apply { func, call_args, .. } => {
+            collect_refs(func, out);
+            for arg in call_args {
+                collect_refs(arg, out);
+            }
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,6 +15,7 @@ pub use parser::{CellAddr, Ref};
 pub use types::{ErrorKind, ParseError, Value};
 
 pub use eval::functions::{FunctionMeta, Registry};
+pub use eval::{extract_refs, Resolver};
 
 use std::collections::HashMap;
 

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -456,11 +456,16 @@ conformance_tsv_test!(financial_conformance,   "financial.tsv");
 /// P1.5 workbook fixtures — cross-sheet refs, named ranges, date-typed scalars
 /// (pipeline-generated, core issue #527; registered via PR #562).
 ///
-/// Report-only (non-blocking) until the engine gains workbook support:
-/// P1.2 reference grammar (#524) + P1.3 resolver resolve cross-sheet/named
-/// refs.  P1.4 (#526) adds `date`-typed row handling and volatile-row pinning
-/// via `Engine::evaluate_at` (see `pinned_now_serial`).  Once P1.2/P1.3 land,
-/// switch this to `conformance_tsv_test!` so every row blocks CI.
+/// Report-only (non-blocking). The language pieces are now in place — P1.2
+/// reference grammar (#524) and P1.3 resolver (#525) resolve cross-sheet/named
+/// refs, and P1.4 (#526) adds `date`-typed row handling and volatile-row
+/// pinning via `Engine::evaluate_at` (see `pinned_now_serial`).  This stays
+/// report-only because the blocking runner evaluates with an empty variable
+/// map and no resolver, and the fixtures pipeline does not yet commit the
+/// authored *input* model (the cell values these formulas read) needed to seed
+/// a `Resolver`.  Hardcoding those inputs here would self-confirm expected
+/// values, so the switch to `conformance_tsv_test!` waits on a fixtures-side
+/// input-model sidecar (tracked separately).
 #[test]
 fn workbook_conformance_report() {
     run_tsv_fixture_report(&fixture("workbook.tsv"));

--- a/crates/core/tests/extract_refs_registry.rs
+++ b/crates/core/tests/extract_refs_registry.rs
@@ -1,0 +1,65 @@
+//! Registry-driven generated test for `extract_refs` (P1.3, #525 acceptance).
+//!
+//! For every user-facing function in the registry, synthesize a call that
+//! places a distinct cell reference in each argument position, then assert
+//! `extract_refs` recovers exactly those references in order. This is
+//! mechanically self-verifiable: the registry is the single source of truth,
+//! so the test grows automatically as functions are added, and it can never
+//! drift from a hand-maintained list.
+
+use truecalc_core::{extract_refs, CellAddr, Engine, Ref, Registry};
+
+/// Cell reference used in argument position `i` (0-based): A1, B1, C1, ...
+/// for the first 26 positions, which is more than any function's arity.
+fn ref_arg_text(i: usize) -> String {
+    let col = (b'A' + (i as u8)) as char;
+    format!("{}1", col)
+}
+
+fn expected_ref(i: usize) -> Ref {
+    Ref::Cell {
+        sheet: None,
+        addr: CellAddr { col: (i as u32) + 1, row: 1 },
+    }
+}
+
+#[test]
+fn extract_refs_finds_refs_in_every_argument_position() {
+    let registry = Registry::new();
+    let engine = Engine::sheets();
+    let mut names = registry.metadata_names();
+    names.sort();
+
+    // Try arities 1..=3 ref args; a function parses as a call for whichever
+    // arity it accepts syntactically. We assert on every formula that parses.
+    let arg_counts = [1usize, 2, 3];
+
+    let mut checked = 0usize;
+    for name in &names {
+        for &n in &arg_counts {
+            let args: Vec<String> = (0..n).map(ref_arg_text).collect();
+            let formula = format!("={}({})", name, args.join(", "));
+
+            let Ok(expr) = engine.parse(&formula) else {
+                continue;
+            };
+            let refs = extract_refs(&expr);
+            let expected: Vec<Ref> = (0..n).map(expected_ref).collect();
+            assert_eq!(
+                refs, expected,
+                "extract_refs mismatch for `{}` (n={})",
+                formula, n
+            );
+            checked += 1;
+        }
+    }
+
+    // Sanity: the registry is non-trivial and the loop actually did work.
+    assert!(
+        checked >= names.len(),
+        "expected at least one checked formula per function ({} functions, {} checked)",
+        names.len(),
+        checked
+    );
+    assert!(names.len() > 100, "registry unexpectedly small: {}", names.len());
+}

--- a/crates/core/tests/resolver.rs
+++ b/crates/core/tests/resolver.rs
@@ -1,0 +1,376 @@
+//! P1.3 resolver — trait, `evaluate_with_resolver`, and `extract_refs` (#525).
+//!
+//! Core stays the language: these tests supply a `Resolver` implementation
+//! that owns workbook semantics (a fixed `Data` / `Quoted Name` sheet model
+//! and a handful of defined names) and assert the engine evaluates
+//! cross-sheet and named references through it. The model here is a *test*
+//! resolver — it does not self-confirm Google Sheets values; the canonical
+//! values live in the immutable `workbook.tsv` fixture and are exercised by
+//! the conformance harness.
+
+use std::collections::HashMap;
+use truecalc_core::{extract_refs, CellAddr, Engine, ErrorKind, Ref, Resolver, Value};
+
+/// Resolver over a fixed two-sheet workbook plus a few defined names, matching
+/// the layout the `workbook.tsv` conformance fixture was authored against.
+struct ModelResolver {
+    cells: HashMap<(String, u32, u32), Value>,
+    sheets: Vec<String>,
+    names: HashMap<String, Ref>,
+}
+
+impl ModelResolver {
+    fn new() -> Self {
+        let mut cells = HashMap::new();
+        let mut put = |sheet: &str, a1: &str, v: Value| {
+            let addr = CellAddr::parse(a1).unwrap();
+            cells.insert((sheet.to_string(), addr.col, addr.row), v);
+        };
+        put("Data", "A1", Value::Number(10.0));
+        put("Data", "A2", Value::Number(20.0));
+        put("Data", "A3", Value::Number(30.0));
+        put("Data", "B1", Value::Number(5.0));
+        put("Data", "B2", Value::Number(20.0));
+        put("Data", "B3", Value::Number(40.0));
+        put("Data", "C1", Value::Text("hello".to_string()));
+        put("Data", "D1", Value::Bool(true));
+        put("Data", "E1", Value::Date(46180.0));
+        put("Quoted Name", "A1", Value::Number(100.0));
+        put("Quoted Name", "A2", Value::Number(200.0));
+        put("Quoted Name", "A3", Value::Number(300.0));
+        put("Quoted Name", "B1", Value::Number(7.0));
+
+        let mut names = HashMap::new();
+        names.insert("TAX_RATE".to_string(), Ref::Cell {
+            sheet: Some("Config".to_string()),
+            addr: CellAddr::parse("A1").unwrap(),
+        });
+        names.insert("PRICES".to_string(), Ref::Range {
+            sheet: Some("Data".to_string()),
+            start: CellAddr::parse("A1").unwrap(),
+            end: CellAddr::parse("A3").unwrap(),
+        });
+        names.insert("GRID".to_string(), Ref::Range {
+            sheet: Some("Data".to_string()),
+            start: CellAddr::parse("A1").unwrap(),
+            end: CellAddr::parse("B1").unwrap(),
+        });
+        names.insert("QUOTED_VALS".to_string(), Ref::Range {
+            sheet: Some("Quoted Name".to_string()),
+            start: CellAddr::parse("A1").unwrap(),
+            end: CellAddr::parse("A3").unwrap(),
+        });
+        cells.insert(("Config".to_string(), 1, 1), Value::Number(0.0825));
+
+        Self {
+            cells,
+            sheets: vec![
+                "Data".to_string(),
+                "Quoted Name".to_string(),
+                "Config".to_string(),
+            ],
+            names,
+        }
+    }
+
+    fn sheet_exists(&self, name: &str) -> bool {
+        self.sheets.iter().any(|s| s.eq_ignore_ascii_case(name))
+    }
+
+    fn canon_sheet(&self, name: &str) -> Option<&str> {
+        self.sheets
+            .iter()
+            .find(|s| s.eq_ignore_ascii_case(name))
+            .map(|s| s.as_str())
+    }
+
+    fn cell(&self, sheet: &str, addr: &CellAddr) -> Value {
+        let Some(canon) = self.canon_sheet(sheet) else {
+            return Value::Error(ErrorKind::Ref);
+        };
+        self.cells
+            .get(&(canon.to_string(), addr.col, addr.row))
+            .cloned()
+            .unwrap_or(Value::Empty)
+    }
+
+    fn range(&self, sheet: &str, start: &CellAddr, end: &CellAddr) -> Value {
+        if !self.sheet_exists(sheet) {
+            return Value::Error(ErrorKind::Ref);
+        }
+        let mut out = Vec::new();
+        for row in start.row..=end.row {
+            for col in start.col..=end.col {
+                let addr = CellAddr { col, row };
+                out.push(self.cell(sheet, &addr));
+            }
+        }
+        Value::Array(out)
+    }
+}
+
+impl Resolver for ModelResolver {
+    fn resolve(&mut self, r: &Ref) -> Value {
+        match r {
+            Ref::Cell { sheet: Some(s), addr } => self.cell(s, addr),
+            Ref::Range { sheet: Some(s), start, end } => self.range(s, start, end),
+            Ref::Cell { sheet: None, .. } | Ref::Range { sheet: None, .. } => Value::Empty,
+            Ref::Name(name) => match self.names.get(&name.to_uppercase()).cloned() {
+                Some(target) => self.resolve(&target),
+                None => Value::Error(ErrorKind::Name),
+            },
+        }
+    }
+}
+
+fn eval(formula: &str) -> Value {
+    let mut r = ModelResolver::new();
+    Engine::sheets().evaluate_with_resolver(formula, &mut r)
+}
+
+#[test]
+fn cross_sheet_cell_to_number() {
+    assert_eq!(eval("=Data!A1"), Value::Number(10.0));
+}
+
+#[test]
+fn cross_sheet_cells_in_arithmetic() {
+    assert_eq!(eval("=Data!A1+Data!B1"), Value::Number(15.0));
+}
+
+#[test]
+fn cross_sheet_lowercase_sheet_name() {
+    assert_eq!(eval("=data!A1"), Value::Number(10.0));
+}
+
+#[test]
+fn cross_sheet_text_cell() {
+    assert_eq!(eval("=Data!C1"), Value::Text("hello".to_string()));
+}
+
+#[test]
+fn cross_sheet_boolean_cell() {
+    assert_eq!(eval("=Data!D1"), Value::Bool(true));
+}
+
+#[test]
+fn cross_sheet_date_cell_is_date_typed() {
+    assert_eq!(eval("=Data!E1"), Value::Date(46180.0));
+}
+
+#[test]
+fn cross_sheet_empty_cell_concats_as_blank() {
+    assert_eq!(eval("=\"<\"&Data!H9&\">\""), Value::Text("<>".to_string()));
+}
+
+#[test]
+fn quoted_sheet_name_cell() {
+    assert_eq!(eval("='Quoted Name'!A1"), Value::Number(100.0));
+}
+
+#[test]
+fn quoted_sheet_name_arithmetic() {
+    assert_eq!(eval("='Quoted Name'!A1+'Quoted Name'!B1"), Value::Number(107.0));
+}
+
+#[test]
+fn cross_sheet_column_range_sum() {
+    assert_eq!(eval("=SUM(Data!A1:A3)"), Value::Number(60.0));
+}
+
+#[test]
+fn cross_sheet_rectangular_range_sum() {
+    assert_eq!(eval("=SUM(Data!A1:B3)"), Value::Number(125.0));
+}
+
+#[test]
+fn cross_sheet_range_average() {
+    assert_eq!(eval("=AVERAGE(Data!A1:A3)"), Value::Number(20.0));
+}
+
+#[test]
+fn cross_sheet_count_matches_bare_range() {
+    // The resolver delivers the same materialized array a bare range would, so
+    // COUNT over the cross-sheet range equals COUNT over the equivalent bare
+    // range bound as a variable. (We assert wiring, not COUNT semantics — the
+    // canonical COUNT value lives in the immutable workbook.tsv fixture.)
+    let bare = Value::Array(vec![
+        Value::Number(10.0), Value::Number(5.0), Value::Text("hello".to_string()), Value::Bool(true),
+        Value::Number(20.0), Value::Number(20.0), Value::Empty, Value::Empty,
+        Value::Number(30.0), Value::Number(40.0), Value::Empty, Value::Empty,
+    ]);
+    let mut vars = HashMap::new();
+    vars.insert("A1:D3".to_string(), bare);
+    let via_bare = Engine::sheets().evaluate("=COUNT(A1:D3)", &vars);
+    assert_eq!(eval("=COUNT(Data!A1:D3)"), via_bare);
+}
+
+#[test]
+fn quoted_sheet_range_sum() {
+    assert_eq!(eval("=SUM('Quoted Name'!A1:A3)"), Value::Number(600.0));
+}
+
+#[test]
+fn cross_sheet_ref_in_if() {
+    assert_eq!(eval("=IF(Data!A1>5,\"big\",\"small\")"), Value::Text("big".to_string()));
+}
+
+#[test]
+fn missing_sheet_cell_is_ref_error() {
+    assert_eq!(eval("=MissingSheet!A1"), Value::Error(ErrorKind::Ref));
+}
+
+#[test]
+fn missing_quoted_sheet_is_ref_error() {
+    assert_eq!(eval("='No Such Sheet'!A1"), Value::Error(ErrorKind::Ref));
+}
+
+#[test]
+fn missing_sheet_range_is_ref_error() {
+    assert_eq!(eval("=SUM(MissingSheet!A1:A3)"), Value::Error(ErrorKind::Ref));
+}
+
+#[test]
+fn missing_sheet_wrapped_in_iferror() {
+    assert_eq!(eval("=IFERROR(MissingSheet!A1,\"fallback\")"), Value::Text("fallback".to_string()));
+}
+
+#[test]
+fn scalar_named_range() {
+    assert_eq!(eval("=TAX_RATE"), Value::Number(0.0825));
+}
+
+#[test]
+fn scalar_named_range_arithmetic() {
+    assert_eq!(eval("=TAX_RATE*100"), Value::Number(8.25));
+}
+
+#[test]
+fn scalar_named_range_lowercase() {
+    assert_eq!(eval("=tax_rate"), Value::Number(0.0825));
+}
+
+#[test]
+fn column_range_name_sum() {
+    assert_eq!(eval("=SUM(PRICES)"), Value::Number(60.0));
+}
+
+#[test]
+fn column_range_name_max() {
+    assert_eq!(eval("=MAX(PRICES)"), Value::Number(30.0));
+}
+
+#[test]
+fn rectangular_range_name_sum() {
+    assert_eq!(eval("=SUM(GRID)"), Value::Number(15.0));
+}
+
+#[test]
+fn named_range_targeting_quoted_sheet() {
+    assert_eq!(eval("=SUM(QUOTED_VALS)"), Value::Number(600.0));
+}
+
+#[test]
+fn missing_name_is_name_error() {
+    assert_eq!(eval("=NOT_A_DEFINED_NAME"), Value::Error(ErrorKind::Name));
+}
+
+#[test]
+fn missing_name_inside_sum() {
+    assert_eq!(eval("=SUM(NOT_A_DEFINED_NAME)"), Value::Error(ErrorKind::Name));
+}
+
+#[test]
+fn missing_name_wrapped_in_iferror() {
+    assert_eq!(eval("=IFERROR(NOT_A_DEFINED_NAME,\"fallback\")"), Value::Text("fallback".to_string()));
+}
+
+#[test]
+fn lambda_parameter_shadows_resolver_name() {
+    assert_eq!(eval("=LAMBDA(X, X*2)(21)"), Value::Number(42.0));
+}
+
+#[test]
+fn extract_refs_finds_refs_in_every_position() {
+    let expr = Engine::sheets()
+        .parse("=SUM(A1, Data!B2, TAX_RATE, 'Quoted Name'!A1:A3)")
+        .unwrap();
+    assert_eq!(
+        extract_refs(&expr),
+        vec![
+            Ref::Cell { sheet: None, addr: CellAddr { col: 1, row: 1 } },
+            Ref::Cell { sheet: Some("Data".to_string()), addr: CellAddr { col: 2, row: 2 } },
+            Ref::Name("TAX_RATE".to_string()),
+            Ref::Range {
+                sheet: Some("Quoted Name".to_string()),
+                start: CellAddr { col: 1, row: 1 },
+                end: CellAddr { col: 1, row: 3 },
+            },
+        ],
+    );
+}
+
+#[test]
+fn extract_refs_classifies_bare_identifiers() {
+    let expr = Engine::sheets().parse("=A1:D4 + B7 - MYNAME").unwrap();
+    assert_eq!(
+        extract_refs(&expr),
+        vec![
+            Ref::Range {
+                sheet: None,
+                start: CellAddr { col: 1, row: 1 },
+                end: CellAddr { col: 4, row: 4 },
+            },
+            Ref::Cell { sheet: None, addr: CellAddr { col: 2, row: 7 } },
+            Ref::Name("MYNAME".to_string()),
+        ],
+    );
+}
+
+#[test]
+fn extract_refs_preserves_duplicates() {
+    let expr = Engine::sheets().parse("=A1+A1").unwrap();
+    let a1 = Ref::Cell { sheet: None, addr: CellAddr { col: 1, row: 1 } };
+    assert_eq!(extract_refs(&expr), vec![a1.clone(), a1]);
+}
+
+#[test]
+fn extract_refs_descends_into_nested_calls_and_arrays() {
+    let expr = Engine::sheets().parse("=IF(A1>0, {B2, C3}, Data!D4)").unwrap();
+    assert_eq!(
+        extract_refs(&expr),
+        vec![
+            Ref::Cell { sheet: None, addr: CellAddr { col: 1, row: 1 } },
+            Ref::Cell { sheet: None, addr: CellAddr { col: 2, row: 2 } },
+            Ref::Cell { sheet: None, addr: CellAddr { col: 3, row: 3 } },
+            Ref::Cell { sheet: Some("Data".to_string()), addr: CellAddr { col: 4, row: 4 } },
+        ],
+    );
+}
+
+#[test]
+fn extract_refs_ignores_literals() {
+    let expr = Engine::sheets().parse("=1 + 2 * 3").unwrap();
+    assert!(extract_refs(&expr).is_empty());
+}
+
+#[test]
+fn evaluate_with_resolver_at_pins_today() {
+    let mut r = ModelResolver::new();
+    let v = Engine::sheets().evaluate_with_resolver_at("=TODAY()", &mut r, Some(46180.0));
+    assert_eq!(v, Value::Date(46180.0));
+}
+
+#[test]
+fn evaluate_with_resolver_at_rejects_non_finite_now() {
+    let mut r = ModelResolver::new();
+    let v = Engine::sheets().evaluate_with_resolver_at("=1", &mut r, Some(f64::NAN));
+    assert_eq!(v, Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn excel_evaluate_with_resolver_is_na() {
+    let mut r = ModelResolver::new();
+    let v = Engine::excel().evaluate_with_resolver("=Data!A1", &mut r);
+    assert_eq!(v, Value::Error(ErrorKind::NA));
+}


### PR DESCRIPTION
## P1.3: Resolver trait + `evaluate_with_resolver` + `extract_refs` (#525)

Adds the reference-resolution seam so the workbook layer can supply the value behind a reference, while `truecalc-core` stays the *language* (no notion of sheets/grids).

### What's added
- **`Resolver` trait** — `resolve(&mut self, &Ref) -> Value`. Implementors own all workbook semantics: `#REF!` for a missing sheet, `#NAME?` for an undefined name, empty cells, and range materialization (`Value::Array` in reading order). `&mut self` lets resolvers memoize / lazily materialize.
- **`Engine::evaluate_with_resolver`** and **`evaluate_with_resolver_at`** — engine flavor stays explicit (Excel still returns `#N/A`); the `_at` variant pins volatile date functions, mirroring `evaluate_at`.
- **`extract_refs(&Expr) -> Vec<Ref>`** — walks the AST so the workbook can build dependency edges without re-parsing. Sheet-qualified refs (`Expr::Reference`) are returned verbatim; bare identifiers (`Expr::Variable`) are classified via `Ref::classify` (`A1` → `Cell`, `A1:D4` → `Range`, `NAME` → `Name`). Refs in every argument position are found; duplicates preserved.

### Design notes
- Evaluation routes **both** `Expr::Variable` and `Expr::Reference` through the resolver, but **only after a local-binding miss**, so LAMBDA parameters and caller-supplied variables still shadow references. `EvalCtx` carries `resolver: Option<&mut dyn Resolver>`; `None` ⇒ unbound refs read as `Value::Empty` — i.e. **zero behavior change** for the existing `Engine::evaluate(formula, &vars)` path.
- `Context::lookup` (new) distinguishes "absent binding" from "bound to Empty" so the fall-through to the resolver is correct.

### Tests (separate files, per repo rule)
- **Doc-tests** on the trait, `evaluate_with_resolver`, and `extract_refs`.
- `tests/resolver.rs` — a workbook-model `Resolver` exercising cross-sheet cells/ranges, lowercase + quoted sheet names, date-typed cells, named ranges (scalar + range, name→target indirection), `#REF!`/`#NAME?` errors, `IFERROR` recovery, LAMBDA shadowing, volatile pinning via `evaluate_with_resolver_at`, and the Excel `#N/A` stub.
- `tests/extract_refs_registry.rs` — the **registry-driven generated test** from the acceptance criteria: iterates the function registry, synthesizes a call per function with a distinct cell ref in each argument position, and asserts `extract_refs` recovers exactly those refs in order (mechanically self-verifiable; grows with the registry).

### Conformance note
The `workbook.tsv` harness stays **report-only**. Switching it to blocking requires a fixtures-pipeline **workbook-model sidecar** (the authored input cells the formulas reference) that does not exist in the repo yet. Confirmed via DeepWiki: the harness evaluates with an empty variable map and there is no committed model. Hardcoding inputs reverse-engineered from expected outputs would violate the no-self-confirm fixture rule, so that switch is left as the documented follow-up (depends on a fixtures-side artifact). The in-test `ModelResolver` demonstrates the resolver resolves the cross-sheet and named-range cases the fixture covers.

### Verification (local, sandbox)
- `cargo test -p truecalc-core --lib` → 2639 passed
- `cargo test -p truecalc-core --test resolver` → 38 passed; `--test extract_refs_registry` → green
- `cargo test -p truecalc-core --doc` → 4 passed (incl. the 2 new examples)
- `refs_eval`, `integration`, `registry`, `conformance`, `value_completeness` → all green (no regressions)
- `cargo clippy -p truecalc-core --lib -- -D warnings` → clean

Closes #525
