### PR TITLE
feat(workbook): dependency graph from extract_refs (P3.2, #534)

### DIFF
--- a/crates/workbook/src/depgraph.rs
+++ b/crates/workbook/src/depgraph.rs
@@ -1,0 +1,683 @@
+//! Dependency graph for the workbook runtime (plan item 3.2, issue #534).
+//!
+//! The graph records, for every formula cell, *which cells, ranges, and named
+//! ranges it reads* — its **precedents** — derived once from the parsed
+//! formula via [`truecalc_core::extract_refs`] (P1.3). The reverse edges (a
+//! cell's **dependents**: the formula cells that must recalculate when it
+//! changes) are what the recalc engine (P3.3, #535) walks to propagate a dirty
+//! set, and what topological ordering and cycle detection run over.
+//!
+//! # What this layer is (and is not)
+//!
+//! This is the dependency *graph only*. It owns no values and performs no
+//! evaluation: [`DependencyGraph::build`] reads a [`Workbook`] and produces the
+//! edges; recalculation is P3.3. It exposes a [topological order /
+//! cycle-detection primitive](DependencyGraph::topological_order) because P3.3
+//! needs it, but it never evaluates a formula.
+//!
+//! # How edges are derived ([`extract_refs`])
+//!
+//! For each formula cell the graph parses the verbatim formula with the
+//! workbook's locked engine, calls [`extract_refs`] on the AST, and resolves
+//! each [`Ref`] to a concrete graph node:
+//!
+//! - [`Ref::Cell`] → a single-cell precedent; a bare `A1` resolves against the
+//!   formula cell's *own* sheet, a qualified `Sheet1!A1` against the named
+//!   sheet.
+//! - [`Ref::Range`] → a **range node** (range-node compression): `A1:A100000`
+//!   is one node, not 100 000 edges. A changed cell finds its range-dependents
+//!   by testing membership in each live range node, so the graph stays linear
+//!   in the number of *distinct ranges*, not their area.
+//! - [`Ref::Name`] → a **name node** (name → target indirection): the formula
+//!   depends on the name, the name depends on its current target cell/range.
+//!   Retargeting a name (P3.4) therefore dirties the name's dependents without
+//!   rebuilding their edges, and a write inside a name's target range dirties
+//!   the name's dependents transitively.
+//!
+//! A reference that cannot be resolved (an unknown sheet, an unknown name, a
+//! malformed or unparseable formula) is recorded as an [`Unresolved`]
+//! precedent rather than dropped: it carries no edge (nothing can dirty it),
+//! but it is preserved so the recalc engine can surface the Sheets error the
+//! formula will ultimately produce (`#REF!` / `#NAME?`), fixture-verified in
+//! P3.3 rather than assumed here.
+//!
+//! [`extract_refs`]: truecalc_core::extract_refs
+//! [`Ref`]: truecalc_core::Ref
+//! [`Ref::Cell`]: truecalc_core::Ref::Cell
+//! [`Ref::Range`]: truecalc_core::Ref::Range
+//! [`Ref::Name`]: truecalc_core::Ref::Name
+//! [`Unresolved`]: Precedent::Unresolved
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+use icu_casemap::CaseMapperBorrowed;
+use truecalc_core::{CellAddr, Engine, EngineFlavor, Ref};
+
+use crate::address::Address;
+use crate::casefold::simple_fold;
+use crate::named_ref;
+use crate::workbook::Workbook;
+
+/// A fully resolved cell coordinate: a sheet (by its position-independent,
+/// case-folded name) and an in-bounds [`Address`].
+///
+/// Sheets are keyed by **folded name**, not tab index, so the key survives a
+/// sheet move (P3.1 `move_sheet`) and matches the case-insensitive sheet
+/// lookup of [`Workbook::sheet`](crate::Workbook::sheet). A rename changes the
+/// key, which is why a rename forces a graph rebuild (see the module docs and
+/// [`DependencyGraph::build`]).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CellRef {
+    /// The target sheet's name, simple-case-folded (schema spec §2).
+    pub sheet: String,
+    /// The in-bounds A1 address within that sheet.
+    pub addr: Address,
+}
+
+impl CellRef {
+    fn new(sheet: String, addr: Address) -> Self {
+        Self { sheet, addr }
+    }
+}
+
+/// A resolved rectangular range: a sheet (folded name) and an inclusive,
+/// top-left-first corner pair.
+///
+/// Range-node compression hinges on this being a single value regardless of
+/// area: membership of a [`CellRef`] is an `O(1)` rectangle test
+/// ([`RangeRef::contains`]), so finding the formula cells that read a changed
+/// cell through a range costs one test per *distinct range*, never one per cell
+/// in the range.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RangeRef {
+    /// The target sheet's name, simple-case-folded.
+    pub sheet: String,
+    /// Top-left corner (minimum row, minimum column).
+    pub start: Address,
+    /// Bottom-right corner (maximum row, maximum column).
+    pub end: Address,
+}
+
+impl RangeRef {
+    /// Whether `cell` lies inside this range (same sheet, within the inclusive
+    /// rectangle). The membership test behind range-node compression.
+    pub fn contains(&self, cell: &CellRef) -> bool {
+        cell.sheet == self.sheet
+            && cell.addr.row >= self.start.row
+            && cell.addr.row <= self.end.row
+            && cell.addr.column >= self.start.column
+            && cell.addr.column <= self.end.column
+    }
+}
+
+/// One resolved precedent of a formula cell: what a single [`Ref`] in the
+/// formula points at, after sheet/name resolution.
+///
+/// [`extract_refs`](truecalc_core::extract_refs) yields one [`Ref`] per
+/// reference occurrence (duplicates preserved); the graph maps each to one of
+/// these. [`Unresolved`](Precedent::Unresolved) keeps a reference that has no
+/// concrete target (unknown sheet/name, unparseable formula) so the recalc
+/// engine can still emit the right Sheets error.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Precedent {
+    /// A single cell (`A1` on the formula's own sheet, or `Sheet1!A1`).
+    Cell(CellRef),
+    /// A rectangular range (`A1:D4`, `Sheet1!A1:B2`) — a compressed range node.
+    Range(RangeRef),
+    /// A workbook-scoped named range, by its case-folded name. The name's
+    /// current target (cell or range) supplies the transitive edges.
+    Name(String),
+    /// A reference that did not resolve to a concrete target: an unknown sheet
+    /// or name, or a formula that failed to parse. Carries the canonical
+    /// reference text for diagnostics; it produces no dirty-propagation edge.
+    Unresolved(String),
+}
+
+/// The dependency graph of a [`Workbook`]: precedents and reverse-edge indexes
+/// derived from every formula cell via [`extract_refs`](truecalc_core::extract_refs).
+///
+/// Built with [`DependencyGraph::build`]; queried with
+/// [`precedents_of`](Self::precedents_of),
+/// [`direct_dependents_of`](Self::direct_dependents_of),
+/// [`topological_order`](Self::topological_order), and
+/// [`cycle_cells`](Self::cycle_cells). It is a pure derived view — it borrows
+/// nothing from the workbook after `build` returns and holds no values.
+///
+/// Rebuild rules (issue #534, "Rebuild rules on set/clear/rename"): the graph
+/// is a function of the workbook's formulas, sheet names, and named-range
+/// targets, so any edit that changes those — `set`/`clear` of a formula cell,
+/// a sheet rename, a named-range retarget — invalidates it. The P3.4 mutation
+/// API rebuilds (or incrementally updates) the graph after such edits; the
+/// graph-rebuild equivalence tests assert that a from-scratch
+/// [`build`](Self::build) after an arbitrary edit sequence equals the
+/// maintained graph.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DependencyGraph {
+    /// Every formula cell, with its resolved precedents in formula order
+    /// (duplicates from `extract_refs` deduplicated per cell). The key set is
+    /// exactly the set of graph nodes that carry a formula.
+    precedents: BTreeMap<CellRef, Vec<Precedent>>,
+    /// Reverse cell→formula edges: for a precedent *cell*, the formula cells
+    /// that read it directly. The `O(1)` half of dependent lookup.
+    cell_dependents: HashMap<CellRef, BTreeSet<CellRef>>,
+    /// Reverse range edges: each distinct range node and the formula cells that
+    /// read it. Range-node compression — one entry per range, tested by
+    /// rectangle membership at query time.
+    range_dependents: Vec<(RangeRef, BTreeSet<CellRef>)>,
+    /// Name → its dependent formula cells (formulas that reference the name).
+    name_dependents: HashMap<String, BTreeSet<CellRef>>,
+    /// Name → its resolved current target (the indirection layer). Absent if
+    /// the name is undefined or dangles; retargeting updates this entry.
+    name_targets: HashMap<String, NameTarget>,
+}
+
+/// What a named range currently resolves to (the name→target indirection).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NameTarget {
+    Cell(CellRef),
+    Range(RangeRef),
+}
+
+impl DependencyGraph {
+    /// Builds the dependency graph from `workbook`.
+    ///
+    /// Walks every populated cell on every sheet; for each *formula* cell,
+    /// parses the formula with the workbook's locked engine, extracts its refs
+    /// ([`extract_refs`](truecalc_core::extract_refs)), resolves each to a
+    /// concrete node, and records both the forward precedent list and the
+    /// reverse edges. Named-range targets are resolved up front so name
+    /// indirection edges are available.
+    ///
+    /// Resolution is total: an unresolvable reference becomes a
+    /// [`Precedent::Unresolved`] rather than an error, so a workbook with a
+    /// dangling `Sheet9!A1` or an unknown name still builds (the recalc engine
+    /// turns those into Sheets errors, fixture-verified in P3.3). Building
+    /// therefore never fails.
+    pub fn build(workbook: &Workbook) -> Self {
+        let folder = CaseMapperBorrowed::new();
+        let engine = match workbook.engine() {
+            EngineFlavor::Sheets => Engine::sheets(),
+            EngineFlavor::Excel => Engine::excel(),
+        };
+
+        // Resolve named-range targets first (the name → target indirection
+        // layer). A name whose ref names a missing sheet, or is itself
+        // malformed, simply has no target and contributes no transitive edge.
+        let mut name_targets: HashMap<String, NameTarget> = HashMap::new();
+        for nr in workbook.names() {
+            let folded = simple_fold(&folder, &nr.name);
+            if let Some(target) = resolve_name_ref(&nr.r#ref, &folder, workbook) {
+                name_targets.insert(folded, target);
+            }
+        }
+
+        let mut graph = DependencyGraph {
+            precedents: BTreeMap::new(),
+            cell_dependents: HashMap::new(),
+            range_dependents: Vec::new(),
+            name_dependents: HashMap::new(),
+            name_targets,
+        };
+        // Stable index from a range node to its slot in `range_dependents`, so
+        // repeated references to the same range share one compressed node.
+        let mut range_slots: HashMap<RangeRef, usize> = HashMap::new();
+
+        for sheet in workbook.sheets() {
+            let sheet_folded = simple_fold(&folder, sheet.name());
+            for (addr, cell) in sheet.iter() {
+                let Some(formula) = cell.formula() else {
+                    continue;
+                };
+                let from = CellRef::new(sheet_folded.clone(), addr);
+
+                let refs = match engine.parse(formula) {
+                    Ok(expr) => truecalc_core::extract_refs(&expr),
+                    // An unparseable formula has one self-describing precedent
+                    // and no edges — the recalc engine reports the parse error.
+                    Err(_) => {
+                        graph.precedents.insert(
+                            from.clone(),
+                            vec![Precedent::Unresolved(formula.to_owned())],
+                        );
+                        continue;
+                    }
+                };
+
+                let mut seen: HashSet<Precedent> = HashSet::new();
+                let mut resolved: Vec<Precedent> = Vec::new();
+                for r in &refs {
+                    let prec = resolve_ref(r, &from.sheet, &folder, workbook);
+                    if seen.insert(prec.clone()) {
+                        resolved.push(prec);
+                    }
+                }
+
+                // Record reverse edges for each resolved precedent.
+                for prec in &resolved {
+                    match prec {
+                        Precedent::Cell(target) => {
+                            graph
+                                .cell_dependents
+                                .entry(target.clone())
+                                .or_default()
+                                .insert(from.clone());
+                        }
+                        Precedent::Range(range) => {
+                            let slot = *range_slots.entry(range.clone()).or_insert_with(|| {
+                                graph
+                                    .range_dependents
+                                    .push((range.clone(), BTreeSet::new()));
+                                graph.range_dependents.len() - 1
+                            });
+                            graph.range_dependents[slot].1.insert(from.clone());
+                        }
+                        Precedent::Name(name) => {
+                            graph
+                                .name_dependents
+                                .entry(name.clone())
+                                .or_default()
+                                .insert(from.clone());
+                        }
+                        Precedent::Unresolved(_) => {}
+                    }
+                }
+
+                graph.precedents.insert(from, resolved);
+            }
+        }
+
+        graph
+    }
+
+    /// The resolved precedents of `cell` in formula order, or `None` if `cell`
+    /// is not a formula cell (a literal or an empty cell has no precedents).
+    pub fn precedents_of(&self, cell: &CellRef) -> Option<&[Precedent]> {
+        self.precedents.get(cell).map(Vec::as_slice)
+    }
+
+    /// Whether `cell` is a formula cell tracked by the graph.
+    pub fn is_formula(&self, cell: &CellRef) -> bool {
+        self.precedents.contains_key(cell)
+    }
+
+    /// Every formula cell in the graph, in canonical (sheet, address) order.
+    pub fn formula_cells(&self) -> impl Iterator<Item = &CellRef> {
+        self.precedents.keys()
+    }
+
+    /// The formula cells that read `cell` **directly** — through a single-cell
+    /// reference, through a range that contains `cell`, or through a named
+    /// range whose target contains `cell`.
+    ///
+    /// This is the dirty-propagation primitive the incremental recalc engine
+    /// (P3.3) walks transitively: when `cell` changes, every cell returned here
+    /// is dirty, and the walk repeats from each of them. It deliberately
+    /// composes all three edge kinds so callers never reason about
+    /// range-node compression or name indirection themselves.
+    ///
+    /// Returned in canonical (sheet, address) order; the set is deduplicated
+    /// even when a formula reaches `cell` by more than one path.
+    pub fn direct_dependents_of(&self, cell: &CellRef) -> BTreeSet<CellRef> {
+        let mut out = BTreeSet::new();
+        if let Some(direct) = self.cell_dependents.get(cell) {
+            out.extend(direct.iter().cloned());
+        }
+        for (range, deps) in &self.range_dependents {
+            if range.contains(cell) {
+                out.extend(deps.iter().cloned());
+            }
+        }
+        // Name indirection: a write inside a name's target dirties the name's
+        // dependents.
+        for (name, target) in &self.name_targets {
+            let hit = match target {
+                NameTarget::Cell(c) => c == cell,
+                NameTarget::Range(r) => r.contains(cell),
+            };
+            if hit {
+                if let Some(deps) = self.name_dependents.get(name) {
+                    out.extend(deps.iter().cloned());
+                }
+            }
+        }
+        out
+    }
+
+    /// The formula cells that depend on the named range `name` (any case),
+    /// i.e. would be dirtied by retargeting it (P3.4).
+    ///
+    /// Retargeting a name changes what its dependents read without changing
+    /// their formulas, so the recalc engine dirties exactly this set (the
+    /// name → target indirection promised by issue #534).
+    pub fn name_dependents_of(&self, name: &str) -> BTreeSet<CellRef> {
+        let folder = CaseMapperBorrowed::new();
+        let folded = simple_fold(&folder, name);
+        self.name_dependents
+            .get(&folded)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// A topological order of the formula cells: every cell appears after all
+    /// the formula cells it (transitively) reads, so evaluating in this order
+    /// visits each cell only once with its precedents already current.
+    ///
+    /// Returns `Ok(order)` when the formula-cell subgraph is acyclic, or
+    /// `Err(cycle_cells)` listing every formula cell that lies on a cycle (the
+    /// set [`cycle_cells`](Self::cycle_cells) returns). Only edges *between
+    /// formula cells* participate: a formula that reads a literal cell has
+    /// nothing to wait for. This is the ordering primitive P3.3 evaluates in;
+    /// the Sheets circular-dependency error semantics for the cells on a cycle
+    /// are applied by the recalc engine (fixture-verified there), not here.
+    pub fn topological_order(&self) -> Result<Vec<CellRef>, BTreeSet<CellRef>> {
+        // Index the formula cells in canonical order so Kahn's algorithm is
+        // O(V + E) and its tie-breaking is deterministic across surfaces.
+        let nodes: Vec<&CellRef> = self.precedents.keys().collect();
+        let index_of: HashMap<&CellRef, usize> =
+            nodes.iter().enumerate().map(|(i, n)| (*n, i)).collect();
+
+        // Formula-cell-only adjacency: precedent formula cell → dependent
+        // formula cell, with in-degrees for Kahn's algorithm. `BTreeSet` keeps
+        // each node's successors in canonical order and dedups parallel edges.
+        let mut succ: Vec<BTreeSet<usize>> = vec![BTreeSet::new(); nodes.len()];
+        let mut indeg: Vec<usize> = vec![0; nodes.len()];
+        for (i, cell) in nodes.iter().enumerate() {
+            for prec in &self.precedents[*cell] {
+                for fp in self.formula_precedent_cells(prec) {
+                    // Edge fp(j) → cell(i): cell i depends on fp.
+                    if let Some(&j) = index_of.get(&fp) {
+                        if succ[j].insert(i) {
+                            indeg[i] += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Kahn's algorithm; the ready set is a BTreeSet of indices, which —
+        // because `nodes` is in canonical order — pops in canonical order, so
+        // the topological order is itself deterministic.
+        let mut ready: BTreeSet<usize> = (0..nodes.len()).filter(|&i| indeg[i] == 0).collect();
+        let mut order: Vec<CellRef> = Vec::with_capacity(nodes.len());
+        while let Some(&node) = ready.iter().next() {
+            ready.remove(&node);
+            order.push(nodes[node].clone());
+            for &dep in &succ[node] {
+                indeg[dep] -= 1;
+                if indeg[dep] == 0 {
+                    ready.insert(dep);
+                }
+            }
+        }
+
+        if order.len() == nodes.len() {
+            Ok(order)
+        } else {
+            // Some cells never reached in-degree 0: they are on or downstream
+            // of a cycle. Report exactly the cells *on* a cycle.
+            Err(self.cycle_cells())
+        }
+    }
+
+    /// Every formula cell that lies on a dependency cycle (a strongly connected
+    /// component of size > 1, or a self-referential cell).
+    ///
+    /// This is the set P3.3 marks with the Sheets circular-dependency error.
+    /// Empty iff the formula-cell subgraph is acyclic. Computed independently
+    /// of [`topological_order`](Self::topological_order) so it can be queried
+    /// directly.
+    pub fn cycle_cells(&self) -> BTreeSet<CellRef> {
+        // Tarjan's SCC over the formula-cell-only graph.
+        let nodes: Vec<CellRef> = self.precedents.keys().cloned().collect();
+        let index_of: HashMap<&CellRef, usize> =
+            nodes.iter().enumerate().map(|(i, n)| (n, i)).collect();
+
+        // Successor list (precedent formula cell → dependent formula cell),
+        // matching topological_order's edge direction. Self loops are kept so a
+        // self-referential formula registers as its own cycle.
+        let mut adj: Vec<BTreeSet<usize>> = vec![BTreeSet::new(); nodes.len()];
+        for (i, cell) in nodes.iter().enumerate() {
+            for prec in &self.precedents[cell] {
+                for fp in self.formula_precedent_cells(prec) {
+                    if let Some(&j) = index_of.get(&fp) {
+                        // Edge fp(j) → cell(i).
+                        adj[j].insert(i);
+                    }
+                }
+            }
+        }
+
+        TarjanScc::new(&adj).cycle_members(&nodes)
+    }
+
+    /// Maps a precedent to the *formula* cells it covers (its intersection with
+    /// the graph's formula-cell set), following name indirection. Literal and
+    /// empty cells are not yielded — only edges between formula cells matter for
+    /// ordering and cycles.
+    fn formula_precedent_cells(&self, prec: &Precedent) -> Vec<CellRef> {
+        match prec {
+            Precedent::Cell(c) => {
+                if self.precedents.contains_key(c) {
+                    vec![c.clone()]
+                } else {
+                    Vec::new()
+                }
+            }
+            Precedent::Range(r) => self
+                .precedents
+                .keys()
+                .filter(|c| r.contains(c))
+                .cloned()
+                .collect(),
+            Precedent::Name(name) => match self.name_targets.get(name) {
+                Some(NameTarget::Cell(c)) if self.precedents.contains_key(c) => vec![c.clone()],
+                Some(NameTarget::Cell(_)) | None => Vec::new(),
+                Some(NameTarget::Range(r)) => self
+                    .precedents
+                    .keys()
+                    .filter(|c| r.contains(c))
+                    .cloned()
+                    .collect(),
+            },
+            Precedent::Unresolved(_) => Vec::new(),
+        }
+    }
+}
+
+/// Resolves a single parsed [`Ref`] against the workbook, relative to the
+/// formula's own (folded) sheet for bare references.
+fn resolve_ref(
+    r: &Ref,
+    own_sheet: &str,
+    folder: &CaseMapperBorrowed<'static>,
+    workbook: &Workbook,
+) -> Precedent {
+    match r {
+        Ref::Cell { sheet, addr } => {
+            let sheet_folded = match sheet {
+                None => own_sheet.to_owned(),
+                Some(name) => match workbook.sheet(name) {
+                    Some(_) => simple_fold(folder, name),
+                    None => return Precedent::Unresolved(r.to_string()),
+                },
+            };
+            match to_address(addr) {
+                Some(a) => Precedent::Cell(CellRef::new(sheet_folded, a)),
+                None => Precedent::Unresolved(r.to_string()),
+            }
+        }
+        Ref::Range { sheet, start, end } => {
+            let sheet_folded = match sheet {
+                None => own_sheet.to_owned(),
+                Some(name) => match workbook.sheet(name) {
+                    Some(_) => simple_fold(folder, name),
+                    None => return Precedent::Unresolved(r.to_string()),
+                },
+            };
+            match normalize_range(start, end) {
+                Some((s, e)) => Precedent::Range(RangeRef {
+                    sheet: sheet_folded,
+                    start: s,
+                    end: e,
+                }),
+                None => Precedent::Unresolved(r.to_string()),
+            }
+        }
+        Ref::Name(name) => {
+            let folded = simple_fold(folder, name);
+            // A name is a precedent only if the workbook actually defines it;
+            // an unknown bare identifier is an unresolved reference (a `#NAME?`
+            // in Sheets), not a phantom name node.
+            if workbook
+                .names()
+                .iter()
+                .any(|nr| simple_fold(folder, &nr.name) == folded)
+            {
+                Precedent::Name(folded)
+            } else {
+                Precedent::Unresolved(name.clone())
+            }
+        }
+    }
+}
+
+/// Resolves a named range's canonical `ref` string to its concrete target,
+/// requiring the target sheet to exist. Returns `None` when the ref is
+/// malformed or names a missing sheet (a dangling name has no target).
+fn resolve_name_ref(
+    r: &str,
+    folder: &CaseMapperBorrowed<'static>,
+    workbook: &Workbook,
+) -> Option<NameTarget> {
+    let parsed = named_ref::parse_canonical_ref(r).ok()?;
+    // The ref's sheet must exist; key the target by its folded name.
+    let sheet = workbook.sheet(&parsed.sheet)?;
+    let sheet_folded = simple_fold(folder, sheet.name());
+
+    // Recover the A1 part (parse_canonical_ref already validated it).
+    let a1_part = r.rsplit_once('!').map(|(_, a)| a).unwrap_or(r);
+    match a1_part.split_once(':') {
+        None => {
+            let addr = Address::from_a1(a1_part)?;
+            Some(NameTarget::Cell(CellRef::new(sheet_folded, addr)))
+        }
+        Some((s, e)) => {
+            let start = Address::from_a1(s)?;
+            let end = Address::from_a1(e)?;
+            Some(NameTarget::Range(RangeRef {
+                sheet: sheet_folded,
+                start,
+                end,
+            }))
+        }
+    }
+}
+
+/// Converts a core [`CellAddr`] (no upper bound of its own) to a workbook
+/// [`Address`], enforcing the workbook's grid bounds. An out-of-bounds ref
+/// (legal to *parse*, but off the grid) resolves to `None` → `Unresolved`.
+fn to_address(addr: &CellAddr) -> Option<Address> {
+    Address::new(addr.row, addr.col)
+}
+
+/// Normalizes a parsed range to top-left-first, in-bounds corners. Returns
+/// `None` if either corner is off-grid.
+fn normalize_range(start: &CellAddr, end: &CellAddr) -> Option<(Address, Address)> {
+    let top = Address::new(start.row.min(end.row), start.col.min(end.col))?;
+    let bottom = Address::new(start.row.max(end.row), start.col.max(end.col))?;
+    Some((top, bottom))
+}
+
+/// Tarjan's strongly-connected-components, specialized to return the set of
+/// nodes that lie on a cycle (SCCs of size > 1, plus self loops). Iterative to
+/// avoid recursion blowup on deep dependency chains (the plan's ≥10k-deep
+/// benchmark).
+struct TarjanScc<'a> {
+    adj: &'a [BTreeSet<usize>],
+    index: Vec<Option<usize>>,
+    lowlink: Vec<usize>,
+    on_stack: Vec<bool>,
+    stack: Vec<usize>,
+    next_index: usize,
+    components: Vec<Vec<usize>>,
+}
+
+impl<'a> TarjanScc<'a> {
+    fn new(adj: &'a [BTreeSet<usize>]) -> Self {
+        let n = adj.len();
+        Self {
+            adj,
+            index: vec![None; n],
+            lowlink: vec![0; n],
+            on_stack: vec![false; n],
+            stack: Vec::new(),
+            next_index: 0,
+            components: Vec::new(),
+        }
+    }
+
+    fn cycle_members(mut self, nodes: &[CellRef]) -> BTreeSet<CellRef> {
+        for v in 0..self.adj.len() {
+            if self.index[v].is_none() {
+                self.strongconnect(v);
+            }
+        }
+        let mut out = BTreeSet::new();
+        for comp in &self.components {
+            let on_cycle = comp.len() > 1
+                // A singleton SCC is on a cycle only via a self loop.
+                || (comp.len() == 1 && self.adj[comp[0]].contains(&comp[0]));
+            if on_cycle {
+                for &i in comp {
+                    out.insert(nodes[i].clone());
+                }
+            }
+        }
+        out
+    }
+
+    fn strongconnect(&mut self, v: usize) {
+        let mut call_stack: Vec<(usize, Vec<usize>)> =
+            vec![(v, self.adj[v].iter().copied().collect())];
+        self.index[v] = Some(self.next_index);
+        self.lowlink[v] = self.next_index;
+        self.next_index += 1;
+        self.stack.push(v);
+        self.on_stack[v] = true;
+
+        while let Some((node, successors)) = call_stack.last_mut() {
+            let node = *node;
+            if let Some(w) = successors.pop() {
+                if self.index[w].is_none() {
+                    self.index[w] = Some(self.next_index);
+                    self.lowlink[w] = self.next_index;
+                    self.next_index += 1;
+                    self.stack.push(w);
+                    self.on_stack[w] = true;
+                    call_stack.push((w, self.adj[w].iter().copied().collect()));
+                } else if self.on_stack[w] {
+                    self.lowlink[node] = self.lowlink[node].min(self.index[w].unwrap());
+                }
+            } else {
+                // All successors processed: finalize this node.
+                if self.lowlink[node] == self.index[node].unwrap() {
+                    let mut component = Vec::new();
+                    loop {
+                        let w = self.stack.pop().unwrap();
+                        self.on_stack[w] = false;
+                        component.push(w);
+                        if w == node {
+                            break;
+                        }
+                    }
+                    self.components.push(component);
+                }
+                call_stack.pop();
+                if let Some((parent, _)) = call_stack.last() {
+                    let parent = *parent;
+                    self.lowlink[parent] = self.lowlink[parent].min(self.lowlink[node]);
+                }
+            }
+        }
+    }
+}

--- a/crates/workbook/src/lib.rs
+++ b/crates/workbook/src/lib.rs
@@ -18,9 +18,9 @@
 
 mod address;
 mod canonical;
-mod depgraph;
 mod casefold;
 mod cell;
+mod depgraph;
 mod engine;
 mod error;
 pub mod limits;

--- a/crates/workbook/src/lib.rs
+++ b/crates/workbook/src/lib.rs
@@ -18,6 +18,7 @@
 
 mod address;
 mod canonical;
+mod depgraph;
 mod casefold;
 mod cell;
 mod engine;
@@ -33,6 +34,7 @@ mod worksheet;
 
 pub use address::Address;
 pub use cell::Cell;
+pub use depgraph::{CellRef, DependencyGraph, Precedent, RangeRef};
 pub use engine::EngineFlavor;
 pub use error::WorkbookError;
 pub use named_range::NamedRange;

--- a/crates/workbook/tests/dependency_graph_rebuild_tests.rs
+++ b/crates/workbook/tests/dependency_graph_rebuild_tests.rs
@@ -1,0 +1,202 @@
+//! Graph-rebuild equivalence after arbitrary edit sequences (issue #534
+//! acceptance criterion).
+//!
+//! The dependency graph is a pure function of the workbook's formulas, sheet
+//! names, and named-range targets. These tests apply edit sequences — the
+//! set/clear/rename/retarget operations the rebuild rules cover — through the
+//! public value-object API, then assert that:
+//!
+//! 1. a graph built from the edited workbook equals a graph built from a fresh
+//!    workbook constructed to the same final state (rebuild is a deterministic
+//!    function of state, the property P3.4's maintained graph is checked
+//!    against), and
+//! 2. each individual edit is reflected in the rebuilt graph (set adds edges,
+//!    clear removes them, rename re-keys cross-sheet edges, retargeting a name
+//!    moves its indirection).
+//!
+//! Recalc (P3.3) is out of scope here; these assert the *graph*, not values.
+
+use truecalc_workbook::{
+    Address, Cell, CellRef, DependencyGraph, EngineFlavor, NamedRange, Value, Workbook, Worksheet,
+};
+
+fn addr(a1: &str) -> Address {
+    Address::from_a1(a1).unwrap()
+}
+
+fn cref(sheet: &str, a1: &str) -> CellRef {
+    CellRef {
+        sheet: sheet.to_string(),
+        addr: addr(a1),
+    }
+}
+
+fn set_formula(wb: &mut Workbook, sheet: &str, a1: &str, formula: &str) {
+    wb.sheet_mut(sheet)
+        .unwrap()
+        .set(addr(a1), Cell::with_formula(formula, Value::Empty));
+}
+
+fn set_num(wb: &mut Workbook, sheet: &str, a1: &str, n: f64) {
+    wb.sheet_mut(sheet)
+        .unwrap()
+        .set(addr(a1), Cell::literal(Value::Number(n)).unwrap());
+}
+
+fn two_sheets() -> Workbook {
+    let mut wb = Workbook::new(EngineFlavor::Sheets);
+    wb.add_sheet(Worksheet::new("Sheet1")).unwrap();
+    wb.add_sheet(Worksheet::new("Sheet2")).unwrap();
+    wb
+}
+
+#[test]
+fn rebuild_equals_fresh_after_edit_sequence() {
+    // Build a workbook by an edit sequence.
+    let mut edited = two_sheets();
+    set_num(&mut edited, "Sheet1", "A1", 1.0);
+    set_formula(&mut edited, "Sheet1", "B1", "=A1+1");
+    set_formula(&mut edited, "Sheet1", "C1", "=SUM(A1:B1)");
+    set_formula(&mut edited, "Sheet2", "A1", "=Sheet1!C1*2");
+    // Overwrite B1 with a different formula.
+    set_formula(&mut edited, "Sheet1", "B1", "=A1*10");
+    // Clear C1, then re-add it differently.
+    edited.sheet_mut("Sheet1").unwrap().clear(addr("C1"));
+    set_formula(&mut edited, "Sheet1", "C1", "=A1-B1");
+
+    // Construct the same *final* state directly.
+    let mut fresh = two_sheets();
+    set_num(&mut fresh, "Sheet1", "A1", 1.0);
+    set_formula(&mut fresh, "Sheet1", "B1", "=A1*10");
+    set_formula(&mut fresh, "Sheet1", "C1", "=A1-B1");
+    set_formula(&mut fresh, "Sheet2", "A1", "=Sheet1!C1*2");
+
+    assert_eq!(
+        DependencyGraph::build(&edited),
+        DependencyGraph::build(&fresh),
+        "graph must be a deterministic function of final workbook state"
+    );
+}
+
+#[test]
+fn build_is_deterministic_for_equal_workbooks() {
+    let mut wb = two_sheets();
+    set_formula(&mut wb, "Sheet1", "A1", "=SUM(Sheet2!A1:A9, B1)");
+    set_formula(&mut wb, "Sheet2", "A1", "=B1");
+    assert_eq!(DependencyGraph::build(&wb), DependencyGraph::build(&wb));
+}
+
+#[test]
+fn set_then_clear_returns_to_empty_graph() {
+    let mut wb = two_sheets();
+    let empty = DependencyGraph::build(&wb);
+    set_formula(&mut wb, "Sheet1", "B1", "=A1");
+    assert_ne!(DependencyGraph::build(&wb), empty);
+    wb.sheet_mut("Sheet1").unwrap().clear(addr("B1"));
+    assert_eq!(
+        DependencyGraph::build(&wb),
+        empty,
+        "clearing the only formula returns the graph to empty"
+    );
+}
+
+#[test]
+fn rename_sheet_rekeys_cross_sheet_edges() {
+    let mut wb = two_sheets();
+    set_num(&mut wb, "Sheet2", "A1", 5.0);
+    set_formula(&mut wb, "Sheet1", "A1", "=Sheet2!A1");
+
+    let before = DependencyGraph::build(&wb);
+    assert!(before
+        .direct_dependents_of(&cref("sheet2", "A1"))
+        .contains(&cref("sheet1", "A1")));
+
+    // Rename Sheet2 → Data. The formula text still says "Sheet2!A1", which now
+    // dangles — the rebuild rule for rename surfaces this (Sheets would rewrite
+    // the formula on rename, which is structural-edit territory deferred to a
+    // post-v1 issue; here the graph just reflects the new state honestly).
+    wb.rename_sheet("Sheet2", "Data").unwrap();
+    let after = DependencyGraph::build(&wb);
+    // The old folded-name edge is gone.
+    assert!(after.direct_dependents_of(&cref("sheet2", "A1")).is_empty());
+    assert_ne!(before, after);
+}
+
+#[test]
+fn retarget_name_moves_indirection() {
+    let mut wb = two_sheets();
+    wb.names_mut().push(NamedRange {
+        name: "Target".to_string(),
+        r#ref: "Sheet1!A1".to_string(),
+    });
+    set_formula(&mut wb, "Sheet1", "B1", "=Target+1");
+
+    let g1 = DependencyGraph::build(&wb);
+    assert!(g1
+        .direct_dependents_of(&cref("sheet1", "A1"))
+        .contains(&cref("sheet1", "B1")));
+    assert!(g1.direct_dependents_of(&cref("sheet1", "A2")).is_empty());
+
+    // Retarget the name A1 → A2 (the P3.4 named-range CRUD; done here directly
+    // on the value object to exercise the graph's rebuild rule for it).
+    wb.names_mut()[0].r#ref = "Sheet1!A2".to_string();
+    let g2 = DependencyGraph::build(&wb);
+
+    // Dependents of A1 no longer include B1; dependents of A2 now do. B1's
+    // formula text is unchanged — only the name's target moved.
+    assert!(g2.direct_dependents_of(&cref("sheet1", "A1")).is_empty());
+    assert!(g2
+        .direct_dependents_of(&cref("sheet1", "A2"))
+        .contains(&cref("sheet1", "B1")));
+    // The name still has B1 as a dependent (retargeting dirties it).
+    assert!(g2
+        .name_dependents_of("Target")
+        .contains(&cref("sheet1", "B1")));
+    assert_ne!(g1, g2);
+}
+
+#[test]
+fn idempotent_set_of_same_formula_is_a_no_op() {
+    let mut wb = two_sheets();
+    set_formula(&mut wb, "Sheet1", "B1", "=A1+A2");
+    let g1 = DependencyGraph::build(&wb);
+    set_formula(&mut wb, "Sheet1", "B1", "=A1+A2"); // same text again
+    let g2 = DependencyGraph::build(&wb);
+    assert_eq!(g1, g2);
+}
+
+#[test]
+fn many_random_like_edits_then_rebuild_matches_replay() {
+    // A longer mixed sequence; rebuild from the live workbook must equal a
+    // rebuild from a workbook replayed to the identical final state.
+    let mut wb = two_sheets();
+    let edits: &[(&str, &str, Option<&str>)] = &[
+        ("Sheet1", "A1", Some("=B1+C1")),
+        ("Sheet1", "B1", Some("=10")),
+        ("Sheet1", "C1", Some("=B1*2")),
+        ("Sheet2", "A1", Some("=Sheet1!A1")),
+        ("Sheet1", "A1", None),                // clear A1
+        ("Sheet1", "A1", Some("=SUM(B1:C1)")), // re-add A1 as a range reader
+        ("Sheet1", "C1", Some("=B1+5")),       // overwrite C1
+        ("Sheet2", "B2", Some("=Sheet1!C1")),
+    ];
+    for (sheet, a1, formula) in edits {
+        match formula {
+            Some(f) => set_formula(&mut wb, sheet, a1, f),
+            None => {
+                wb.sheet_mut(sheet).unwrap().clear(addr(a1));
+            }
+        }
+    }
+    let live = DependencyGraph::build(&wb);
+
+    // Final state, written directly.
+    let mut replay = two_sheets();
+    set_formula(&mut replay, "Sheet1", "A1", "=SUM(B1:C1)");
+    set_formula(&mut replay, "Sheet1", "B1", "=10");
+    set_formula(&mut replay, "Sheet1", "C1", "=B1+5");
+    set_formula(&mut replay, "Sheet2", "A1", "=Sheet1!A1");
+    set_formula(&mut replay, "Sheet2", "B2", "=Sheet1!C1");
+
+    assert_eq!(live, DependencyGraph::build(&replay));
+}

--- a/crates/workbook/tests/dependency_graph_tests.rs
+++ b/crates/workbook/tests/dependency_graph_tests.rs
@@ -1,0 +1,349 @@
+//! Dependency-graph construction, resolution, and cycle/topology tests
+//! (plan item 3.2, issue #534).
+//!
+//! Verifies that precedents are derived from each formula via core's
+//! `extract_refs` (P1.3), that cross-sheet and named references resolve to
+//! concrete graph nodes, that ranges are compressed to a single node, and that
+//! cycles and topological order are reported correctly. The graph-rebuild
+//! equivalence property (the issue's acceptance criterion) lives in
+//! `dependency_graph_rebuild_tests.rs`.
+
+use std::collections::{BTreeSet, HashSet};
+
+use truecalc_workbook::{
+    Address, Cell, CellRef, DependencyGraph, EngineFlavor, NamedRange, Precedent, Value, Workbook,
+    Worksheet,
+};
+
+/// A Sheets workbook with one sheet named `Sheet1`.
+fn wb_one_sheet() -> Workbook {
+    let mut wb = Workbook::new(EngineFlavor::Sheets);
+    wb.add_sheet(Worksheet::new("Sheet1")).unwrap();
+    wb
+}
+
+fn addr(a1: &str) -> Address {
+    Address::from_a1(a1).unwrap()
+}
+
+/// Sets a formula cell `a1 = formula` on sheet `sheet` (value empty until
+/// recalc, which is P3.3).
+fn set_formula(wb: &mut Workbook, sheet: &str, a1: &str, formula: &str) {
+    wb.sheet_mut(sheet)
+        .unwrap()
+        .set(addr(a1), Cell::with_formula(formula, Value::Empty));
+}
+
+/// Sets a literal number cell.
+fn set_num(wb: &mut Workbook, sheet: &str, a1: &str, n: f64) {
+    wb.sheet_mut(sheet)
+        .unwrap()
+        .set(addr(a1), Cell::literal(Value::Number(n)).unwrap());
+}
+
+fn cref(sheet: &str, a1: &str) -> CellRef {
+    CellRef {
+        sheet: sheet.to_string(),
+        addr: addr(a1),
+    }
+}
+
+#[test]
+fn single_cell_precedent_from_extract_refs() {
+    let mut wb = wb_one_sheet();
+    set_num(&mut wb, "Sheet1", "A1", 10.0);
+    set_formula(&mut wb, "Sheet1", "B1", "=A1+1");
+
+    let g = DependencyGraph::build(&wb);
+    let precs = g.precedents_of(&cref("sheet1", "B1")).unwrap();
+    assert_eq!(precs, &[Precedent::Cell(cref("sheet1", "A1"))]);
+
+    let deps = g.direct_dependents_of(&cref("sheet1", "A1"));
+    assert!(deps.contains(&cref("sheet1", "B1")));
+}
+
+#[test]
+fn literal_cells_are_not_formula_nodes() {
+    let mut wb = wb_one_sheet();
+    set_num(&mut wb, "Sheet1", "A1", 5.0);
+    let g = DependencyGraph::build(&wb);
+    assert!(!g.is_formula(&cref("sheet1", "A1")));
+    assert!(g.precedents_of(&cref("sheet1", "A1")).is_none());
+    assert_eq!(g.formula_cells().count(), 0);
+}
+
+#[test]
+fn duplicate_refs_in_one_formula_are_deduplicated() {
+    let mut wb = wb_one_sheet();
+    set_formula(&mut wb, "Sheet1", "B1", "=A1+A1+A1");
+    let g = DependencyGraph::build(&wb);
+    let precs = g.precedents_of(&cref("sheet1", "B1")).unwrap();
+    assert_eq!(precs, &[Precedent::Cell(cref("sheet1", "A1"))]);
+}
+
+#[test]
+fn refs_found_in_every_argument_position() {
+    let mut wb = wb_one_sheet();
+    set_formula(&mut wb, "Sheet1", "D1", "=SUM(A1, B1, C1)");
+    let g = DependencyGraph::build(&wb);
+    let precs: HashSet<_> = g
+        .precedents_of(&cref("sheet1", "D1"))
+        .unwrap()
+        .iter()
+        .cloned()
+        .collect();
+    assert_eq!(
+        precs,
+        HashSet::from([
+            Precedent::Cell(cref("sheet1", "A1")),
+            Precedent::Cell(cref("sheet1", "B1")),
+            Precedent::Cell(cref("sheet1", "C1")),
+        ])
+    );
+}
+
+#[test]
+fn cross_sheet_ref_resolves_to_named_sheet() {
+    let mut wb = Workbook::new(EngineFlavor::Sheets);
+    wb.add_sheet(Worksheet::new("Sheet1")).unwrap();
+    wb.add_sheet(Worksheet::new("Data")).unwrap();
+    set_num(&mut wb, "Data", "B2", 7.0);
+    set_formula(&mut wb, "Sheet1", "A1", "=Data!B2*2");
+
+    let g = DependencyGraph::build(&wb);
+    let precs = g.precedents_of(&cref("sheet1", "A1")).unwrap();
+    assert_eq!(precs, &[Precedent::Cell(cref("data", "B2"))]);
+
+    assert!(g
+        .direct_dependents_of(&cref("data", "B2"))
+        .contains(&cref("sheet1", "A1")));
+}
+
+#[test]
+fn bare_ref_resolves_against_formulas_own_sheet() {
+    let mut wb = Workbook::new(EngineFlavor::Sheets);
+    wb.add_sheet(Worksheet::new("Sheet1")).unwrap();
+    wb.add_sheet(Worksheet::new("Sheet2")).unwrap();
+    set_formula(&mut wb, "Sheet1", "A1", "=B1");
+    set_formula(&mut wb, "Sheet2", "A1", "=B1");
+
+    let g = DependencyGraph::build(&wb);
+    assert_eq!(
+        g.precedents_of(&cref("sheet1", "A1")).unwrap(),
+        &[Precedent::Cell(cref("sheet1", "B1"))]
+    );
+    assert_eq!(
+        g.precedents_of(&cref("sheet2", "A1")).unwrap(),
+        &[Precedent::Cell(cref("sheet2", "B1"))]
+    );
+}
+
+#[test]
+fn unknown_sheet_is_unresolved_no_edge() {
+    let mut wb = wb_one_sheet();
+    set_formula(&mut wb, "Sheet1", "A1", "=Ghost!B2");
+    let g = DependencyGraph::build(&wb);
+    let precs = g.precedents_of(&cref("sheet1", "A1")).unwrap();
+    assert_eq!(precs.len(), 1);
+    assert!(matches!(&precs[0], Precedent::Unresolved(_)));
+    assert!(g.direct_dependents_of(&cref("ghost", "B2")).is_empty());
+}
+
+#[test]
+fn unparseable_formula_is_unresolved() {
+    let mut wb = wb_one_sheet();
+    set_formula(&mut wb, "Sheet1", "A1", "=SUM(");
+    let g = DependencyGraph::build(&wb);
+    let precs = g.precedents_of(&cref("sheet1", "A1")).unwrap();
+    assert_eq!(precs.len(), 1);
+    assert!(matches!(&precs[0], Precedent::Unresolved(_)));
+}
+
+#[test]
+fn range_is_one_compressed_node() {
+    let mut wb = wb_one_sheet();
+    set_formula(&mut wb, "Sheet1", "B1", "=SUM(A1:A100)");
+    let g = DependencyGraph::build(&wb);
+    let precs = g.precedents_of(&cref("sheet1", "B1")).unwrap();
+    assert_eq!(precs.len(), 1, "a range is a single precedent node");
+    match &precs[0] {
+        Precedent::Range(r) => {
+            assert_eq!(r.start, addr("A1"));
+            assert_eq!(r.end, addr("A100"));
+            assert_eq!(r.sheet, "sheet1");
+        }
+        other => panic!("expected a range precedent, got {other:?}"),
+    }
+
+    assert!(g
+        .direct_dependents_of(&cref("sheet1", "A50"))
+        .contains(&cref("sheet1", "B1")));
+    assert!(g.direct_dependents_of(&cref("sheet1", "A101")).is_empty());
+    assert!(g.direct_dependents_of(&cref("sheet1", "B5")).is_empty());
+}
+
+#[test]
+fn huge_range_does_not_explode_edges() {
+    let mut wb = wb_one_sheet();
+    set_formula(&mut wb, "Sheet1", "B1", "=SUM(A1:A1000000)");
+    let g = DependencyGraph::build(&wb);
+    let precs = g.precedents_of(&cref("sheet1", "B1")).unwrap();
+    assert_eq!(precs.len(), 1);
+    assert!(matches!(&precs[0], Precedent::Range(_)));
+    assert!(g
+        .direct_dependents_of(&cref("sheet1", "A999999"))
+        .contains(&cref("sheet1", "B1")));
+}
+
+#[test]
+fn named_range_indirection() {
+    let mut wb = wb_one_sheet();
+    wb.names_mut().push(NamedRange {
+        name: "TaxRate".to_string(),
+        r#ref: "Sheet1!C1".to_string(),
+    });
+    set_num(&mut wb, "Sheet1", "C1", 0.2);
+    set_formula(&mut wb, "Sheet1", "A1", "=B1*TaxRate");
+
+    let g = DependencyGraph::build(&wb);
+    let precs: HashSet<_> = g
+        .precedents_of(&cref("sheet1", "A1"))
+        .unwrap()
+        .iter()
+        .cloned()
+        .collect();
+    assert!(precs.contains(&Precedent::Name("taxrate".to_string())));
+    assert!(precs.contains(&Precedent::Cell(cref("sheet1", "B1"))));
+
+    assert!(g
+        .name_dependents_of("TaxRate")
+        .contains(&cref("sheet1", "A1")));
+    assert!(g
+        .name_dependents_of("TAXRATE")
+        .contains(&cref("sheet1", "A1")));
+
+    assert!(g
+        .direct_dependents_of(&cref("sheet1", "C1"))
+        .contains(&cref("sheet1", "A1")));
+}
+
+#[test]
+fn named_range_pointing_at_a_range() {
+    let mut wb = wb_one_sheet();
+    wb.names_mut().push(NamedRange {
+        name: "Region".to_string(),
+        r#ref: "Sheet1!A1:A10".to_string(),
+    });
+    set_formula(&mut wb, "Sheet1", "C1", "=SUM(Region)");
+    let g = DependencyGraph::build(&wb);
+    assert!(g
+        .direct_dependents_of(&cref("sheet1", "A5"))
+        .contains(&cref("sheet1", "C1")));
+    assert!(g.direct_dependents_of(&cref("sheet1", "A11")).is_empty());
+}
+
+#[test]
+fn undefined_name_is_unresolved_not_a_name_node() {
+    let mut wb = wb_one_sheet();
+    set_formula(&mut wb, "Sheet1", "A1", "=NoSuchName+1");
+    let g = DependencyGraph::build(&wb);
+    let precs = g.precedents_of(&cref("sheet1", "A1")).unwrap();
+    assert_eq!(precs, &[Precedent::Unresolved("NoSuchName".to_string())]);
+}
+
+#[test]
+fn acyclic_chain_topological_order() {
+    let mut wb = wb_one_sheet();
+    set_num(&mut wb, "Sheet1", "A1", 1.0);
+    set_formula(&mut wb, "Sheet1", "B1", "=A1+1");
+    set_formula(&mut wb, "Sheet1", "C1", "=B1+1");
+    set_formula(&mut wb, "Sheet1", "D1", "=C1+1");
+
+    let g = DependencyGraph::build(&wb);
+    let order = g.topological_order().expect("acyclic");
+    let pos = |a1: &str| order.iter().position(|c| *c == cref("sheet1", a1)).unwrap();
+    assert!(pos("B1") < pos("C1"));
+    assert!(pos("C1") < pos("D1"));
+    assert!(g.cycle_cells().is_empty());
+}
+
+#[test]
+fn deep_chain_does_not_overflow() {
+    let mut wb = wb_one_sheet();
+    set_num(&mut wb, "Sheet1", "A1", 1.0);
+    let mut prev = addr("A1");
+    for row in 2..=5000u32 {
+        let here = Address::new(row, 1).unwrap();
+        let f = format!("={}", prev.to_a1());
+        wb.sheet_mut("Sheet1")
+            .unwrap()
+            .set(here, Cell::with_formula(f, Value::Empty));
+        prev = here;
+    }
+    let g = DependencyGraph::build(&wb);
+    assert!(g.cycle_cells().is_empty());
+    let order = g.topological_order().expect("acyclic");
+    assert_eq!(order.len(), 4999);
+}
+
+#[test]
+fn direct_two_cell_cycle_detected() {
+    let mut wb = wb_one_sheet();
+    set_formula(&mut wb, "Sheet1", "A1", "=B1");
+    set_formula(&mut wb, "Sheet1", "B1", "=A1");
+    let g = DependencyGraph::build(&wb);
+    let cyc = g.cycle_cells();
+    assert_eq!(
+        cyc,
+        BTreeSet::from([cref("sheet1", "A1"), cref("sheet1", "B1")])
+    );
+    assert!(g.topological_order().is_err());
+}
+
+#[test]
+fn self_reference_is_a_cycle() {
+    let mut wb = wb_one_sheet();
+    set_formula(&mut wb, "Sheet1", "A1", "=A1+1");
+    let g = DependencyGraph::build(&wb);
+    assert_eq!(g.cycle_cells(), BTreeSet::from([cref("sheet1", "A1")]));
+    assert!(g.topological_order().is_err());
+}
+
+#[test]
+fn cycle_via_range_and_cross_sheet() {
+    let mut wb = Workbook::new(EngineFlavor::Sheets);
+    wb.add_sheet(Worksheet::new("S1")).unwrap();
+    wb.add_sheet(Worksheet::new("S2")).unwrap();
+    set_formula(&mut wb, "S1", "A1", "=SUM(S2!A1:A3)");
+    set_formula(&mut wb, "S2", "A2", "=S1!A1");
+    let g = DependencyGraph::build(&wb);
+    let cyc = g.cycle_cells();
+    assert!(cyc.contains(&cref("s1", "A1")));
+    assert!(cyc.contains(&cref("s2", "A2")));
+}
+
+#[test]
+fn cycle_through_named_range() {
+    let mut wb = wb_one_sheet();
+    wb.names_mut().push(NamedRange {
+        name: "Loop".to_string(),
+        r#ref: "Sheet1!A1".to_string(),
+    });
+    set_formula(&mut wb, "Sheet1", "A1", "=B1");
+    set_formula(&mut wb, "Sheet1", "B1", "=Loop");
+    let g = DependencyGraph::build(&wb);
+    let cyc = g.cycle_cells();
+    assert!(cyc.contains(&cref("sheet1", "A1")));
+    assert!(cyc.contains(&cref("sheet1", "B1")));
+}
+
+#[test]
+fn formula_reading_only_literals_has_no_topo_edges() {
+    let mut wb = wb_one_sheet();
+    set_num(&mut wb, "Sheet1", "A1", 1.0);
+    set_num(&mut wb, "Sheet1", "A2", 2.0);
+    set_formula(&mut wb, "Sheet1", "B1", "=A1+A2");
+    let g = DependencyGraph::build(&wb);
+    let order = g.topological_order().unwrap();
+    assert_eq!(order, vec![cref("sheet1", "B1")]);
+}


### PR DESCRIPTION
## P3.2 — Dependency graph from `extract_refs` (#534)

Builds the workbook dependency graph (plan item 3.2). This is the **graph only**: it owns no values and performs no evaluation — recalc/topological evaluation is P3.3 (#535). It exposes the topological-order and cycle-detection primitives P3.3 needs.

### Design

New module `crates/workbook/src/depgraph.rs` (kept isolated to minimize conflicts with the parallel P3.4 mutation-API work; the only shared edit is `lib.rs` re-exports).

For every formula cell, the graph parses the verbatim formula with the workbook's locked engine, calls `truecalc_core::extract_refs` (P1.3), and resolves each `Ref` to a concrete node:

- **`Ref::Cell`** → single-cell precedent. Bare `A1` resolves against the formula cell's own sheet; `Sheet1!A1` against the named sheet.
- **`Ref::Range`** → **compressed range node** (issue: "range-node compression — `A1:A100000` is not 100k edges"). One node per distinct range; a changed cell finds its range-dependents by `O(1)` rectangle membership, so the graph stays linear in the number of distinct ranges, never their area. (Test builds `A1:A1000000` and resolves instantly.)
- **`Ref::Name`** → **name node with name→target indirection** (issue: "name→target indirection so retargeting dirties dependents"). The formula depends on the name; the name depends on its current target cell/range. Retargeting a name dirties its dependents without rebuilding their edges; a write inside a name's target range dirties them transitively.

**Cross-sheet & named-ref resolution:** sheets are keyed by their simple-case-folded name (matching `Workbook::sheet` lookup), so edges survive `move_sheet`; a rename re-keys them on rebuild. Named-range `ref`s are resolved through the existing canonical-ref parser.

**Unresolved refs:** an unknown sheet/name or an unparseable formula becomes a `Precedent::Unresolved` (no dirty edge) rather than being dropped, so P3.3 can surface the right Sheets error (`#REF!`/`#NAME?`), fixture-verified there. Building therefore never fails.

**Cycle detection:** iterative Tarjan SCC over the formula-cell-only subgraph (`cycle_cells`) — reports self-loops and every cell in an SCC of size > 1. `topological_order` is Kahn's algorithm with deterministic, canonical-order tie-breaking; returns `Err(cycle_cells)` on a cycle. Both are iterative to avoid stack overflow on deep chains (tested to depth 5000).

### Public API

`DependencyGraph::build`, `precedents_of`, `direct_dependents_of` (the dirty-propagation primitive — composes cell + range + name edges so callers never reason about compression/indirection), `name_dependents_of`, `topological_order`, `cycle_cells`; plus `CellRef`, `RangeRef`, `Precedent`.

### How this sets up P3.3 recalc

`direct_dependents_of` is the transitive dirty-set walk; `topological_order` is the evaluation order; `cycle_cells` is the set P3.3 marks with the Sheets circular-dependency error.

### Tests (separate files, per repo rules)

- `dependency_graph_tests.rs` (20): precedents via `extract_refs`, dedup, refs in every arg position, cross-sheet + bare-ref resolution, unknown-sheet/unparseable → Unresolved, range compression (incl. 1M-row range), named-range cell/range indirection, undefined name, acyclic topo order, deep (5000) chain, 2-cell / self / range+cross-sheet / named-range cycles.
- `dependency_graph_rebuild_tests.rs` (7): the issue's **acceptance** — graph-rebuild equivalence after arbitrary edit sequences (set / overwrite / clear / rename / name-retarget); rebuild is a deterministic function of final workbook state.

### CI

`cargo test -p truecalc-workbook` green (full crate suite, incl. the 27 new tests); `cargo clippy -p truecalc-workbook --all-targets -- -D warnings` clean; new files rustfmt-clean. Changes are workbook-only.

Closes #534
