### PR TITLE
P3.1: Sparse grid + A1 addressing + sheet management

### DIFF
--- a/crates/workbook/src/address.rs
+++ b/crates/workbook/src/address.rs
@@ -1,14 +1,27 @@
-//! Plain uppercase A1 cell-address parsing and bounds checking (schema spec §3).
+//! A1 cell addressing: parsing, bounds checking, and the A1↔`(row, column)`
+//! conversion utilities of the runtime grid (plan item 3.1).
 //!
 //! A serialized cell key MUST match `^[A-Z]{1,3}[1-9][0-9]{0,7}$` **and** lie
 //! within the address bounds of the limits ADR (rows `1..=10_000_000`,
-//! columns `1..=18_278`, i.e. `A..=ZZZ`). `from_json` rejects every other key
-//! — no `$`, no sheet qualifier, no lowercase, no leading zero.
+//! columns `1..=18_278`, i.e. `A..=ZZZ`). [`Workbook::from_json`] rejects every
+//! other key — no `$`, no sheet qualifier, no lowercase, no leading zero.
+//!
+//! An [`Address`] is the parsed, bounds-validated form used as the in-memory
+//! grid key (plan item 3.1). It can only be constructed in bounds, so every
+//! address held by a [`Worksheet`] is guaranteed valid; [`Address::to_a1`]
+//! re-emits the exact plain-uppercase key the canonical serializer writes.
+//!
+//! [`Workbook::from_json`]: crate::Workbook::from_json
+//! [`Worksheet`]: crate::Worksheet
 
 use crate::limits::{MAX_COLUMN, MAX_ROW};
 
-/// A parsed A1 address: 1-based `(row, column)`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// A parsed, in-bounds A1 address: 1-based `(row, column)`.
+///
+/// The grid key of a [`Worksheet`](crate::Worksheet). Every constructor is
+/// bounds-checked (rows `1..=10_000_000`, columns `1..=18_278`), so an
+/// `Address` value is always serializable to a valid A1 key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Address {
     /// 1-based row.
     pub row: u32,
@@ -16,12 +29,41 @@ pub struct Address {
     pub column: u32,
 }
 
+impl Address {
+    /// Builds an address from 1-based `(row, column)`, enforcing the address
+    /// bounds (rows `1..=10_000_000`, columns `1..=18_278`). Returns `None`
+    /// when either coordinate is `0` or out of bounds.
+    pub fn new(row: u32, column: u32) -> Option<Self> {
+        if row == 0 || row > MAX_ROW || column == 0 || column > MAX_COLUMN {
+            return None;
+        }
+        Some(Self { row, column })
+    }
+
+    /// Parses a plain uppercase A1 address (e.g. `A1`, `BC42`), enforcing the
+    /// normative key syntax (`^[A-Z]{1,3}[1-9][0-9]{0,7}$`) and the address
+    /// bounds (schema spec §3). Returns `None` on any malformed or
+    /// out-of-bounds key.
+    pub fn from_a1(key: &str) -> Option<Self> {
+        parse_a1(key)
+    }
+
+    /// Re-emits the plain-uppercase A1 key (`A1`, `BC42`) — the inverse of
+    /// [`Address::from_a1`] and the exact key the canonical serializer writes.
+    pub fn to_a1(&self) -> String {
+        let mut s = column_to_letters(self.column);
+        s.push_str(&self.row.to_string());
+        s
+    }
+}
+
 /// Parses a plain uppercase A1 address, enforcing the normative key syntax
 /// (`^[A-Z]{1,3}[1-9][0-9]{0,7}$`) and the address bounds (schema spec §3).
 ///
 /// Returns `None` on any malformed key or out-of-bounds row/column. Hand-rolled
 /// rather than regex-backed to keep the crate dependency-light and to fold the
-/// bounds check into the same pass.
+/// bounds check into the same pass. Kept as a free function because the
+/// document validator and named-ref parser call it on untrusted keys.
 pub fn parse_a1(key: &str) -> Option<Address> {
     let bytes = key.as_bytes();
     let mut i = 0;
@@ -55,8 +97,22 @@ pub fn parse_a1(key: &str) -> Option<Address> {
         row = row.checked_mul(10)?.checked_add((b - b'0') as u32)?;
     }
 
-    if row == 0 || row > MAX_ROW || column == 0 || column > MAX_COLUMN {
-        return None;
+    Address::new(row, column)
+}
+
+/// Converts a 1-based column index to its bijective base-26 letters
+/// (`1 → "A"`, `26 → "Z"`, `27 → "AA"`, `18_278 → "ZZZ"`). The input is
+/// assumed in bounds (it always is when called on an [`Address`] column).
+pub(crate) fn column_to_letters(mut column: u32) -> String {
+    let mut buf = [0u8; 3]; // ZZZ is the widest in-bounds column.
+    let mut len = 0;
+    while column > 0 {
+        let rem = ((column - 1) % 26) as u8;
+        buf[len] = b'A' + rem;
+        len += 1;
+        column = (column - 1) / 26;
     }
-    Some(Address { row, column })
+    buf[..len].reverse();
+    // Safe: every byte written is an ASCII uppercase letter.
+    String::from_utf8(buf[..len].to_vec()).expect("ASCII letters are valid UTF-8")
 }

--- a/crates/workbook/src/casefold.rs
+++ b/crates/workbook/src/casefold.rs
@@ -1,0 +1,15 @@
+//! Unicode **simple** case folding (schema spec §2), the single source of
+//! truth for every case-insensitive comparison in this crate: sheet-name
+//! uniqueness, named-range uniqueness, and case-insensitive sheet lookup
+//! (plan item 3.1 sheet management).
+//!
+//! Pinned to Unicode *simple* `Case_Folding` (not `to_lowercase()` / full
+//! folding, which disagree on some case pairs and would break cross-surface
+//! determinism for names differing only in such characters).
+
+use icu_casemap::CaseMapperBorrowed;
+
+/// Applies simple case folding to `s`, character by character.
+pub fn simple_fold(folder: &CaseMapperBorrowed<'static>, s: &str) -> String {
+    s.chars().map(|c| folder.simple_fold(c)).collect()
+}

--- a/crates/workbook/src/error.rs
+++ b/crates/workbook/src/error.rs
@@ -16,6 +16,17 @@ pub enum WorkbookError {
     /// resource-limit breach (scope ADR Decision 5). Carries a human-readable
     /// description of the first violation found.
     Validation(String),
+    /// A sheet-management operation
+    /// ([`add_sheet`](crate::Workbook::add_sheet),
+    /// [`insert_sheet`](crate::Workbook::insert_sheet),
+    /// [`rename_sheet`](crate::Workbook::rename_sheet),
+    /// [`move_sheet`](crate::Workbook::move_sheet)) violated an invariant —
+    /// a duplicate sheet name under simple case folding (schema spec §2), a
+    /// name that is empty or exceeds the length limit (schema spec §3), the
+    /// per-workbook sheet cap (scope ADR Decision 5), an out-of-range tab
+    /// position, or an unknown sheet name. Carries a human-readable
+    /// description.
+    SheetManagement(String),
 }
 
 impl fmt::Display for WorkbookError {
@@ -27,6 +38,7 @@ impl fmt::Display for WorkbookError {
                  clear a cell by removing its entry instead"
             ),
             WorkbookError::Validation(msg) => write!(f, "{msg}"),
+            WorkbookError::SheetManagement(msg) => write!(f, "{msg}"),
         }
     }
 }

--- a/crates/workbook/src/lib.rs
+++ b/crates/workbook/src/lib.rs
@@ -18,6 +18,7 @@
 
 mod address;
 mod canonical;
+mod casefold;
 mod cell;
 mod engine;
 mod error;
@@ -30,6 +31,7 @@ mod value;
 mod workbook;
 mod worksheet;
 
+pub use address::Address;
 pub use cell::Cell;
 pub use engine::EngineFlavor;
 pub use error::WorkbookError;

--- a/crates/workbook/src/validate.rs
+++ b/crates/workbook/src/validate.rs
@@ -26,6 +26,7 @@ use icu_casemap::CaseMapperBorrowed;
 use serde_json::Value;
 
 use crate::address::{parse_a1, Address};
+use crate::casefold::simple_fold;
 use crate::limits;
 use crate::named_ref;
 
@@ -362,11 +363,4 @@ fn validate_named_ranges(
     }
 
     Ok(())
-}
-
-/// Unicode **simple** case folding applied per character (schema spec §2): not
-/// `to_lowercase()`/full folding, which disagree on some case pairs and would
-/// break cross-surface determinism.
-fn simple_fold(folder: &CaseMapperBorrowed<'static>, s: &str) -> String {
-    s.chars().map(|c| folder.simple_fold(c)).collect()
 }

--- a/crates/workbook/src/workbook.rs
+++ b/crates/workbook/src/workbook.rs
@@ -1,7 +1,10 @@
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize};
 
+use icu_casemap::CaseMapperBorrowed;
+
 use crate::canonical;
+use crate::casefold::simple_fold;
 use crate::engine::EngineFlavor;
 use crate::error::WorkbookError;
 use crate::limits;
@@ -75,6 +78,120 @@ impl Workbook {
         &mut self.names
     }
 
+    /// The worksheet named `name` (case-insensitive, simple case folding per
+    /// schema spec §2), or `None` if no sheet matches.
+    pub fn sheet(&self, name: &str) -> Option<&Worksheet> {
+        self.sheet_index(name).map(|i| &self.sheets[i])
+    }
+
+    /// Mutable access to the worksheet named `name` (case-insensitive).
+    pub fn sheet_mut(&mut self, name: &str) -> Option<&mut Worksheet> {
+        match self.sheet_index(name) {
+            Some(i) => Some(&mut self.sheets[i]),
+            None => None,
+        }
+    }
+
+    /// The tab position (0-based array index) of the sheet named `name`
+    /// (case-insensitive per schema spec §2), or `None` if no sheet matches.
+    pub fn sheet_index(&self, name: &str) -> Option<usize> {
+        let folder = CaseMapperBorrowed::new();
+        let target = simple_fold(&folder, name);
+        self.sheets
+            .iter()
+            .position(|s| simple_fold(&folder, s.name()) == target)
+    }
+
+    /// Appends `sheet` after the last tab and returns its 0-based position.
+    ///
+    /// Errors if the name collides with an existing sheet under simple case
+    /// folding (schema spec §2), is empty or too long (schema spec §3), or
+    /// would exceed the per-workbook sheet cap (scope ADR Decision 5).
+    pub fn add_sheet(&mut self, sheet: Worksheet) -> Result<usize, WorkbookError> {
+        let pos = self.sheets.len();
+        self.insert_sheet(pos, sheet)?;
+        Ok(pos)
+    }
+
+    /// Inserts `sheet` at tab position `index`, shifting later tabs right.
+    /// `index == sheets().len()` appends. Position semantics: array index is
+    /// tab position (schema spec §2 — order is significant).
+    ///
+    /// Errors on a duplicate name (case-insensitive, §2), an empty/too-long
+    /// name (§3), the sheet cap (Decision 5), or `index` out of `0..=len`.
+    pub fn insert_sheet(&mut self, index: usize, sheet: Worksheet) -> Result<(), WorkbookError> {
+        if self.sheets.len() >= limits::MAX_SHEETS {
+            return Err(WorkbookError::SheetManagement(format!(
+                "cannot add sheet: workbook already has {} sheets, the limit (scope ADR Decision 5)",
+                limits::MAX_SHEETS
+            )));
+        }
+        if index > self.sheets.len() {
+            return Err(WorkbookError::SheetManagement(format!(
+                "cannot insert sheet at position {index}: only {} tab slots exist",
+                self.sheets.len() + 1
+            )));
+        }
+        validate_sheet_name(sheet.name())?;
+        if let Some(existing) = self.sheet(sheet.name()) {
+            return Err(WorkbookError::SheetManagement(format!(
+                "cannot add sheet {:?}: it collides with the existing sheet {:?} under simple \
+                 case folding (schema spec §2)",
+                sheet.name(),
+                existing.name()
+            )));
+        }
+        self.sheets.insert(index, sheet);
+        Ok(())
+    }
+
+    /// Removes and returns the sheet named `name` (case-insensitive),
+    /// shifting later tabs left, or `None` if no sheet matches.
+    ///
+    /// A workbook-scoped named range may now dangle to the removed sheet; the
+    /// dangling-ref invariant is re-checked at [`to_json`](Self::to_json) /
+    /// [`from_json`](Self::from_json) (schema spec §7).
+    pub fn remove_sheet(&mut self, name: &str) -> Option<Worksheet> {
+        self.sheet_index(name).map(|i| self.sheets.remove(i))
+    }
+
+    /// Renames the sheet currently named `from` (case-insensitive) to `to`.
+    ///
+    /// A pure case change of the *same* sheet is allowed (it does not collide
+    /// with itself). Errors if `from` does not exist, if `to` is empty/too
+    /// long (§3), or if `to` collides with a *different* sheet (§2).
+    pub fn rename_sheet(&mut self, from: &str, to: &str) -> Result<(), WorkbookError> {
+        let idx = self.sheet_index(from).ok_or_else(|| {
+            WorkbookError::SheetManagement(format!("cannot rename: no sheet named {from:?}"))
+        })?;
+        validate_sheet_name(to)?;
+        if let Some(other) = self.sheet_index(to) {
+            if other != idx {
+                return Err(WorkbookError::SheetManagement(format!(
+                    "cannot rename sheet to {to:?}: it collides with another sheet under simple \
+                     case folding (schema spec §2)"
+                )));
+            }
+        }
+        self.sheets[idx].set_name(to);
+        Ok(())
+    }
+
+    /// Moves the sheet at tab position `from` to position `to`, shifting the
+    /// sheets in between (schema spec §2 — array position is tab position).
+    /// Errors if either index is out of `0..len`.
+    pub fn move_sheet(&mut self, from: usize, to: usize) -> Result<(), WorkbookError> {
+        let len = self.sheets.len();
+        if from >= len || to >= len {
+            return Err(WorkbookError::SheetManagement(format!(
+                "cannot move sheet from {from} to {to}: valid tab positions are 0..{len}"
+            )));
+        }
+        let sheet = self.sheets.remove(from);
+        self.sheets.insert(to, sheet);
+        Ok(())
+    }
+
     /// Parses a workbook from JSON bytes, enforcing every document-level rule
     /// of the schema (schema spec §1–§10) and the resource limits of the scope
     /// ADR (Decision 5).
@@ -137,6 +254,29 @@ impl Workbook {
         }
         Ok(canonical)
     }
+}
+
+/// Validates a sheet name for the mutation API: non-empty and ≤ 100 Unicode
+/// scalar values (schema spec §3). Uniqueness is checked separately against the
+/// existing sheet set; this is only the per-name shape check, mirroring the
+/// rule [`Workbook::from_json`] applies to a deserialized document.
+///
+/// [`Workbook::from_json`]: crate::Workbook::from_json
+fn validate_sheet_name(name: &str) -> Result<(), WorkbookError> {
+    let len = name.chars().count();
+    if len == 0 {
+        return Err(WorkbookError::SheetManagement(
+            "a worksheet name must be non-empty (schema spec §3)".to_owned(),
+        ));
+    }
+    if len > limits::MAX_SHEET_NAME_LEN {
+        return Err(WorkbookError::SheetManagement(format!(
+            "worksheet name {name:?} has {len} scalar values, exceeding the limit of {} \
+             (schema spec §3)",
+            limits::MAX_SHEET_NAME_LEN
+        )));
+    }
+    Ok(())
 }
 
 /// Domain ordering of schema spec §8.7: `names` is serialized sorted by `name`

--- a/crates/workbook/src/worksheet.rs
+++ b/crates/workbook/src/worksheet.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::address::Address;
 use crate::cell::Cell;
 
 /// A named sheet holding a sparse cell grid (schema spec §3).
@@ -11,9 +12,13 @@ use crate::cell::Cell;
 /// never serialized. The map is ordered (`BTreeMap`), which matches the
 /// canonical (JCS) key order for ASCII A1 addresses: `A10` sorts before `A2`.
 ///
-/// Address-syntax and sheet-name validation against the schema's normative
-/// rules happens at the serialization boundary (`Workbook::from_json`,
-/// plan item 2.3), not at construction.
+/// The typed grid API ([`get`](Self::get) / [`set`](Self::set) /
+/// [`clear`](Self::clear), keyed by a bounds-validated [`Address`]) is the
+/// in-memory accessor used by the recalc runtime (plan item 3.1); the raw
+/// [`cells`](Self::cells) map is retained for the serde layer. Address-syntax
+/// and sheet-name validation against the schema's normative rules also happens
+/// at the serialization boundary ([`Workbook::from_json`](crate::Workbook::from_json)),
+/// independently of the typed API, since `from_json` parses untrusted keys.
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Worksheet {
@@ -35,6 +40,13 @@ impl Worksheet {
         &self.name
     }
 
+    /// Sets the sheet name. Crate-internal: uniqueness and length validation is
+    /// the workbook's job ([`Workbook::rename_sheet`](crate::Workbook::rename_sheet)),
+    /// the only public path to a rename.
+    pub(crate) fn set_name(&mut self, name: impl Into<String>) {
+        self.name = name.into();
+    }
+
     /// The sparse cell grid, keyed by plain uppercase A1 address.
     pub fn cells(&self) -> &BTreeMap<String, Cell> {
         &self.cells
@@ -43,5 +55,58 @@ impl Worksheet {
     /// Mutable access to the sparse cell grid.
     pub fn cells_mut(&mut self) -> &mut BTreeMap<String, Cell> {
         &mut self.cells
+    }
+
+    /// The cell at `addr`, or `None` if that address is empty.
+    pub fn get(&self, addr: Address) -> Option<&Cell> {
+        self.cells.get(&addr.to_a1())
+    }
+
+    /// Mutable access to the cell at `addr`, or `None` if that address is empty.
+    pub fn get_mut(&mut self, addr: Address) -> Option<&mut Cell> {
+        self.cells.get_mut(&addr.to_a1())
+    }
+
+    /// Writes `cell` at `addr`, returning the cell previously there (if any).
+    ///
+    /// `addr` is already bounds-validated by construction, so a set never
+    /// escapes the address bounds. To clear a cell use [`clear`](Self::clear),
+    /// never a set of an empty value (schema spec §4).
+    pub fn set(&mut self, addr: Address, cell: Cell) -> Option<Cell> {
+        self.cells.insert(addr.to_a1(), cell)
+    }
+
+    /// Removes the cell at `addr`, returning it if present.
+    ///
+    /// Clearing a cell is *removing its entry*, never writing an empty value:
+    /// an empty entry would be byte-distinguishable from the absent cell it
+    /// denotes (schema spec §4).
+    pub fn clear(&mut self, addr: Address) -> Option<Cell> {
+        self.cells.remove(&addr.to_a1())
+    }
+
+    /// Whether a cell is present at `addr`.
+    pub fn contains(&self, addr: Address) -> bool {
+        self.cells.contains_key(&addr.to_a1())
+    }
+
+    /// The number of populated cells.
+    pub fn len(&self) -> usize {
+        self.cells.len()
+    }
+
+    /// Whether the grid has no populated cells.
+    pub fn is_empty(&self) -> bool {
+        self.cells.is_empty()
+    }
+
+    /// Iterates the populated cells in canonical (JCS) key order, yielding the
+    /// parsed [`Address`] for each. Keys held by a worksheet are always valid
+    /// A1, so parsing cannot fail.
+    pub fn iter(&self) -> impl Iterator<Item = (Address, &Cell)> {
+        self.cells.iter().map(|(key, cell)| {
+            let addr = Address::from_a1(key).expect("worksheet keys are always valid A1");
+            (addr, cell)
+        })
     }
 }

--- a/crates/workbook/tests/address_tests.rs
+++ b/crates/workbook/tests/address_tests.rs
@@ -1,0 +1,80 @@
+//! A1 ↔ `(row, column)` conversion and address-bounds tests (plan item 3.1,
+//! schema spec §3, limits ADR Decision 5).
+
+use truecalc_workbook::Address;
+
+#[test]
+fn a1_round_trips_through_address() {
+    for key in [
+        "A1",
+        "B2",
+        "Z9",
+        "AA1",
+        "AZ10",
+        "BA100",
+        "ZZ65536",
+        "ZZZ10000000",
+    ] {
+        let addr = Address::from_a1(key).unwrap_or_else(|| panic!("{key} should parse"));
+        assert_eq!(addr.to_a1(), key, "{key} should round-trip");
+    }
+}
+
+#[test]
+fn column_letters_map_to_indices() {
+    assert_eq!(Address::from_a1("A1").unwrap().column, 1);
+    assert_eq!(Address::from_a1("Z1").unwrap().column, 26);
+    assert_eq!(Address::from_a1("AA1").unwrap().column, 27);
+    assert_eq!(Address::from_a1("AZ1").unwrap().column, 52);
+    assert_eq!(Address::from_a1("BA1").unwrap().column, 53);
+    // ZZZ is the maximum in-bounds column (18,278).
+    assert_eq!(Address::from_a1("ZZZ1").unwrap().column, 18_278);
+}
+
+#[test]
+fn new_is_the_inverse_of_to_a1() {
+    let addr = Address::new(42, 53).unwrap();
+    assert_eq!(addr.to_a1(), "BA42");
+    assert_eq!(Address::from_a1("BA42"), Some(addr));
+}
+
+#[test]
+fn rows_at_the_bounds() {
+    assert!(Address::new(1, 1).is_some());
+    assert!(Address::new(10_000_000, 1).is_some());
+    assert!(Address::from_a1("A10000000").is_some());
+    // Row 0 and beyond the 10,000,000 cap are out of bounds.
+    assert!(Address::new(0, 1).is_none());
+    assert!(Address::new(10_000_001, 1).is_none());
+    assert!(Address::from_a1("A0").is_none());
+    assert!(Address::from_a1("A10000001").is_none());
+}
+
+#[test]
+fn columns_at_the_bounds() {
+    assert!(Address::new(1, 18_278).is_some());
+    assert!(Address::new(1, 0).is_none());
+    assert!(Address::new(1, 18_279).is_none());
+    // Four letters always exceed the bound and the 3-letter key grammar.
+    assert!(Address::from_a1("AAAA1").is_none());
+}
+
+#[test]
+fn malformed_keys_are_rejected() {
+    for bad in [
+        "",
+        "1",
+        "A",
+        "a1",
+        "$A$1",
+        "A1:B2",
+        "Sheet1!A1",
+        "A01",
+        "A 1",
+        "A1 ",
+        " A1",
+        "A1.0",
+    ] {
+        assert!(Address::from_a1(bad).is_none(), "{bad:?} must not parse");
+    }
+}

--- a/crates/workbook/tests/grid_tests.rs
+++ b/crates/workbook/tests/grid_tests.rs
@@ -1,0 +1,80 @@
+//! Sparse worksheet grid: get / set / clear / iterate keyed by a parsed
+//! [`Address`] (plan item 3.1, schema spec §3–§4).
+
+use truecalc_workbook::{Address, Cell, Value, Worksheet};
+
+fn addr(key: &str) -> Address {
+    Address::from_a1(key).unwrap()
+}
+
+#[test]
+fn empty_grid_has_no_cells() {
+    let ws = Worksheet::new("Sheet1");
+    assert!(ws.is_empty());
+    assert_eq!(ws.len(), 0);
+    assert_eq!(ws.get(addr("A1")), None);
+    assert!(!ws.contains(addr("A1")));
+}
+
+#[test]
+fn set_then_get_round_trips() {
+    let mut ws = Worksheet::new("Sheet1");
+    let cell = Cell::literal(Value::Number(42.0)).unwrap();
+    assert_eq!(ws.set(addr("B2"), cell.clone()), None);
+    assert_eq!(ws.get(addr("B2")), Some(&cell));
+    assert!(ws.contains(addr("B2")));
+    assert_eq!(ws.len(), 1);
+}
+
+#[test]
+fn set_returns_the_previous_cell() {
+    let mut ws = Worksheet::new("Sheet1");
+    let first = Cell::literal(Value::Number(1.0)).unwrap();
+    let second = Cell::literal(Value::Number(2.0)).unwrap();
+    ws.set(addr("C3"), first.clone());
+    assert_eq!(ws.set(addr("C3"), second.clone()), Some(first));
+    assert_eq!(ws.get(addr("C3")), Some(&second));
+    assert_eq!(ws.len(), 1, "overwriting does not grow the grid");
+}
+
+#[test]
+fn clear_removes_the_entry_and_returns_it() {
+    let mut ws = Worksheet::new("Sheet1");
+    let cell = Cell::literal(Value::Text("hi".to_owned())).unwrap();
+    ws.set(addr("A1"), cell.clone());
+    assert_eq!(ws.clear(addr("A1")), Some(cell));
+    assert_eq!(
+        ws.clear(addr("A1")),
+        None,
+        "clearing an absent cell is a no-op"
+    );
+    assert!(ws.is_empty());
+}
+
+#[test]
+fn get_mut_edits_in_place() {
+    let mut ws = Worksheet::new("Sheet1");
+    ws.set(addr("A1"), Cell::with_formula("=1+1", Value::Empty));
+    *ws.get_mut(addr("A1")).unwrap() = Cell::with_formula("=1+1", Value::Number(2.0));
+    assert_eq!(ws.get(addr("A1")).unwrap().value(), &Value::Number(2.0));
+}
+
+#[test]
+fn iter_yields_addresses_in_canonical_key_order() {
+    let mut ws = Worksheet::new("Sheet1");
+    // Insert out of order; JCS key order sorts "A10" before "A2".
+    for key in ["A2", "A10", "A1", "B1"] {
+        ws.set(addr(key), Cell::literal(Value::Number(1.0)).unwrap());
+    }
+    let keys: Vec<String> = ws.iter().map(|(a, _)| a.to_a1()).collect();
+    assert_eq!(keys, vec!["A1", "A10", "A2", "B1"]);
+}
+
+#[test]
+fn iter_addresses_match_their_cells() {
+    let mut ws = Worksheet::new("Sheet1");
+    ws.set(addr("ZZ100"), Cell::literal(Value::Number(7.0)).unwrap());
+    let (a, cell) = ws.iter().next().unwrap();
+    assert_eq!(a, addr("ZZ100"));
+    assert_eq!(cell.value(), &Value::Number(7.0));
+}

--- a/crates/workbook/tests/sheet_management_tests.rs
+++ b/crates/workbook/tests/sheet_management_tests.rs
@@ -1,0 +1,154 @@
+//! Sheet management: add / insert / remove / rename / move with position
+//! semantics, plus name uniqueness under Unicode *simple* case folding
+//! (plan item 3.1, schema spec §2–§3, scope ADR Decision 5).
+
+use truecalc_workbook::{Cell, EngineFlavor, Value, Workbook, Worksheet};
+
+fn wb() -> Workbook {
+    Workbook::new(EngineFlavor::Sheets)
+}
+
+fn names(wb: &Workbook) -> Vec<&str> {
+    wb.sheets().iter().map(Worksheet::name).collect()
+}
+
+#[test]
+fn add_sheet_appends_in_tab_order() {
+    let mut wb = wb();
+    assert_eq!(wb.add_sheet(Worksheet::new("Alpha")).unwrap(), 0);
+    assert_eq!(wb.add_sheet(Worksheet::new("Beta")).unwrap(), 1);
+    assert_eq!(names(&wb), vec!["Alpha", "Beta"]);
+}
+
+#[test]
+fn insert_sheet_shifts_later_tabs_right() {
+    let mut wb = wb();
+    wb.add_sheet(Worksheet::new("Alpha")).unwrap();
+    wb.add_sheet(Worksheet::new("Gamma")).unwrap();
+    wb.insert_sheet(1, Worksheet::new("Beta")).unwrap();
+    assert_eq!(names(&wb), vec!["Alpha", "Beta", "Gamma"]);
+}
+
+#[test]
+fn insert_at_len_appends_and_beyond_len_errors() {
+    let mut wb = wb();
+    wb.add_sheet(Worksheet::new("Alpha")).unwrap();
+    wb.insert_sheet(1, Worksheet::new("Beta")).unwrap(); // == len: appends
+    assert_eq!(names(&wb), vec!["Alpha", "Beta"]);
+    assert!(wb.insert_sheet(99, Worksheet::new("Far")).is_err());
+}
+
+#[test]
+fn lookup_is_case_insensitive() {
+    let mut wb = wb();
+    wb.add_sheet(Worksheet::new("Budget")).unwrap();
+    assert!(wb.sheet("budget").is_some());
+    assert!(wb.sheet("BUDGET").is_some());
+    assert_eq!(wb.sheet_index("BuDgEt"), Some(0));
+    assert!(wb.sheet("Other").is_none());
+}
+
+#[test]
+fn duplicate_name_is_rejected_case_insensitively() {
+    let mut wb = wb();
+    wb.add_sheet(Worksheet::new("Sheet1")).unwrap();
+    assert!(wb.add_sheet(Worksheet::new("sheet1")).is_err());
+    assert!(wb.add_sheet(Worksheet::new("SHEET1")).is_err());
+    assert_eq!(
+        names(&wb),
+        vec!["Sheet1"],
+        "rejected adds leave the workbook unchanged"
+    );
+}
+
+#[test]
+fn uniqueness_uses_simple_case_folding_not_ascii_lowercasing() {
+    // Kelvin sign (U+212A) simple-folds to ASCII 'k'; a sheet named "K" must
+    // collide with one named "\u{212A}" (KELVIN SIGN). ASCII-only lowercasing
+    // would miss this — the test pins the simple-case-folding rule (§2).
+    let mut wb = wb();
+    wb.add_sheet(Worksheet::new("K")).unwrap();
+    assert!(
+        wb.add_sheet(Worksheet::new("\u{212A}")).is_err(),
+        "Kelvin sign must collide with ASCII K under simple case folding"
+    );
+}
+
+#[test]
+fn remove_sheet_shifts_later_tabs_left() {
+    let mut wb = wb();
+    for n in ["Alpha", "Beta", "Gamma"] {
+        wb.add_sheet(Worksheet::new(n)).unwrap();
+    }
+    let removed = wb.remove_sheet("beta").unwrap();
+    assert_eq!(removed.name(), "Beta");
+    assert_eq!(names(&wb), vec!["Alpha", "Gamma"]);
+    assert!(wb.remove_sheet("missing").is_none());
+}
+
+#[test]
+fn rename_keeps_cells_and_position() {
+    let mut wb = wb();
+    let mut ws = Worksheet::new("Old");
+    ws.set(
+        truecalc_workbook::Address::from_a1("A1").unwrap(),
+        Cell::literal(Value::Number(5.0)).unwrap(),
+    );
+    wb.add_sheet(ws).unwrap();
+    wb.add_sheet(Worksheet::new("Other")).unwrap();
+    wb.rename_sheet("old", "New").unwrap();
+    assert_eq!(names(&wb), vec!["New", "Other"]);
+    assert_eq!(wb.sheet("New").unwrap().len(), 1, "cells survive a rename");
+}
+
+#[test]
+fn rename_to_a_pure_case_change_of_itself_is_allowed() {
+    let mut wb = wb();
+    wb.add_sheet(Worksheet::new("data")).unwrap();
+    wb.rename_sheet("data", "DATA").unwrap();
+    assert_eq!(names(&wb), vec!["DATA"]);
+}
+
+#[test]
+fn rename_to_a_different_sheets_name_is_rejected() {
+    let mut wb = wb();
+    wb.add_sheet(Worksheet::new("Alpha")).unwrap();
+    wb.add_sheet(Worksheet::new("Beta")).unwrap();
+    assert!(wb.rename_sheet("Alpha", "beta").is_err());
+    assert!(wb.rename_sheet("Missing", "X").is_err());
+    assert_eq!(names(&wb), vec!["Alpha", "Beta"]);
+}
+
+#[test]
+fn move_sheet_repositions_with_shift() {
+    let mut wb = wb();
+    for n in ["Alpha", "Beta", "Gamma"] {
+        wb.add_sheet(Worksheet::new(n)).unwrap();
+    }
+    wb.move_sheet(0, 2).unwrap(); // Alpha to the end
+    assert_eq!(names(&wb), vec!["Beta", "Gamma", "Alpha"]);
+    wb.move_sheet(2, 0).unwrap(); // back to the front
+    assert_eq!(names(&wb), vec!["Alpha", "Beta", "Gamma"]);
+    assert!(wb.move_sheet(0, 99).is_err());
+}
+
+#[test]
+fn empty_and_too_long_names_are_rejected() {
+    let mut wb = wb();
+    assert!(wb.add_sheet(Worksheet::new("")).is_err());
+    let too_long: String = "x".repeat(101);
+    assert!(wb.add_sheet(Worksheet::new(too_long)).is_err());
+    let max_len: String = "x".repeat(100);
+    assert!(wb.add_sheet(Worksheet::new(max_len)).is_ok());
+}
+
+#[test]
+fn sheet_mut_edits_the_grid_in_place() {
+    let mut wb = wb();
+    wb.add_sheet(Worksheet::new("Sheet1")).unwrap();
+    wb.sheet_mut("sheet1").unwrap().set(
+        truecalc_workbook::Address::from_a1("A1").unwrap(),
+        Cell::literal(Value::Number(9.0)).unwrap(),
+    );
+    assert_eq!(wb.sheet("Sheet1").unwrap().len(), 1);
+}


### PR DESCRIPTION
## P3.1: Sparse grid + A1 addressing + sheet management

Lays the **runtime grid foundation** for the workbook recalc engine (plan item 3.1) — the layer the dependency graph (P3.2 #534), recalc (P3.3 #535), mutation API (P3.4 #536), and spill (P3.5 #537) build on. Scope is strictly grid + addressing + sheet management; none of those later layers are implemented here.

### Addressing (`address.rs`)
- `Address` is now public — a bounds-validated `(row, column)` grid key (rows `1..=10_000_000`, columns `1..=18_278`, i.e. `A..=ZZZ`).
- A1 ↔ `(row, column)` utilities: `Address::new`, `Address::from_a1`, `Address::to_a1` (schema spec §3, limits ADR Decision 5).
- `parse_a1` stays a free function (the document validator and named-ref parser call it on untrusted keys); `Address::new` now folds in the bounds check so every constructor path is bounds-validated.

### Sparse grid (`worksheet.rs`)
- Typed accessors keyed by `Address` over the existing ordered (`BTreeMap`) sparse store: `get` / `get_mut` / `set` / `clear` / `contains` / `len` / `is_empty` / `iter`.
- `clear` **removes** the entry (never writes an empty value — schema spec §4); `iter` yields canonical (JCS) key order, so `A10` precedes `A2`.

### Sheet management (`workbook.rs`)
- `sheet` / `sheet_mut` / `sheet_index` (case-insensitive lookup); `add_sheet` / `insert_sheet` / `remove_sheet` / `rename_sheet` / `move_sheet` with **array-position-is-tab-position** semantics (schema spec §2 — order is significant).
- Name uniqueness enforced under Unicode **simple** case folding (§2), names non-empty / ≤ 100 scalar values (§3), and the per-workbook sheet cap (scope ADR Decision 5). New `WorkbookError::SheetManagement`. A rename that is a pure case change of the same sheet is allowed.

### Shared (`casefold.rs`)
- Extracted the simple-case-folding helper so sheet management and the existing document validator share one implementation (no drift). `validate.rs` updated to use it.

### Tests (separate files, per repo rules)
- `address_tests.rs` — A1↔(row,col) round-trip, column-letter mapping, **row/column bounds** at and beyond `A1`/`ZZZ`/`10_000_000`, malformed-key rejection.
- `grid_tests.rs` — get/set/clear (returns prior cell; clear is a no-op on absent), in-place `get_mut`, canonical key-order iteration.
- `sheet_management_tests.rs` — add/insert/remove/move position semantics, case-insensitive lookup, **Unicode simple-case-folding name uniqueness** (Kelvin sign U+212A vs ASCII `K`), rename keeps cells + position, empty/too-long name rejection.

### Verification (local)
- `cargo build -p truecalc-workbook` ✅
- `cargo clippy -p truecalc-workbook --all-targets -- -D warnings` ✅
- `cargo fmt -p truecalc-workbook -- --check` ✅
- Full `truecalc-workbook` suite green, including the canonical-JSON golden byte-identity and roundtrip property tests (the casefold extraction is behavior-preserving).

### Scope discipline
No dependency graph, recalc, mutation diffing, or spill logic — those are P3.2–P3.5. No fixture TSVs touched. Engine flavor stays explicit; workbooks remain engine-locked at creation.

Closes #533
