### PR TITLE
ci: add macOS golden byte-identity job for truecalc-workbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,3 +190,25 @@ jobs:
 
       - name: Build WASM
         run: wasm-pack build crates/wasm --target web
+
+  macos-golden:
+    name: macOS golden byte-identity (truecalc-workbook)
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      # Verifies the truecalc-workbook canonical-JSON golden files are
+      # byte-identical on macOS (issue #530 P2.3 acceptance: Linux + macOS).
+      # The golden byte-identity assertions live in
+      # crates/workbook/tests/canonical_json_tests.rs; running the crate's
+      # full test set (incl. canonical_json + golden) keeps this minimal yet
+      # complete for proving cross-OS byte identity.
+      - name: Test truecalc-workbook (golden + canonical JSON)
+        run: cargo test -p truecalc-workbook


### PR DESCRIPTION
## Summary

Issue #530 (P2.3) acceptance requires the `truecalc-workbook` canonical-JSON golden files to be **byte-identical on Linux + macOS CI**, but `.github/workflows/ci.yml` ran `ubuntu-latest` only. Cross-OS byte-identity currently holds by construction (ryu-js + hand-rolled JCS writer are platform-independent; no libc printf/locale float formatting), but the literal acceptance criterion was never exercised on macOS.

This adds a focused, fast `macos-latest` job that runs `cargo test -p truecalc-workbook`, which exercises the golden byte-identity assertions in `crates/workbook/tests/canonical_json_tests.rs` (plus the rest of the crate's canonical-JSON tests) on macOS. It reuses the same toolchain/cache actions as the existing `ci` job (`dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`).

## Job details

- **Check name:** `macOS golden byte-identity (truecalc-workbook)` (stable `name:` so it can later be added to branch protection's required checks).
- Runs only the workbook crate tests — deliberately minimal, not the whole workspace suite.

## Note for the owner

Once this is green on `main`, you may want to add **`macOS golden byte-identity (truecalc-workbook)`** to the required status checks in branch protection so cross-OS byte identity stays enforced.

Closes #576