### PR TITLE
fix(eval): operator conformance — align with 2026-06-08 fixtures

### DIFF
--- a/crates/core/src/eval/functions/operator/mod.rs
+++ b/crates/core/src/eval/functions/operator/mod.rs
@@ -298,7 +298,8 @@ pub fn isbetween_fn(args: &[Value]) -> Value {
         true
     };
     // Use text comparison if all three comparison args are text.
-    // Mixed text+numeric types return #VALUE! (same as GS behavior).
+    // When value is non-numeric text but bounds are numeric (mixed-type), Google Sheets
+    // returns FALSE rather than #VALUE! — the value simply cannot be in range.
     let is_text_val = matches!(&args[0], Value::Text(_));
     let is_text_lo = matches!(&args[1], Value::Text(_));
     let is_text_hi = matches!(&args[2], Value::Text(_));
@@ -319,8 +320,11 @@ pub fn isbetween_fn(args: &[Value]) -> Value {
         let upper_ok = if upper_inclusive { value <= upper } else { value < upper };
         Value::Bool(lower_ok && upper_ok)
     } else {
+        // In a mixed-type scenario (e.g. text value, numeric bounds), attempt numeric
+        // coercion.  If the value argument cannot be coerced to a number, Google Sheets
+        // returns FALSE (out-of-range) rather than propagating a #VALUE! error.
         let value = match to_number(args[0].clone()) {
-            Err(e) => return e,
+            Err(_) => return Value::Bool(false),
             Ok(v) => v,
         };
         let lower = match to_number(args[1].clone()) {

--- a/crates/core/src/eval/functions/operator/tests/isbetween.rs
+++ b/crates/core/src/eval/functions/operator/tests/isbetween.rs
@@ -109,15 +109,16 @@ fn too_many_args_returns_na_error() {
 // ── type error paths ──────────────────────────────────────────────────────────
 
 #[test]
-fn non_numeric_first_arg_returns_value_error() {
-    // ISBETWEEN("text", 1, 10) → #VALUE!
+fn non_numeric_first_arg_returns_false() {
+    // ISBETWEEN("text", 1, 10) -> FALSE (GS 2026-06-08 fixture: mixed-type value
+    // cannot be in a numeric range, so result is FALSE not #VALUE!)
     assert_eq!(
         isbetween_fn(&[
             Value::Text("text".to_string()),
             Value::Number(1.0),
             Value::Number(10.0),
         ]),
-        Value::Error(ErrorKind::Value)
+        Value::Bool(false)
     );
 }
 

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -454,7 +454,7 @@ conformance_tsv_test_report!(math_conformance,        "math.tsv");
 conformance_tsv_test_report!(logical_conformance,     "logical.tsv");
 conformance_tsv_test_report!(info_conformance,        "info.tsv");
 conformance_tsv_test_report!(statistical_conformance, "statistical.tsv");
-conformance_tsv_test_report!(operator_conformance,    "operator.tsv");
+conformance_tsv_test!(operator_conformance,         "operator.tsv");
 conformance_tsv_test_report!(text_conformance,        "text.tsv");
 conformance_tsv_test_report!(date_conformance,        "date.tsv");
 conformance_tsv_test_report!(engineering_conformance, "engineering.tsv");


### PR DESCRIPTION
## Summary

Fixes the `operator` conformance category to pass against the 2026-06-08 Google Sheets fixtures, then flips it from report-only to blocking.

## Root cause

`ISBETWEEN("a", 1, 10)` was returning `#VALUE!` but the fixture expects `FALSE`.

When the value argument is non-numeric text and both bounds are numeric (mixed-type scenario), Google Sheets returns `FALSE` — the text value simply cannot fall inside a numeric range. The old code propagated the `to_number` error as `#VALUE!`, which was wrong.

## Changes

- `crates/core/src/eval/functions/operator/mod.rs`: In `isbetween_fn`, convert a failed `to_number` on `args[0]` into `Bool(false)` instead of returning the error value (mixed-type: text value + numeric bounds).
- `crates/core/src/eval/functions/operator/tests/isbetween.rs`: Update `non_numeric_first_arg` test to assert the correct `Bool(false)` result (old assertion asserted the wrong `#VALUE!` behavior).
- `crates/core/tests/conformance.rs`: Flip `operator_conformance` from `conformance_tsv_test_report!` to `conformance_tsv_test!` (blocking).

No `.tsv` fixture files were edited.

Closes #592.