### PR TITLE
fix(workbook): version requirement on truecalc-core dep (unblock crates.io publish)

### DIFF
--- a/crates/workbook/Cargo.toml
+++ b/crates/workbook/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["spreadsheet", "workbook", "formula", "excel", "sheets"]
 
 [dependencies]
-truecalc-core = { path = "../core", features = ["serde"] }
+truecalc-core = { path = "../core", version = "0.8", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["float_roundtrip"] }
 ryu-js = "1"


### PR DESCRIPTION
## Problem
The v0.8.0 release partially failed: `release-plz` published `truecalc-core` 0.8.0 and `truecalc-mcp` 0.8.0 to crates.io, then **failed publishing `truecalc-workbook`**:

```
error: failed to verify manifest at crates/workbook/Cargo.toml
Caused by: all dependencies must have a version requirement specified when publishing.
  dependency `truecalc-core` does not specify a version
```

The `truecalc-core` dependency (added in #567) was path-only. CI and tests build via the path so it was never caught; only a real `cargo publish` enforces the version-requirement rule.

## Fix
Add `version = "0.8"` to the dependency, mirroring the working `truecalc-mcp` crate (`{ path = "../core", version = "0.8" }`). Path is still used for in-workspace builds; the version is used for the published crate.

Workbook stays at 0.8.0 (not yet on crates.io), so merging this lets `release-plz` complete the workbook 0.8.0 publish.

Follow-up worth considering: a `cargo publish -p truecalc-workbook --dry-run` CI step would catch this class of error pre-release.