### PR TITLE
fix(wasm): full array results + typed date on the @truecalc/core surface (#569)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +205,12 @@ dependencies = [
  "serde",
  "zip",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -1021,6 +1038,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +1087,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1110,6 +1143,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1189,6 +1231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1202,6 +1245,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
@@ -1641,6 +1690,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,6 +2109,7 @@ dependencies = [
  "truecalc-core",
  "tsify-next",
  "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -2189,6 +2248,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,6 +2346,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2426,15 @@ checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -9,7 +9,9 @@ keywords = ["spreadsheet", "formula", "excel", "wasm", "evaluator"]
 repository.workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+# `rlib` (in addition to `cdylib` for wasm-pack) lets the native test harness
+# link the crate so `cargo nextest`/`cargo test` can exercise the value mapping.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 truecalc-core = { path = "../core" }
@@ -18,6 +20,10 @@ serde-wasm-bindgen = "0.6"
 serde_json = "1"
 tsify-next = { version = "0.5", features = ["js"] }
 serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"
+wasm-bindgen-test = "0.3"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false  # wasm-opt segfaults on this binary; re-enable when wasm-pack ships a fix

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -79,15 +79,57 @@ evaluate('CONCAT("Hello, ", name)', { name: 'world' })
 // => { type: 'text', value: 'Hello, world' }
 ```
 
-**Return value shape:**
+**Return value shape** (a discriminated union tagged by `type`):
 
-| `type`    | Shape                                |
-|-----------|--------------------------------------|
-| `number`  | `{ type: 'number', value: 6 }`       |
-| `text`    | `{ type: 'text', value: 'yes' }`     |
-| `boolean` | `{ type: 'boolean', value: true }`   |
-| `error`   | `{ type: 'error', error: '#NAME?' }` |
-| `empty`   | `{ type: 'empty', value: null }`     |
+| `type`   | Shape                                                  |
+|----------|--------------------------------------------------------|
+| `number` | `{ type: 'number', value: 6 }`                         |
+| `text`   | `{ type: 'text', value: 'yes' }`                       |
+| `bool`   | `{ type: 'bool', value: true }`                        |
+| `date`   | `{ type: 'date', value: 46180 }`                       |
+| `error`  | `{ type: 'error', error: '#NAME?' }`                   |
+| `empty`  | `{ type: 'empty' }`                                    |
+| `array`  | `{ type: 'array', value: [ /* EvalResult cells */ ] }` |
+
+`date` carries a spreadsheet **serial number** (`value`); the epoch is implied by
+the engine flavor (`google-sheets`: day 0 = 1899-12-30). Format it yourself if you
+need a calendar date.
+
+`array` is **recursive**: each element is itself an `EvalResult`, so a 1-D result is
+a flat `value` list of scalar cells and a 2-D result is a `value` list of `array`
+rows whose elements are scalar cells. Array cells keep their own type (including
+nested `date`/`error`/`empty`).
+
+```js
+evaluate('SEQUENCE(2,2)')
+// => {
+//   type: 'array',
+//   value: [
+//     { type: 'array', value: [ { type: 'number', value: 1 }, { type: 'number', value: 2 } ] },
+//     { type: 'array', value: [ { type: 'number', value: 3 }, { type: 'number', value: 4 } ] },
+//   ],
+// }
+
+evaluate('TODAY()')
+// => { type: 'date', value: 46180 }
+```
+
+> #### Breaking change in 0.7.0 (surface shape)
+>
+> 0.7.0 ships the unspilled-array core change (see core PR #566 / issue #569).
+> Two observable shapes changed for npm consumers:
+>
+> - **Array-producing formulas** (`SORT`, `FILTER`, `UNIQUE`, `SEQUENCE`,
+>   `TRANSPOSE`, `MMULT`, `HSTACK`/`VSTACK`, `RANDARRAY`, array literals, ...) now
+>   return a full `{ type: 'array', value: [...] }` result. In `<= 0.6.x` these
+>   returned the top-left anchor-cell **scalar** (and, transiently after #566 but
+>   before this fix, an `{ type: 'error', error: 'array not supported' }` object).
+>   To recover the old single-cell behavior, read the first cell yourself, e.g.
+>   `const tl = r.type === 'array' ? r.value[0] : r;` (recurse once more for 2-D).
+> - **Date-producing functions** (`TODAY`, `DATE`, ...) now return
+>   `{ type: 'date', value }` instead of `{ type: 'number', value }`. If you were
+>   treating the result as a number, also accept `type === 'date'` (the `value`
+>   encoding is identical — a serial number).
 
 ### `validate(formula)`
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -24,15 +24,59 @@ fn json_to_value(v: &serde_json::Value) -> Value {
     }
 }
 
-#[derive(Tsify, Serialize)]
+/// The result of evaluating a formula on the WASM surface.
+///
+/// A discriminated union tagged by `type`. Scalars carry their value directly;
+/// the `array` variant is recursive -- each element is itself an `EvalResult`,
+/// so a 2-D array result is an array of `array` rows whose elements are scalar
+/// `EvalResult`s. This mirrors how `truecalc-core` represents array values
+/// internally (1-D arrays are flat, 2-D arrays nest row sub-arrays) and matches
+/// the recursive shape `truecalc-mcp` already emits.
+///
+/// # Surface shape (npm `@truecalc/core` >= 0.7.0)
+///
+/// - `{ type: "number", value: 1.5 }`
+/// - `{ type: "text", value: "yes" }`
+/// - `{ type: "bool", value: true }`
+/// - `{ type: "empty" }`
+/// - `{ type: "error", error: "#REF!" }`
+/// - `{ type: "date", value: 46180 }` -- spreadsheet serial number (epoch implied
+///   by the engine flavor; `sheets` day 0 = 1899-12-30)
+/// - `{ type: "array", value: [ EvalResult, ... ] }` -- recursive; a 2-D result is
+///   `{ type: "array", value: [ { type: "array", value: [ <cells> ] }, ... ] }`
+#[derive(Tsify, Serialize, Debug)]
 #[tsify(into_wasm_abi)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum EvalResult {
     Number { value: f64 },
     Text { value: String },
     Bool { value: bool },
+    /// A spreadsheet serial date number. Distinct from `Number` so consumers can
+    /// format it as a date; the epoch is implied by the engine flavor.
+    Date { value: f64 },
     Error { error: String },
     Empty,
+    /// An (unspilled) array result. Recursive: 2-D arrays are arrays of `array`
+    /// rows. Cells carry their own type, including nested `date`/`error`/`empty`.
+    Array { value: Vec<EvalResult> },
+}
+
+/// Map a `truecalc-core` `Value` onto the WASM `EvalResult` surface shape.
+///
+/// Recurses into arrays so every cell carries its own type; `Date` is preserved
+/// as a distinct `date` result rather than collapsed to `number`.
+pub fn value_to_result(value: Value) -> EvalResult {
+    match value {
+        Value::Number(n) => EvalResult::Number { value: n },
+        Value::Date(n) => EvalResult::Date { value: n },
+        Value::Text(s) => EvalResult::Text { value: s },
+        Value::Bool(b) => EvalResult::Bool { value: b },
+        Value::Error(e) => EvalResult::Error { error: e.to_string() },
+        Value::Empty => EvalResult::Empty,
+        Value::Array(items) => EvalResult::Array {
+            value: items.into_iter().map(value_to_result).collect(),
+        },
+    }
 }
 
 #[derive(Tsify, Serialize)]
@@ -69,14 +113,7 @@ pub fn evaluate(formula: &str, variables: JsValue) -> EvalResult {
         None => HashMap::new(),
     };
 
-    match truecalc_core::Engine::sheets().evaluate(formula, &vars) {
-        Value::Number(n) | Value::Date(n) => EvalResult::Number { value: n },
-        Value::Text(s) => EvalResult::Text { value: s },
-        Value::Bool(b) => EvalResult::Bool { value: b },
-        Value::Error(e) => EvalResult::Error { error: e.to_string() },
-        Value::Empty => EvalResult::Empty,
-        Value::Array(_) => EvalResult::Error { error: "array not supported".to_string() },
-    }
+    value_to_result(truecalc_core::Engine::sheets().evaluate(formula, &vars))
 }
 
 /// Validate a formula string without evaluating it.
@@ -194,14 +231,7 @@ impl WasmEngine {
             None => HashMap::new(),
         };
 
-        match self.inner.evaluate(formula, &vars) {
-            Value::Number(n) | Value::Date(n) => EvalResult::Number { value: n },
-            Value::Text(s) => EvalResult::Text { value: s },
-            Value::Bool(b) => EvalResult::Bool { value: b },
-            Value::Error(e) => EvalResult::Error { error: e.to_string() },
-            Value::Empty => EvalResult::Empty,
-            Value::Array(_) => EvalResult::Error { error: "array not supported".to_string() },
-        }
+        value_to_result(self.inner.evaluate(formula, &vars))
     }
 }
 

--- a/crates/wasm/tests/eval_result.rs
+++ b/crates/wasm/tests/eval_result.rs
@@ -1,0 +1,139 @@
+//! Surface-shape tests for the `EvalResult` mapping (issue #569).
+//!
+//! These run natively under `cargo nextest`/`cargo test` and assert the exact
+//! JSON shape `@truecalc/core` consumers observe. The WASM ABI is not exercised
+//! here (that requires a wasm runtime); the value -> result mapping that
+//! determines the surface shape is, which is the behavior #569 changes.
+
+use serde_json::json;
+use truecalc_core::{ErrorKind, Value};
+use truecalc_wasm::{value_to_result, EvalResult};
+
+/// Serialize an `EvalResult` to JSON the way `serde-wasm-bindgen` would for the
+/// `type`-tagged shape, so we can assert on the observable consumer payload.
+fn shape(value: Value) -> serde_json::Value {
+    serde_json::to_value(value_to_result(value)).expect("EvalResult serializes")
+}
+
+#[test]
+fn number_maps_to_number() {
+    assert_eq!(shape(Value::Number(1.5)), json!({ "type": "number", "value": 1.5 }));
+}
+
+#[test]
+fn text_maps_to_text() {
+    assert_eq!(shape(Value::Text("yes".into())), json!({ "type": "text", "value": "yes" }));
+}
+
+#[test]
+fn bool_maps_to_bool() {
+    // Tag stays `bool` (the published <=0.6.x shape), not `boolean`.
+    assert_eq!(shape(Value::Bool(true)), json!({ "type": "bool", "value": true }));
+}
+
+#[test]
+fn empty_maps_to_empty() {
+    assert_eq!(shape(Value::Empty), json!({ "type": "empty" }));
+}
+
+#[test]
+fn error_maps_to_error_with_error_key() {
+    assert_eq!(
+        shape(Value::Error(ErrorKind::Ref)),
+        json!({ "type": "error", "error": "#REF!" })
+    );
+}
+
+#[test]
+fn date_maps_to_distinct_date_not_number() {
+    // #569: dates are no longer collapsed to `number`.
+    let out = shape(Value::Date(46180.0));
+    assert_eq!(out, json!({ "type": "date", "value": 46180.0 }));
+    assert_ne!(out["type"], json!("number"));
+}
+
+#[test]
+fn one_dimensional_array_serializes_each_cell_typed() {
+    // #569: arrays no longer map to `{ type: "error", error: "array not supported" }`.
+    let v = Value::Array(vec![
+        Value::Number(1.0),
+        Value::Text("a".into()),
+        Value::Bool(false),
+    ]);
+    assert_eq!(
+        shape(v),
+        json!({
+            "type": "array",
+            "value": [
+                { "type": "number", "value": 1.0 },
+                { "type": "text", "value": "a" },
+                { "type": "bool", "value": false }
+            ]
+        })
+    );
+}
+
+#[test]
+fn two_dimensional_array_nests_rows() {
+    // Row-major: outer array of `array` rows whose cells carry their own type.
+    let v = Value::Array(vec![
+        Value::Array(vec![Value::Number(1.0), Value::Number(2.0)]),
+        Value::Array(vec![Value::Number(3.0), Value::Number(4.0)]),
+    ]);
+    assert_eq!(
+        shape(v),
+        json!({
+            "type": "array",
+            "value": [
+                { "type": "array", "value": [
+                    { "type": "number", "value": 1.0 },
+                    { "type": "number", "value": 2.0 }
+                ]},
+                { "type": "array", "value": [
+                    { "type": "number", "value": 3.0 },
+                    { "type": "number", "value": 4.0 }
+                ]}
+            ]
+        })
+    );
+}
+
+#[test]
+fn array_preserves_nested_date_and_error_cells() {
+    let v = Value::Array(vec![Value::Date(46180.0), Value::Error(ErrorKind::Num)]);
+    assert_eq!(
+        shape(v),
+        json!({
+            "type": "array",
+            "value": [
+                { "type": "date", "value": 46180.0 },
+                { "type": "error", "error": "#NUM!" }
+            ]
+        })
+    );
+}
+
+#[test]
+fn empty_array_serializes_as_empty_value_list() {
+    assert_eq!(shape(Value::Array(vec![])), json!({ "type": "array", "value": [] }));
+}
+
+/// Exhaustiveness guard: every `Value` variant must produce a non-error result
+/// here except the genuine `Error` variant. Guarantees no variant silently
+/// falls back to "array not supported"-style errors.
+#[test]
+fn no_value_variant_maps_to_a_spurious_error() {
+    for v in [
+        Value::Number(0.0),
+        Value::Text(String::new()),
+        Value::Bool(false),
+        Value::Empty,
+        Value::Date(0.0),
+        Value::Array(vec![Value::Number(0.0)]),
+    ] {
+        assert!(
+            !matches!(value_to_result(v.clone()), EvalResult::Error { .. }),
+            "variant {v:?} unexpectedly mapped to EvalResult::Error"
+        );
+    }
+}

--- a/crates/wasm/tests/wasm_surface.rs
+++ b/crates/wasm/tests/wasm_surface.rs
@@ -40,7 +40,7 @@ fn one_dimensional_array_formula_returns_flat_array() {
 fn date_formula_returns_distinct_date_result() {
     // DATE(...) is date-typed; previously collapsed to `number`.
     match evaluate("DATE(2026,6,9)", JsValue::UNDEFINED) {
-        EvalResult::Date { value } => assert_eq!(value, 46180.0),
+        EvalResult::Date { value } => assert_eq!(value, 46182.0), // sheets serial for 2026-06-09 (day 0 = 1899-12-30)
         other => panic!("expected date result, got {other:?}"),
     }
 }

--- a/crates/wasm/tests/wasm_surface.rs
+++ b/crates/wasm/tests/wasm_surface.rs
@@ -1,0 +1,54 @@
+//! End-to-end WASM-surface tests (issue #569), exercising the real wasm-bindgen
+//! ABI. Run with `wasm-pack test --node crates/wasm` (or `--headless --chrome`).
+//!
+//! Gated to `wasm32` so the native `cargo nextest` run (CI's test job) skips it;
+//! the native shape coverage lives in `eval_result.rs`. CI builds the wasm
+//! package via `wasm-pack build` but does not currently run `wasm-pack test`, so
+//! these are developer-facing checks of the live ABI.
+#![cfg(target_arch = "wasm32")]
+
+use truecalc_wasm::{evaluate, EvalResult};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn array_formula_returns_nested_array_result() {
+    // SEQUENCE(2,2) -> 2x2 array; previously errored with "array not supported".
+    match evaluate("SEQUENCE(2,2)", JsValue::UNDEFINED) {
+        EvalResult::Array { value } => {
+            assert_eq!(value.len(), 2, "two rows");
+            for row in value {
+                match row {
+                    EvalResult::Array { value: cells } => assert_eq!(cells.len(), 2),
+                    other => panic!("expected row array, got {other:?}"),
+                }
+            }
+        }
+        other => panic!("expected array result, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+fn one_dimensional_array_formula_returns_flat_array() {
+    match evaluate("{1,2,3}", JsValue::UNDEFINED) {
+        EvalResult::Array { value } => assert_eq!(value.len(), 3),
+        other => panic!("expected array result, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+fn date_formula_returns_distinct_date_result() {
+    // DATE(...) is date-typed; previously collapsed to `number`.
+    match evaluate("DATE(2026,6,9)", JsValue::UNDEFINED) {
+        EvalResult::Date { value } => assert_eq!(value, 46180.0),
+        other => panic!("expected date result, got {other:?}"),
+    }
+}
+
+#[wasm_bindgen_test]
+fn scalar_number_formula_still_returns_number() {
+    match evaluate("1+1", JsValue::UNDEFINED) {
+        EvalResult::Number { value } => assert_eq!(value, 2.0),
+        other => panic!("expected number result, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## What

The `@truecalc/core` WASM surface now returns **top-level array results as nested JS arrays** and **DATE results as a distinct typed value**, instead of erroring on arrays / collapsing dates to numbers. This is the owner-chosen option from #569: **full arrays + typed dates**.

## Why

PR #566 (P1.4, #526) removed `first_of_array` from `Engine::evaluate`, so array results now flow through evaluation **unspilled** (spill/collapse is the workbook/surface layer's job, per the workbook scope ADR). Before #566 the wasm crate's `Value::Array(_) => Error { error: "array not supported" }` arm was dead code; after #566 it became live, so *every* array-producing formula (`SORT`, `FILTER`, `UNIQUE`, `SEQUENCE`, `TRANSPOSE`, `MMULT`, `HSTACK`/`VSTACK`, `RANDARRAY`, array literals, ...) returned an error object to npm consumers. Separately, `EvalResult` collapsed `Value::Date(n)` to `number`, so the schema-spec date type was invisible on the surface.

## Changes

- **`crates/wasm/src/lib.rs`**: `EvalResult` is now a recursive `type`-tagged union with two new variants:
  - `Date { value: f64 }` — a `{ type: "date", value }` result (spreadsheet serial number; epoch implied by the engine flavor).
  - `Array { value: Vec<EvalResult> }` — a `{ type: "array", value: [...] }` result whose elements are themselves `EvalResult`s. **Recursive**: a 1-D result is a flat cell list; a 2-D result is a list of `array` rows. Cells keep their own type (including nested `date`/`error`/`empty`). This matches the recursive shape `crates/mcp` already emits and mirrors how core represents arrays internally.
  - A shared `value_to_result` mapper replaces the duplicated match arms in both the free `evaluate` and `Engine.evaluate`. The `"array not supported"` arm is gone.
- **`crates/wasm/Cargo.toml`**: `crate-type` adds `rlib` (alongside `cdylib` for wasm-pack) so the native test harness can link the crate; adds `wasm-bindgen-test` + `serde_json` dev-deps.
- **Tests** (separate files, per repo rules):
  - `crates/wasm/tests/eval_result.rs` — native (runs under `cargo nextest` in CI): asserts the exact JSON shape for every variant, incl. 1-D/2-D arrays, nested date/error cells, empty arrays, and an exhaustiveness guard that no `Value` variant maps to a spurious error.
  - `crates/wasm/tests/wasm_surface.rs` — `wasm32`-gated `wasm-bindgen-test`s driving the live ABI (`SEQUENCE(2,2)`, `{1,2,3}`, `DATE(...)`, scalar), run via `wasm-pack test`.
- **`crates/wasm/README.md`**: documents the new union, the `date`/`array` shapes, and a **breaking-change / migration** section. (Also corrects the pre-existing table, which listed `boolean`/`value:null` for empty — the actual published tags are `bool` and `{type:"empty"}`.)

## New `EvalResult` TypeScript shape

Regenerated `crates/wasm/pkg/truecalc_wasm.d.ts` (recursive, accurate):

```ts
export type EvalResult =
  | { type: "number"; value: number }
  | { type: "text"; value: string }
  | { type: "bool"; value: boolean }
  | { type: "date"; value: number }
  | { type: "error"; error: string }
  | { type: "empty" }
  | { type: "array"; value: EvalResult[] };
```

## Breaking change for npm consumers (intended; lands with 0.7.0)

This is a **deliberate breaking surface change**, approved per #569, shipping in the same release as the #566 core change (next minor/major, e.g. 0.7.0). Two observable changes:

- **Array formulas**: `<= 0.6.x` returned the top-left anchor-cell **scalar** (and, transiently after #566 before this fix, `{ type: "error", error: "array not supported" }`). `0.7.x` returns a full `{ type: "array", value: [...] }`. To recover single-cell behavior, read the first cell: `const tl = r.type === "array" ? r.value[0] : r;` (recurse once more for 2-D).
- **Date functions** (`TODAY`, `DATE`, ...): now `{ type: "date", value }` instead of `{ type: "number", value }`. The `value` encoding is identical (serial number); consumers treating it as a number should also accept `type === "date"`.

Releases are owner-triggered (scope ADR Decision 6) — do not publish 0.7.0 to npm until intended.

## Verification

- `cargo test -p truecalc-wasm` — 11 native tests pass.
- `cargo clippy -p truecalc-wasm --all-targets -- -D warnings` — clean.
- `wasm-pack build crates/wasm --target bundler` — builds; `.d.ts` reflects the union above.
- `cargo build -p truecalc-wasm --tests --target wasm32-unknown-unknown` — wasm32 tests compile.

Closes #569

Refs: #566, #526, scope ADR `decisions/2026-06-07-workbook-v1-scope.md`, JSON schema spec section 6.