### PR TITLE
fix(workbook): unify EngineFlavor with truecalc-core's flavor enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,6 +2030,8 @@ dependencies = [
  "nom",
  "proptest",
  "regex-lite",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2063,6 +2065,7 @@ dependencies = [
  "ryu-js",
  "serde",
  "serde_json",
+ "truecalc-core",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,12 +7,20 @@ description = "Spreadsheet formula engine — parser and evaluator for Excel-com
 repository.workspace = true
 readme = "README.md"
 
+[features]
+# serde off by default: keeps the default core build serde-free. Enables
+# Serialize/Deserialize on EngineFlavor so downstream crates (truecalc-workbook)
+# reuse the single canonical flavor enum on the JSON wire. Wire: "sheets"|"excel".
+serde = ["dep:serde"]
+
 [dependencies]
 nom = "8"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 regex-lite = "0.1"
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 proptest = "1"
 calamine = "0.26"
 csv = "1"
+serde_json = "1"

--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -16,21 +16,23 @@ use crate::types::{ErrorKind, ParseError, Value};
 ///   1900-02-29). Conversion helpers live in
 ///   `eval::functions::date::serial`; Excel evaluation itself is still
 ///   stubbed (`evaluate` returns `#N/A`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Flavor {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+pub enum EngineFlavor {
     Sheets,
     Excel,
 }
 
 pub struct Engine {
-    flavor: Flavor,
+    flavor: EngineFlavor,
     registry: Registry,
 }
 
 impl Engine {
     /// Engine targeting Google Sheets conformance.
     pub fn sheets() -> Self {
-        Self { flavor: Flavor::Sheets, registry: Registry::new() }
+        Self { flavor: EngineFlavor::Sheets, registry: Registry::new() }
     }
 
     /// Engine targeting Excel conformance.
@@ -40,13 +42,23 @@ impl Engine {
     /// `Value::Error(ErrorKind::NA)` for every formula. [`Engine::parse`]
     /// and [`Engine::validate`] work.
     pub fn excel() -> Self {
-        Self { flavor: Flavor::Excel, registry: Registry::new() }
+        Self { flavor: EngineFlavor::Excel, registry: Registry::new() }
     }
 
     /// Deprecated alias for [`Engine::sheets`].
     #[deprecated(note = "use Engine::sheets() — engine flavor is required; see ADR 2026-04-27")]
     pub fn google_sheets() -> Self {
         Self::sheets()
+    }
+
+    /// The engine flavor this instance targets.
+    ///
+    /// Flavor is fixed at construction (`Engine::sheets()` / `Engine::excel()`);
+    /// there is no way to change it on an existing engine (engine-flavor ADR
+    /// 2026-04-27). The workbook layer uses this to assert a workbook's locked
+    /// [`EngineFlavor`] matches the engine driving its recalc.
+    pub fn flavor(&self) -> EngineFlavor {
+        self.flavor
     }
 
     /// Parse a formula string into an expression tree.
@@ -156,7 +168,7 @@ impl Engine {
                 return Value::Error(ErrorKind::Num);
             }
         }
-        if self.flavor == Flavor::Excel {
+        if self.flavor == EngineFlavor::Excel {
             return Value::Error(ErrorKind::NA);
         }
         match parse_formula(formula) {
@@ -176,7 +188,7 @@ impl Engine {
         variables: &HashMap<String, Value>,
         now_serial: Option<f64>,
     ) -> Value {
-        if self.flavor == Flavor::Excel {
+        if self.flavor == EngineFlavor::Excel {
             // Excel evaluation semantics are not implemented yet.
             return Value::Error(ErrorKind::NA);
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,7 +7,7 @@ pub mod parser;
 pub mod types;
 
 pub use display::display_number;
-pub use engine::Engine;
+pub use engine::{Engine, EngineFlavor};
 #[allow(deprecated)]
 pub use parser::{parse, validate};
 pub use parser::Expr;

--- a/crates/core/tests/engine_flavor.rs
+++ b/crates/core/tests/engine_flavor.rs
@@ -1,0 +1,45 @@
+//! Public API guarantees for the unified engine flavor enum (issue #567).
+//!
+//! `EngineFlavor` is the single canonical flavor type, owned by truecalc-core
+//! and re-exported by truecalc-workbook. These tests guard the public surface
+//! and the JSON wire strings pinned by the workbook JSON schema v1.
+
+use truecalc_core::{Engine, EngineFlavor};
+
+#[test]
+fn engine_constructors_expose_their_flavor() {
+    assert_eq!(Engine::sheets().flavor(), EngineFlavor::Sheets);
+    assert_eq!(Engine::excel().flavor(), EngineFlavor::Excel);
+}
+
+/// Exhaustive-match guard: adding a variant to `EngineFlavor` forces this
+/// match (and therefore the build) to be updated, so the enum cannot silently
+/// grow in one place. With a single shared enum this is the cross-crate
+/// drift protection requested in issue #567.
+#[test]
+fn flavor_variants_are_exhaustively_known() {
+    for flavor in [EngineFlavor::Sheets, EngineFlavor::Excel] {
+        match flavor {
+            EngineFlavor::Sheets => {}
+            EngineFlavor::Excel => {}
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn flavor_serializes_to_pinned_wire_strings() {
+    // Pinned by workbook JSON schema v1 (spec section 2): must never change.
+    assert_eq!(serde_json::to_string(&EngineFlavor::Sheets).unwrap(), "\"sheets\"");
+    assert_eq!(serde_json::to_string(&EngineFlavor::Excel).unwrap(), "\"excel\"");
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn flavor_deserializes_from_pinned_wire_strings() {
+    let s: EngineFlavor = serde_json::from_str("\"sheets\"").unwrap();
+    let e: EngineFlavor = serde_json::from_str("\"excel\"").unwrap();
+    assert_eq!(s, EngineFlavor::Sheets);
+    assert_eq!(e, EngineFlavor::Excel);
+    assert!(serde_json::from_str::<EngineFlavor>("\"lotus123\"").is_err());
+}

--- a/crates/workbook/Cargo.toml
+++ b/crates/workbook/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["spreadsheet", "workbook", "formula", "excel", "sheets"]
 
 [dependencies]
+truecalc-core = { path = "../core", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["float_roundtrip"] }
 ryu-js = "1"

--- a/crates/workbook/src/engine.rs
+++ b/crates/workbook/src/engine.rs
@@ -1,17 +1,14 @@
-use serde::{Deserialize, Serialize};
+//! Engine flavor for workbooks.
+//!
+//! The flavor enum is owned by `truecalc-core` (the single source of truth);
+//! the workbook layer re-exports it as [`EngineFlavor`] so there is exactly one
+//! enum across the two crates and no drift is possible (issue #567). Core derives
+//! the serde impls under its `serde` feature with `rename_all = "lowercase"`, so
+//! the JSON wire strings stay `"sheets"` | `"excel"` as pinned by the workbook
+//! JSON schema v1 (spec section 2).
+//!
+//! Engine flavor is explicit and required on every public entry point; there is
+//! no default (ADR 2026-04-27-engine-flavor-explicit-everywhere). It is the
+//! workbook value serialized as the required top-level `engine` field.
 
-/// Which spreadsheet product's semantics every formula in a workbook targets.
-///
-/// Engine flavor is explicit and required on every public entry point; there
-/// is no default (ADR 2026-04-27-engine-flavor-explicit-everywhere).
-/// Serialized as the workbook's required top-level `engine` field:
-/// `"sheets"` | `"excel"`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum EngineFlavor {
-    /// Google Sheets semantics (day 0 of the date serial system is 1899-12-30).
-    Sheets,
-    /// Excel semantics (1900 date system, including the historical
-    /// 1900 leap-year bug).
-    Excel,
-}
+pub use truecalc_core::EngineFlavor;


### PR DESCRIPTION
## Summary

Resolves the duplicated engine-flavor enum flagged in the P2.2 Principal Review. `truecalc-workbook` defined its own `EngineFlavor { Sheets, Excel }` while `truecalc-core` had a **private** `Flavor { Sheets, Excel }` — a drift risk once the workbook layer drives evaluation (P3.x recalc).

## Approach chosen

Of the two directions the issue proposed, I took the **single-shared-enum** route (core exposes the enum, workbook re-exports it) rather than maintaining two enums with `From` conversions. With one canonical type there is literally nothing to drift — strictly stronger than a conversion + exhaustive-match test, and it is exactly what the workbook->core recalc path needs.

- **core**: `Flavor` is now the public `EngineFlavor`, the single source of truth, exported from the crate root. Its `Serialize`/`Deserialize` impls are derived behind a **new, default-off `serde` feature** (`rename_all = "lowercase"`), so the default core build stays dependency-free of serde (core had zero serde usage before) while downstream crates can opt in. Added an `Engine::flavor()` accessor so the workbook layer can assert a workbook's locked flavor matches the engine driving its recalc.
- **workbook**: now depends on `truecalc-core` with `features = ["serde"]` and re-exports `truecalc_core::EngineFlavor`; the local enum is deleted. Layering stays **workbook -> core** (no cycle); workbooks remain **engine-locked at creation** and the flavor stays explicit/required on every public entry point.

### Why not the `From` + conversion option

That keeps two enums alive (still "duplication") and only *detects* drift at build time; a shared enum *prevents* it. The only cost of the shared-enum route is core gaining an optional serde feature, which is gated off by default and adds no dependency to the default build.

## JSON wire value: unchanged

The serde wire strings `"sheets"` | `"excel"` are pinned by the workbook JSON schema v1 (spec section 2) and **do not change**. Core derives the same `rename_all = "lowercase"` the workbook enum used. Verified:
- workbook golden files (`empty_sheets.json`, `worked_example.json`, ...) round-trip byte-for-byte;
- `engine_lock_tests::engine_serializes_as_lowercase_literal` still asserts `"engine":"sheets"` / `"engine":"excel"`;
- new `crates/core/tests/engine_flavor.rs` asserts the pinned wire strings serialize/deserialize under the serde feature, plus an exhaustive-match guard so a future variant can't be added in one place silently.

## Tests

- `cargo test -p truecalc-workbook`: all pass (golden, canonical-JSON, engine-lock, serde, property/round-trip).
- `cargo test -p truecalc-core` (default features) and `--features serde`: all pass (2639 unit + integration; new `engine_flavor` test in both feature configs).
- `cargo clippy -p truecalc-core --features serde -p truecalc-workbook`: clean.

## Open questions

- Once workbook->core recalc lands (P3.x), the workbook can use `Engine::flavor()` to enforce the lock at the recalc boundary; no API change needed then.
- The new core `serde` feature is intentionally minimal (only `EngineFlavor`). If more core types ever need wire serialization, this is the feature to extend.

Closes #567