### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "calamine",
  "chrono",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-workbook"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/mcp", "crates/workbook", "xtask
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/truecalc/core/compare/truecalc-core-v0.7.0...truecalc-core-v0.8.0) - 2026-06-08
+
+### Fixed
+
+- *(workbook)* unify EngineFlavor with truecalc-core's flavor enum ([#567](https://github.com/truecalc/core/pull/567))
+
+### Other
+
+- *(workbook)* correct COUNT-skip comment to reference filed issue #584
+- *(workbook)* seed Resolver from input-model sidecar (#575 / #532)
+
 ## [0.7.0](https://github.com/truecalc/core/compare/truecalc-core-v0.6.5...truecalc-core-v0.7.0) - 2026-06-08
 
 ### Added

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -12,6 +12,6 @@ name = "truecalc-mcp"
 path = "src/main.rs"
 
 [dependencies]
-truecalc-core = { path = "../core", version = "0.7" }
+truecalc-core = { path = "../core", version = "0.8" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/workbook/CHANGELOG.md
+++ b/crates/workbook/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/truecalc/core/compare/truecalc-workbook-v0.7.0...truecalc-workbook-v0.8.0) - 2026-06-08
+
+### Added
+
+- *(workbook)* array spill — Sheets semantics (P3.5)
+- *(workbook)* dependency graph from extract_refs (P3.2, #534)
+- *(workbook)* sparse grid, A1 addressing, and sheet management (P3.1)
+
+### Fixed
+
+- *(workbook)* incremental ≡ full across spill shrink and unblock ([#591](https://github.com/truecalc/core/pull/591))
+- *(workbook)* unify EngineFlavor with truecalc-core's flavor enum ([#567](https://github.com/truecalc/core/pull/567))
+
+### Other
+
+- recalc engine — full, incremental, cycles, RecalcContext
+- Merge branch 'main' into feat/536-mutation-api
+- *(workbook)* order mod depgraph alphabetically in lib.rs
+
 ## [0.7.0](https://github.com/truecalc/core/compare/truecalc-workbook-v0.6.5...truecalc-workbook-v0.7.0) - 2026-06-08
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `truecalc-mcp`: 0.7.0 -> 0.8.0
* `truecalc-workbook`: 0.7.0 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `truecalc-workbook` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_missing.ron

Failed in:
  enum truecalc_workbook::EngineFlavor, previously in file /tmp/.tmprghHJf/truecalc-workbook/src/engine.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [0.8.0](https://github.com/truecalc/core/compare/truecalc-core-v0.7.0...truecalc-core-v0.8.0) - 2026-06-08

### Fixed

- *(workbook)* unify EngineFlavor with truecalc-core's flavor enum ([#567](https://github.com/truecalc/core/pull/567))

### Other

- *(workbook)* correct COUNT-skip comment to reference filed issue #584
- *(workbook)* seed Resolver from input-model sidecar (#575 / #532)
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.6.5](https://github.com/truecalc/core/compare/truecalc-mcp-v0.6.4...truecalc-mcp-v0.6.5) - 2026-06-08

### Added

- engine-explicit API — Engine::sheets()/excel() required entry points
</blockquote>

## `truecalc-workbook`

<blockquote>

## [0.8.0](https://github.com/truecalc/core/compare/truecalc-workbook-v0.7.0...truecalc-workbook-v0.8.0) - 2026-06-08

### Added

- *(workbook)* array spill — Sheets semantics (P3.5)
- *(workbook)* dependency graph from extract_refs (P3.2, #534)
- *(workbook)* sparse grid, A1 addressing, and sheet management (P3.1)

### Fixed

- *(workbook)* incremental ≡ full across spill shrink and unblock ([#591](https://github.com/truecalc/core/pull/591))
- *(workbook)* unify EngineFlavor with truecalc-core's flavor enum ([#567](https://github.com/truecalc/core/pull/567))

### Other

- recalc engine — full, incremental, cycles, RecalcContext
- Merge branch 'main' into feat/536-mutation-api
- *(workbook)* order mod depgraph alphabetically in lib.rs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).