### PR TITLE
test(workbook): round-trip + schema-validation property tests (P2.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,10 +151,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -299,6 +340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +365,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -346,6 +402,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +435,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +456,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -401,6 +485,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -470,9 +564,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -526,7 +622,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -869,6 +976,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5fe5206f06e589caf25e79fc05ccdf91fca745685fe9fe1a13bbdfb479a631"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +1033,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1052,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "mime"
@@ -955,6 +1110,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1020,6 +1245,35 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1174,6 +1428,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e4e17ef386c5383591d07623d3de49cbc601156e7582973e6db98d66a57de2"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1648,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1729,6 +2058,8 @@ name = "truecalc-workbook"
 version = "0.6.5"
 dependencies = [
  "icu_casemap",
+ "jsonschema",
+ "proptest",
  "ryu-js",
  "serde",
  "serde_json",
@@ -1773,6 +2104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,10 +2152,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/workbook/Cargo.toml
+++ b/crates/workbook/Cargo.toml
@@ -13,3 +13,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["float_roundtrip"] }
 ryu-js = "1"
 icu_casemap = "2"
+
+[dev-dependencies]
+proptest = "1"
+jsonschema = { version = "0.46", default-features = false }

--- a/crates/workbook/schema/workbook.v1.schema.json
+++ b/crates/workbook/schema/workbook.v1.schema.json
@@ -1,0 +1,319 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://truecalc.dev/schema/workbook.v1.schema.json",
+  "title": "TrueCalc Workbook v1",
+  "description": "Structural schema for a TrueCalc workbook document (schema spec v1). Rules that JSON Schema cannot express -- canonical key ordering, ECMAScript number formatting, spill reconstruction, duplicate-key rejection, simple-case-fold uniqueness, named-range ref canonicality, and resource limits -- are governed by the prose spec and enforced by Workbook::from_json, not here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "engine",
+    "names",
+    "sheets",
+    "version"
+  ],
+  "properties": {
+    "engine": {
+      "enum": [
+        "sheets",
+        "excel"
+      ]
+    },
+    "version": {
+      "const": "1"
+    },
+    "names": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/namedRange"
+      }
+    },
+    "sheets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/worksheet"
+      }
+    }
+  },
+  "$defs": {
+    "worksheet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "cells",
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "cells": {
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[A-Z]{1,3}[1-9][0-9]{0,7}$"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/cell"
+          }
+        }
+      }
+    },
+    "cell": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "formula": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/value"
+        }
+      }
+    },
+    "namedRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "ref"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+        },
+        "ref": {
+          "type": "string"
+        }
+      }
+    },
+    "value": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "number"
+            },
+            "value": {
+              "type": "number"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "text"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "boolean"
+            },
+            "value": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "error"
+          ],
+          "properties": {
+            "type": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "empty"
+            },
+            "value": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "date"
+            },
+            "value": {
+              "type": "number"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "array"
+            },
+            "value": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/scalarValue"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "scalarValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "number"
+            },
+            "value": {
+              "type": "number"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "text"
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "boolean"
+            },
+            "value": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "error"
+          ],
+          "properties": {
+            "type": {
+              "const": "error"
+            },
+            "error": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "empty"
+            },
+            "value": {
+              "type": "null"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "const": "date"
+            },
+            "value": {
+              "type": "number"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/workbook/tests/roundtrip_property_tests.rs
+++ b/crates/workbook/tests/roundtrip_property_tests.rs
@@ -1,0 +1,210 @@
+//! Property tests (issue #531): canonical round-trip byte identity
+//! (`to_json ∘ from_json = id`), hash stability across round-trips, and a
+//! generator of structurally valid workbooks. Schema-validation of the golden
+//! files lives in `schema_validation_tests.rs`.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use proptest::prelude::*;
+use truecalc_workbook::{Cell, EngineFlavor, NamedRange, Value, Workbook, Worksheet};
+
+fn hash_of<T: Hash>(t: &T) -> u64 {
+    let mut h = DefaultHasher::new();
+    t.hash(&mut h);
+    h.finish()
+}
+
+/// A finite f64 that is representable in canonical form (no NaN/Inf).
+fn finite_f64() -> impl Strategy<Value = f64> {
+    prop_oneof![
+        any::<f64>().prop_filter("finite", |x| x.is_finite()),
+        Just(0.0),
+        Just(-0.0),
+        Just(1e21),
+        Just(1e-7),
+        Just(1e-6),
+        Just(0.1 + 0.2),
+        (-1000i64..1000).prop_map(|n| n as f64),
+    ]
+}
+
+/// A scalar (non-array) value.
+fn scalar_value() -> impl Strategy<Value = Value> {
+    prop_oneof![
+        finite_f64().prop_map(Value::Number),
+        ".*".prop_map(Value::Text),
+        any::<bool>().prop_map(Value::Boolean),
+        prop_oneof![
+            Just("#REF!"),
+            Just("#DIV/0!"),
+            Just("#VALUE!"),
+            Just("#N/A"),
+            Just("#NUM!"),
+        ]
+        .prop_map(|c| Value::Error(c.to_owned())),
+        Just(Value::Empty),
+        finite_f64().prop_map(Value::Date),
+    ]
+}
+
+/// A scalar value that is valid as an *anchor array element* (no Empty padding
+/// restriction here — empty elements are allowed in arrays per the spec).
+fn array_element() -> impl Strategy<Value = Value> {
+    scalar_value()
+}
+
+/// A 2-D array value (≥ 2 cells, rectangular) for spill anchors.
+fn array_value() -> impl Strategy<Value = Value> {
+    (1usize..3, 1usize..3)
+        .prop_filter("not 1x1", |(r, c)| !(*r == 1 && *c == 1))
+        .prop_flat_map(|(rows, cols)| {
+            proptest::collection::vec(
+                proptest::collection::vec(array_element(), cols..=cols),
+                rows..=rows,
+            )
+        })
+        .prop_map(Value::Array)
+}
+
+/// A literal cell value (never Empty — empty literal is rejected) or a formula
+/// cell. Returns the Cell plus the spill dims if it is an array anchor.
+fn cell_strategy() -> impl Strategy<Value = Cell> {
+    prop_oneof![
+        // Literal scalar (non-empty).
+        scalar_value()
+            .prop_filter("non-empty literal", |v| !matches!(v, Value::Empty))
+            .prop_map(|v| Cell::literal(v).unwrap()),
+        // Formula cell with a scalar value (incl. empty before recalc).
+        ("=[A-Z0-9+*/() ]{0,16}", scalar_value()).prop_map(|(f, v)| Cell::with_formula(f, v)),
+    ]
+}
+
+/// A small, well-spaced set of A1 addresses that never collide and leave room
+/// so a 2x2 array anchor never overlaps a neighbour.
+fn spaced_addresses(n: usize) -> Vec<String> {
+    // Columns A, D, G, ...; rows 1, 4, 7, ... — 3 apart in both axes.
+    let mut out = Vec::new();
+    let cols = ["A", "D", "G", "J"];
+    let rows = [1u32, 4, 7, 10];
+    'outer: for &r in &rows {
+        for &c in &cols {
+            out.push(format!("{c}{r}"));
+            if out.len() == n {
+                break 'outer;
+            }
+        }
+    }
+    out
+}
+
+/// A worksheet with up to a few well-spaced cells; at most one array anchor to
+/// keep spill rectangles trivially non-overlapping.
+fn worksheet_strategy(name: String) -> impl Strategy<Value = Worksheet> {
+    (0usize..4)
+        .prop_flat_map(|n| {
+            (
+                proptest::collection::vec(cell_strategy(), n..=n),
+                proptest::option::of(array_value()),
+            )
+        })
+        .prop_map(move |(cells, anchor)| {
+            let mut ws = Worksheet::new(name.clone());
+            let addrs = spaced_addresses(cells.len() + usize::from(anchor.is_some()));
+            let mut it = addrs.into_iter();
+            for cell in cells {
+                if let Some(addr) = it.next() {
+                    ws.cells_mut().insert(addr, cell);
+                }
+            }
+            if let Some(arr) = anchor {
+                if let Some(addr) = it.next() {
+                    ws.cells_mut()
+                        .insert(addr, Cell::with_formula("=SEQUENCE(2,2)", arr));
+                }
+            }
+            ws
+        })
+}
+
+/// A workbook with unique sheet names (Sheet0, Sheet1, …) and named ranges
+/// that target existing sheets with canonical refs.
+fn workbook_strategy() -> impl Strategy<Value = Workbook> {
+    let engine = prop_oneof![Just(EngineFlavor::Sheets), Just(EngineFlavor::Excel)];
+    (engine, 0usize..4)
+        .prop_flat_map(|(engine, n_sheets)| {
+            let sheets = (0..n_sheets)
+                .map(|i| worksheet_strategy(format!("Sheet{i}")).boxed())
+                .collect::<Vec<_>>();
+            (Just(engine), Just(n_sheets), sheets)
+        })
+        .prop_flat_map(|(engine, n_sheets, sheets)| {
+            // Up to 3 named ranges, each targeting an existing sheet; none when
+            // there are no sheets (a ref must target a real sheet).
+            let max_names = if n_sheets == 0 { 0usize } else { 3 };
+            (
+                Just(engine),
+                Just(sheets),
+                Just(n_sheets),
+                proptest::collection::vec(0usize..n_sheets.max(1), 0..=max_names),
+            )
+        })
+        .prop_map(|(engine, sheets, n_sheets, name_targets)| {
+            let mut wb = Workbook::new(engine);
+            for ws in sheets {
+                wb.sheets_mut().push(ws);
+            }
+            if n_sheets > 0 {
+                for (i, target) in name_targets.into_iter().enumerate() {
+                    let sheet_idx = target % n_sheets;
+                    wb.names_mut().push(NamedRange {
+                        name: format!("Name{i}"),
+                        r#ref: format!("Sheet{sheet_idx}!A1"),
+                    });
+                }
+            }
+            wb
+        })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    /// to_json ∘ from_json = id, byte-for-byte (schema spec §8 guarantee).
+    #[test]
+    fn round_trip_is_byte_identical(wb in workbook_strategy()) {
+        let json = wb.to_json().expect("serialize");
+        let back = Workbook::from_json(json.as_bytes()).expect("deserialize");
+        let json2 = back.to_json().expect("re-serialize");
+        prop_assert_eq!(json, json2);
+    }
+
+    /// from_json output re-serializes identically and is structurally equal.
+    #[test]
+    fn parsed_workbook_equals_original(wb in workbook_strategy()) {
+        let json = wb.to_json().expect("serialize");
+        let back = Workbook::from_json(json.as_bytes()).expect("deserialize");
+        prop_assert_eq!(&wb, &back);
+    }
+
+    /// Hash is stable across a canonical round-trip (schema spec §8: hash and
+    /// float equality operate on post-normalization bit patterns).
+    #[test]
+    fn hash_is_stable_across_round_trip(wb in workbook_strategy()) {
+        let json = wb.to_json().expect("serialize");
+        let back = Workbook::from_json(json.as_bytes()).expect("deserialize");
+        prop_assert_eq!(hash_of(&wb), hash_of(&back));
+    }
+
+    /// Canonical output is idempotent: parsing canonical bytes and
+    /// re-serializing yields the same bytes (and a second parse too).
+    #[test]
+    fn canonicalization_is_idempotent(wb in workbook_strategy()) {
+        let once = wb.to_json().expect("serialize");
+        let parsed = Workbook::from_json(once.as_bytes()).expect("parse");
+        let twice = parsed.to_json().expect("re-serialize");
+        prop_assert_eq!(&once, &twice);
+        let parsed2 = Workbook::from_json(twice.as_bytes()).expect("re-parse");
+        prop_assert_eq!(twice, parsed2.to_json().expect("third serialize"));
+    }
+}

--- a/crates/workbook/tests/schema_validation_tests.rs
+++ b/crates/workbook/tests/schema_validation_tests.rs
@@ -1,0 +1,128 @@
+//! Schema-validation tests (issue #531): the committed machine-readable
+//! `schema/workbook.v1.schema.json` validates the golden documents and the
+//! canonical output of arbitrary workbooks. JSON Schema cannot express the
+//! canonical-ordering / number-formatting / spill / duplicate-key / case-fold /
+//! ref-canonicality / limit rules — those are the prose spec's job and are
+//! covered elsewhere — but it pins the structural shape.
+
+use proptest::prelude::*;
+use truecalc_workbook::{Cell, EngineFlavor, NamedRange, Value, Workbook, Worksheet};
+
+fn schema() -> serde_json::Value {
+    let text = std::fs::read_to_string("schema/workbook.v1.schema.json").unwrap();
+    serde_json::from_str(&text).unwrap()
+}
+
+fn validator() -> jsonschema::Validator {
+    jsonschema::validator_for(&schema()).expect("schema compiles")
+}
+
+fn golden(name: &str) -> serde_json::Value {
+    let text = std::fs::read_to_string(format!("tests/golden/{name}")).unwrap();
+    serde_json::from_str(&text).unwrap()
+}
+
+#[test]
+fn schema_file_is_a_valid_json_schema() {
+    // validator_for already compiles + meta-validates the schema.
+    let _ = validator();
+}
+
+#[test]
+fn worked_example_golden_validates() {
+    let v = validator();
+    let inst = golden("worked_example.json");
+    assert!(v.is_valid(&inst), "worked_example.json must validate");
+}
+
+#[test]
+fn empty_golden_validates() {
+    assert!(validator().is_valid(&golden("empty_sheets.json")));
+}
+
+#[test]
+fn number_boundaries_golden_validates() {
+    assert!(validator().is_valid(&golden("number_boundaries.json")));
+}
+
+#[test]
+fn unicode_golden_validates() {
+    assert!(validator().is_valid(&golden("unicode.json")));
+}
+
+#[test]
+fn a_hand_built_workbook_validates() {
+    let mut wb = Workbook::new(EngineFlavor::Excel);
+    wb.names_mut().push(NamedRange {
+        name: "Rate".into(),
+        r#ref: "S!A1".into(),
+    });
+    let mut s = Worksheet::new("S");
+    s.cells_mut()
+        .insert("A1".into(), Cell::literal(Value::Number(1.5)).unwrap());
+    s.cells_mut().insert(
+        "B2".into(),
+        Cell::with_formula("=A1*Rate", Value::Date(46180.5)),
+    );
+    wb.sheets_mut().push(s);
+    let json: serde_json::Value = serde_json::from_str(&wb.to_json().unwrap()).unwrap();
+    assert!(validator().is_valid(&json), "got: {json}");
+}
+
+#[test]
+fn a_document_missing_a_required_field_fails_schema() {
+    let bad: serde_json::Value =
+        serde_json::from_str(r#"{"engine":"sheets","names":[],"sheets":[]}"#).unwrap();
+    assert!(
+        !validator().is_valid(&bad),
+        "missing version must fail schema"
+    );
+}
+
+#[test]
+fn a_document_with_a_bad_address_key_fails_schema() {
+    let bad: serde_json::Value = serde_json::from_str(
+        r#"{"engine":"sheets","names":[],"sheets":[{"name":"S","cells":{"a1":{"value":{"type":"number","value":1}}}}],"version":"1"}"#,
+    )
+    .unwrap();
+    assert!(
+        !validator().is_valid(&bad),
+        "lowercase address key must fail schema"
+    );
+}
+
+fn finite_f64() -> impl Strategy<Value = f64> {
+    prop_oneof![
+        any::<f64>().prop_filter("finite", |x| x.is_finite()),
+        (-1000i64..1000).prop_map(|n| n as f64),
+    ]
+}
+
+fn small_workbook() -> impl Strategy<Value = Workbook> {
+    (0usize..3, finite_f64()).prop_map(|(n, x)| {
+        let mut wb = Workbook::new(EngineFlavor::Sheets);
+        let cols = ["A", "D", "G"];
+        let mut s = Worksheet::new("Sheet0");
+        for (i, c) in cols.iter().enumerate().take(n) {
+            s.cells_mut().insert(
+                format!("{c}1"),
+                Cell::literal(Value::Number(x + i as f64)).unwrap(),
+            );
+        }
+        wb.sheets_mut().push(s);
+        wb
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Canonical output of arbitrary workbooks always validates against the
+    /// committed schema.
+    #[test]
+    fn canonical_output_validates_against_schema(wb in small_workbook()) {
+        let json: serde_json::Value = serde_json::from_str(&wb.to_json().unwrap()).unwrap();
+        let v = validator();
+        prop_assert!(v.is_valid(&json));
+    }
+}


### PR DESCRIPTION
## P2.4 — Round-trip + schema-validation property tests

**Stacked on #573 (P2.3).** Base branch is `feat/530-canonical-json`, not `main`. The diff below feat/530 is only the P2.4 commit. **Merge #573 first** via GitHub's merge button (with *delete branch*); this PR will then auto-retarget to `main`. Do not delete the base branch via the API — that would close this PR.

### What this adds

**Machine-readable schema** — `crates/workbook/schema/workbook.v1.schema.json` (Draft 2020-12), deferred from Phase 0 by design. It pins the *structural* shape (top-level fields, `engine` enum, `version` const, worksheet/cell/value/named-range shapes, the `^[A-Z]{1,3}[1-9][0-9]{0,7}$` address-key pattern). Rules JSON Schema cannot express — canonical ordering, ECMAScript number formatting, spill reconstruction, duplicate-key rejection, simple-case-fold uniqueness, ref canonicality, resource limits — stay with the prose spec and `Workbook::from_json`.

**Property tests** (`tests/roundtrip_property_tests.rs`, proptest):
- `to_json ∘ from_json = id` — byte-identical.
- parsed workbook equals the original (structural equality).
- hash stability across a canonical round-trip.
- canonicalization idempotence (parse→serialize→parse→serialize is stable).

A generator builds structurally valid workbooks: unique sheet names, well-spaced A1 addresses, non-overlapping spill anchors, canonical named-range refs, and a value strategy spanning all 7 types incl. extreme floats.

**Schema-validation tests** (`tests/schema_validation_tests.rs`, jsonschema):
- every golden document validates against the committed schema;
- canonical output of arbitrary workbooks validates (property test);
- malformed shapes (missing required field, lowercase address key) are rejected.

### Note carried up from P2.3
While writing these property tests the round-trip caught a real serde_json float-parsing bug: its default parser is off by up to one ULP for some extreme exponents (e.g. 1.5926045055164742e-152), which broke byte-identity. Fixed in #573 by enabling serde_json's `float_roundtrip` feature (with a regression test there).

### Acceptance (#531)
- property suites green in CI
- `schema/workbook.v1.schema.json` committed
- goldens validate against the schema in CI

All 13 new tests pass (4 property + 9 schema-validation); full crate suite green; clippy clean.

Closes #531