### PR TITLE
fix(parser): parser conformance — align with 2026-06-08 fixtures

### DIFF
--- a/crates/core/src/eval/functions/parser/convert/mod.rs
+++ b/crates/core/src/eval/functions/parser/convert/mod.rs
@@ -104,25 +104,27 @@ fn get_unit(name: &str) -> Option<(UnitCategory, f64)> {
         "admkn" => Some((UnitCategory::Speed, 0.514773)),
 
         // Area (base: m²)
-        "m2"   => Some((UnitCategory::Area, 1.0)),
-        "km2"  => Some((UnitCategory::Area, 1e6)),
-        "ft2"  => Some((UnitCategory::Area, 0.09290304)),
-        "in2"  => Some((UnitCategory::Area, 0.00064516)),
-        "yd2"  => Some((UnitCategory::Area, 0.83612736)),
-        "mi2"  => Some((UnitCategory::Area, 2589988.110336)),
+        // GS accepts both "m2" and "m^2" notation for squared units.
+        "m2"  | "m^2"   => Some((UnitCategory::Area, 1.0)),
+        "km2" | "km^2"  => Some((UnitCategory::Area, 1e6)),
+        "ft2" | "ft^2"  => Some((UnitCategory::Area, 0.09290304)),
+        "in2" | "in^2"  => Some((UnitCategory::Area, 0.00064516)),
+        "yd2" | "yd^2"  => Some((UnitCategory::Area, 0.83612736)),
+        "mi2" | "mi^2"  => Some((UnitCategory::Area, 2589988.110336)),
         "ha"   => Some((UnitCategory::Area, 10000.0)),
         "ar"   => Some((UnitCategory::Area, 100.0)),
         "acre" => Some((UnitCategory::Area, 4046.8564224)),
 
         // Volume (base: L)
+        // GS accepts both "m3" and "m^3" notation for cubed units.
         "l" | "L" | "lt" => Some((UnitCategory::Volume, 1.0)),
         "ml" | "mL"      => Some((UnitCategory::Volume, 0.001)),
-        "m3"             => Some((UnitCategory::Volume, 1000.0)),
-        "km3"            => Some((UnitCategory::Volume, 1e12)),
-        "ft3"            => Some((UnitCategory::Volume, 28.316846592)),
-        "in3"            => Some((UnitCategory::Volume, 0.016387064)),
-        "yd3"            => Some((UnitCategory::Volume, 764.554857984)),
-        "mi3"            => Some((UnitCategory::Volume, 4_168_181_825.440_579_4)),
+        "m3"  | "m^3"    => Some((UnitCategory::Volume, 1000.0)),
+        "km3" | "km^3"   => Some((UnitCategory::Volume, 1e12)),
+        "ft3" | "ft^3"   => Some((UnitCategory::Volume, 28.316846592)),
+        "in3" | "in^3"   => Some((UnitCategory::Volume, 0.016387064)),
+        "yd3" | "yd^3"   => Some((UnitCategory::Volume, 764.554857984)),
+        "mi3" | "mi^3"   => Some((UnitCategory::Volume, 4_168_181_825.440_579_4)),
         "gal"            => Some((UnitCategory::Volume, 3.785411784)),
         "qt"             => Some((UnitCategory::Volume, 0.946352946)),
         "cup"            => Some((UnitCategory::Volume, 0.2365882365)),
@@ -132,7 +134,7 @@ fn get_unit(name: &str) -> Option<(UnitCategory, f64)> {
         "uk_pt"          => Some((UnitCategory::Volume, 0.56826125)),
         "uk_qt"          => Some((UnitCategory::Volume, 1.1365225)),
         "uk_gal"         => Some((UnitCategory::Volume, 4.54609)),
-        "ang3"           => Some((UnitCategory::Volume, 1e-30)),
+        "ang3" | "ang^3" => Some((UnitCategory::Volume, 1e-30)),
 
         // Magnetism (base: T)
         "T"  => Some((UnitCategory::Magnetism, 1.0)),

--- a/crates/core/src/eval/functions/parser/to_dollars/mod.rs
+++ b/crates/core/src/eval/functions/parser/to_dollars/mod.rs
@@ -7,6 +7,7 @@ pub fn to_dollars_fn(args: &[Value]) -> Value {
     }
     match &args[0] {
         Value::Number(n) => Value::Number(*n),
+        Value::Bool(b)   => Value::Bool(*b),
         Value::Text(s)   => Value::Text(s.clone()),
         Value::Error(_)  => args[0].clone(),
         _                => Value::Error(ErrorKind::Value),

--- a/crates/core/src/eval/functions/parser/to_dollars/tests/failure.rs
+++ b/crates/core/src/eval/functions/parser/to_dollars/tests/failure.rs
@@ -19,7 +19,14 @@ fn error_propagates() {
 }
 
 #[test]
-fn bool_returns_value_error() {
+fn bool_true_passes_through() {
+    // Google Sheets: TO_DOLLARS(TRUE) returns TRUE (boolean passthrough).
     let args = [Value::Bool(true)];
-    assert_eq!(to_dollars_fn(&args), Value::Error(ErrorKind::Value));
+    assert_eq!(to_dollars_fn(&args), Value::Bool(true));
+}
+
+#[test]
+fn bool_false_passes_through() {
+    let args = [Value::Bool(false)];
+    assert_eq!(to_dollars_fn(&args), Value::Bool(false));
 }

--- a/crates/core/src/eval/functions/parser/to_percent/mod.rs
+++ b/crates/core/src/eval/functions/parser/to_percent/mod.rs
@@ -7,6 +7,7 @@ pub fn to_percent_fn(args: &[Value]) -> Value {
     }
     match &args[0] {
         Value::Number(n) => Value::Number(*n),
+        Value::Bool(b)   => Value::Bool(*b),
         Value::Text(s)   => Value::Text(s.clone()),
         Value::Error(_)  => args[0].clone(),
         _                => Value::Error(ErrorKind::Value),

--- a/crates/core/src/eval/functions/parser/to_percent/tests/failure.rs
+++ b/crates/core/src/eval/functions/parser/to_percent/tests/failure.rs
@@ -19,7 +19,14 @@ fn error_propagates() {
 }
 
 #[test]
-fn bool_returns_value_error() {
+fn bool_true_passes_through() {
+    // Google Sheets: TO_PERCENT(TRUE) returns TRUE (boolean passthrough).
     let args = [Value::Bool(true)];
-    assert_eq!(to_percent_fn(&args), Value::Error(ErrorKind::Value));
+    assert_eq!(to_percent_fn(&args), Value::Bool(true));
+}
+
+#[test]
+fn bool_false_passes_through() {
+    let args = [Value::Bool(false)];
+    assert_eq!(to_percent_fn(&args), Value::Bool(false));
 }

--- a/crates/core/src/eval/functions/parser/to_pure_number/mod.rs
+++ b/crates/core/src/eval/functions/parser/to_pure_number/mod.rs
@@ -8,7 +8,7 @@ pub fn to_pure_number_fn(args: &[Value]) -> Value {
     match &args[0] {
         Value::Number(n) => Value::Number(*n),
         Value::Date(n)   => Value::Number(*n),
-        Value::Bool(b)   => Value::Number(if *b { 1.0 } else { 0.0 }),
+        Value::Bool(b)   => Value::Bool(*b),
         Value::Text(s)   => Value::Text(s.clone()),
         Value::Error(_)  => args[0].clone(),
         _                => Value::Error(ErrorKind::Value),

--- a/crates/core/src/eval/functions/parser/to_pure_number/tests/edge.rs
+++ b/crates/core/src/eval/functions/parser/to_pure_number/tests/edge.rs
@@ -8,15 +8,17 @@ fn negative_float() {
 }
 
 #[test]
-fn bool_true_is_one() {
+fn bool_true_passes_through() {
+    // Google Sheets: TO_PURE_NUMBER(TRUE) returns TRUE (boolean passthrough).
     let args = [Value::Bool(true)];
-    assert_eq!(to_pure_number_fn(&args), Value::Number(1.0));
+    assert_eq!(to_pure_number_fn(&args), Value::Bool(true));
 }
 
 #[test]
-fn bool_false_is_zero() {
+fn bool_false_passes_through() {
+    // Google Sheets: TO_PURE_NUMBER(FALSE) returns FALSE (boolean passthrough).
     let args = [Value::Bool(false)];
-    assert_eq!(to_pure_number_fn(&args), Value::Number(0.0));
+    assert_eq!(to_pure_number_fn(&args), Value::Bool(false));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/parser/to_text/mod.rs
+++ b/crates/core/src/eval/functions/parser/to_text/mod.rs
@@ -1,13 +1,42 @@
+use crate::display::display_number;
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
+
+/// Format a number as Google Sheets `TO_TEXT` would.
+///
+/// - For `abs(n) >= 1e15` Sheets switches to upper-case scientific notation
+///   with an explicit sign on the exponent: `"1E+15"`, `"-2.5E+20"`.
+/// - For everything else, use the standard spreadsheet display formatter
+///   (`display_number`), which strips trailing zeros and gives up to 14 sig
+///   figs — matching what Sheets shows in the formula bar.
+fn gs_number_to_text(n: f64) -> String {
+    if n.is_nan() || n.is_infinite() {
+        return "#NUM!".to_string();
+    }
+    let abs = n.abs();
+    if abs >= 1e15 {
+        // Rust's {:E} gives e.g. "1E15" — we need "1E+15" (explicit + sign).
+        let raw = format!("{:E}", n);
+        // Insert '+' after 'E' when the exponent has no sign.
+        if let Some(pos) = raw.find('E') {
+            let after = &raw[pos + 1..];
+            if !after.starts_with('-') && !after.starts_with('+') {
+                return format!("{}E+{}", &raw[..pos], after);
+            }
+        }
+        raw
+    } else {
+        display_number(n)
+    }
+}
 
 pub fn to_text_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 1, 1) {
         return err;
     }
     match &args[0] {
-        Value::Number(n) => Value::Text(format!("{}", n)),
-        Value::Date(n)   => Value::Text(format!("{}", n)),
+        Value::Number(n) => Value::Text(gs_number_to_text(*n)),
+        Value::Date(n)   => Value::Text(gs_number_to_text(*n)),
         Value::Bool(b)   => Value::Text(if *b { "TRUE".to_string() } else { "FALSE".to_string() }),
         Value::Text(s)   => Value::Text(s.clone()),
         Value::Error(_)  => args[0].clone(),

--- a/crates/core/src/eval/functions/parser/to_text/tests/edge.rs
+++ b/crates/core/src/eval/functions/parser/to_text/tests/edge.rs
@@ -18,3 +18,11 @@ fn date_serial_to_text() {
     let args = [Value::Date(45292.0)];
     assert_eq!(to_text_fn(&args), Value::Text("45292".to_string()));
 }
+
+#[test]
+fn very_large_number_to_text_scientific() {
+    // Google Sheets switches to scientific notation for abs(n) >= 1e15.
+    // TO_TEXT(1E15) = "1E+15" (upper-case E, explicit + sign on exponent).
+    let args = [Value::Number(1e15_f64)];
+    assert_eq!(to_text_fn(&args), Value::Text("1E+15".to_string()));
+}

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -459,7 +459,7 @@ conformance_tsv_test_report!(text_conformance,        "text.tsv");
 conformance_tsv_test_report!(date_conformance,        "date.tsv");
 conformance_tsv_test_report!(engineering_conformance, "engineering.tsv");
 conformance_tsv_test_report!(lookup_conformance,      "lookup.tsv");
-conformance_tsv_test_report!(parser_conformance,      "parser.tsv");
+conformance_tsv_test!(parser_conformance,      "parser.tsv");
 conformance_tsv_test_report!(database_conformance,    "database.tsv");
 conformance_tsv_test_report!(array_conformance,       "array.tsv");
 conformance_tsv_test_report!(filter_conformance,      "filter.tsv");


### PR DESCRIPTION
Fixes all failing rows in `parser.tsv` against the refreshed 2026-06-08 Google Sheets fixtures and flips `parser_conformance` from report-only to blocking.

Closes backlog #592.

## Changes

### `to_dollars/mod.rs`
Booleans pass through unchanged. GS returns `TRUE`/`FALSE` directly from `TO_DOLLARS(TRUE/FALSE)`. Was returning `Error(Value)`.

### `to_percent/mod.rs`
Same boolean passthrough fix as `TO_DOLLARS`.

### `to_pure_number/mod.rs`
Booleans pass through unchanged. GS fixture shows `TO_PURE_NUMBER(TRUE)` → `Bool(true)`, not `Number(1.0)`. Was converting booleans to numbers.

### `to_text/mod.rs`
Added `gs_number_to_text` helper: uses `display_number` for `abs(n) < 1e15`, and GS-style scientific notation (`1E+15`) for `abs(n) >= 1e15`. Fixture: `TO_TEXT(1E15)` → `"1E+15"`.

### Unit tests updated
- `to_dollars/tests/failure.rs` — replaced `bool_returns_value_error` with `bool_true/false_passes_through`
- `to_percent/tests/failure.rs` — same
- `to_pure_number/tests/edge.rs` — replaced `bool_true_is_one`/`bool_false_is_zero` with `passes_through` variants
- `to_text/tests/edge.rs` — added `very_large_number_to_text_scientific`

### `conformance.rs`
Flipped `parser_conformance` from `conformance_tsv_test_report!` to `conformance_tsv_test!` (blocking).