### PR TITLE
fix(eval): date conformance — align with 2026-06-08 fixtures

### DIFF
--- a/crates/core/src/eval/functions/date/datedif/mod.rs
+++ b/crates/core/src/eval/functions/date/datedif/mod.rs
@@ -4,7 +4,7 @@ use crate::eval::functions::check_arity;
 use crate::eval::functions::date::serial::serial_to_date;
 use crate::types::{ErrorKind, Value};
 
-/// `DATEDIF(start_date, end_date, unit)` — difference between two dates.
+/// `DATEDIF(start_date, end_date, unit)` -- difference between two dates.
 pub fn datedif_fn(args: &[Value]) -> Value {
     if let Some(e) = check_arity(args, 3, 3) {
         return e;
@@ -46,13 +46,16 @@ pub fn datedif_fn(args: &[Value]) -> Value {
             Value::Number((end - start).num_days() as f64)
         }
         "MD" => {
-            // Complete months elapsed from start to end, then measure remaining days.
-            let total_months = (end.year() - start.year()) * 12
-                + (end.month() as i32 - start.month() as i32);
-            let had_day_pass = end.day() >= start.day();
-            let complete_months = if had_day_pass { total_months } else { total_months - 1 };
-            let adjusted_start = add_months(start, complete_months);
-            Value::Number((end - adjusted_start).num_days() as f64)
+            // Google Sheets implementation: end.day - start.day, and if the result
+            // is negative, add the number of days in the month before end.
+            let diff = end.day() as i32 - start.day() as i32;
+            let result = if diff < 0 {
+                let prev = prev_month(end.year(), end.month());
+                diff + days_in_month(prev.0, prev.1) as i32
+            } else {
+                diff
+            };
+            Value::Number(result as f64)
         }
         "YM" => {
             let total_months = (end.year() - start.year()) * 12
@@ -80,14 +83,22 @@ pub fn datedif_fn(args: &[Value]) -> Value {
     }
 }
 
-/// Add `months` months to a date, clamping to end-of-month on overflow.
-fn add_months(date: NaiveDate, months: i32) -> NaiveDate {
-    let total_months = date.year() * 12 + date.month() as i32 - 1 + months;
-    let year = total_months / 12;
-    let month = (total_months % 12 + 1) as u32;
-    NaiveDate::from_ymd_opt(year, month, date.day())
-        .or_else(|| NaiveDate::from_ymd_opt(year, month + 1, 1))
-        .unwrap()
+/// Returns (year, month) for the month preceding the given month.
+fn prev_month(year: i32, month: u32) -> (i32, u32) {
+    if month == 1 {
+        (year - 1, 12)
+    } else {
+        (year, month - 1)
+    }
+}
+
+/// Number of days in the given (year, month).
+fn days_in_month(year: i32, month: u32) -> u32 {
+    let next_month = if month == 12 { 1 } else { month + 1 };
+    let next_year  = if month == 12 { year + 1 } else { year };
+    let first_of_next = NaiveDate::from_ymd_opt(next_year, next_month, 1).unwrap();
+    let first_of_curr = NaiveDate::from_ymd_opt(year, month, 1).unwrap();
+    (first_of_next - first_of_curr).num_days() as u32
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/datevalue/mod.rs
+++ b/crates/core/src/eval/functions/date/datevalue/mod.rs
@@ -22,30 +22,47 @@ pub fn datevalue_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::Value);
     }
 
-    // Strip trailing time portion (e.g. "2023-06-15 14:30:00" → "2023-06-15")
-    // so ISO-datetime and slash-datetime strings are handled correctly.
-    let date_part = if let Some(idx) = text.find(' ') {
-        &text[..idx]
+    // Strip trailing time component only when the suffix after the space looks
+    // like a time string (starts with a digit followed by ':').  This preserves
+    // month-name formats such as "January 1, 2023".
+    let date_part: &str = if let Some(idx) = text.find(' ') {
+        let after = &text[idx + 1..];
+        let looks_like_time = after.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false)
+            && after.contains(':');
+        if looks_like_time { &text[..idx] } else { text.as_str() }
     } else {
         text.as_str()
     };
 
-    let formats = [
+    // Formats without two-digit year (%y) — parsed directly.
+    let formats_4y = [
         "%m/%d/%Y",
-        "%m/%d/%y",
         "%Y-%m-%d",
         "%Y/%m/%d",
         "%d-%b-%Y",
-        "%d-%b-%y",
         "%B %d, %Y",
         "%b %d, %Y",
         "%B %d %Y",
         "%b %d %Y",
     ];
 
-    for fmt in &formats {
+    for fmt in &formats_4y {
         if let Ok(date) = NaiveDate::parse_from_str(date_part, fmt) {
             return Value::Number(date_to_serial(date));
+        }
+    }
+
+    // Two-digit-year formats: chrono maps %y to the literal year (e.g. 99 → year 99),
+    // but GS/Excel use 00-29 → 2000-2029 and 30-99 → 1930-1999.
+    let formats_2y: &[&str] = &["%m/%d/%y", "%d-%b-%y"];
+    for fmt in formats_2y {
+        if let Ok(date) = NaiveDate::parse_from_str(date_part, fmt) {
+            let y = date.year();
+            // Remap raw two-digit year to spreadsheet century.
+            let century_year = if y <= 29 { y + 2000 } else if y <= 99 { y + 1900 } else { y };
+            if let Some(remapped) = NaiveDate::from_ymd_opt(century_year, date.month(), date.day()) {
+                return Value::Number(date_to_serial(remapped));
+            }
         }
     }
 

--- a/crates/core/src/eval/functions/date/datevalue/mod.rs
+++ b/crates/core/src/eval/functions/date/datevalue/mod.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDate;
+use chrono::{Datelike, NaiveDate};
 use crate::eval::functions::check_arity;
 use crate::eval::functions::date::serial::date_to_serial;
 use crate::types::{ErrorKind, Value};

--- a/crates/core/src/eval/functions/date/datevalue/mod.rs
+++ b/crates/core/src/eval/functions/date/datevalue/mod.rs
@@ -3,6 +3,20 @@ use crate::eval::functions::check_arity;
 use crate::eval::functions::date::serial::date_to_serial;
 use crate::types::{ErrorKind, Value};
 
+/// Returns true if `s` looks like a slash-separated date where the year field
+/// (the last `/`-delimited token) is exactly 1 or 2 digits.  Used to prevent
+/// chrono's `%m/%d/%Y` from consuming "01/15/99" as year 99 CE instead of
+/// routing it through the two-digit-year century-remap path.
+fn has_two_digit_slash_year(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('/').collect();
+    if parts.len() == 3 {
+        let y = parts[2].trim();
+        y.len() <= 2 && y.chars().all(|c| c.is_ascii_digit())
+    } else {
+        false
+    }
+}
+
 /// `DATEVALUE(date_text)` — parses a date string and returns its serial number.
 ///
 /// Supports common formats: ISO (YYYY-MM-DD), US slash (M/D/YYYY), long/short month names,
@@ -35,6 +49,8 @@ pub fn datevalue_fn(args: &[Value]) -> Value {
     };
 
     // Formats without two-digit year (%y) — parsed directly.
+    // Skip %m/%d/%Y when the year field is only 1-2 digits; those inputs must
+    // go through the century-remap path below (%m/%d/%y).
     let formats_4y = [
         "%m/%d/%Y",
         "%Y-%m-%d",
@@ -47,6 +63,10 @@ pub fn datevalue_fn(args: &[Value]) -> Value {
     ];
 
     for fmt in &formats_4y {
+        // Guard: don't let %m/%d/%Y swallow two-digit-year slash inputs.
+        if *fmt == "%m/%d/%Y" && has_two_digit_slash_year(date_part) {
+            continue;
+        }
         if let Ok(date) = NaiveDate::parse_from_str(date_part, fmt) {
             return Value::Number(date_to_serial(date));
         }

--- a/crates/core/src/eval/functions/date/datevalue/mod.rs
+++ b/crates/core/src/eval/functions/date/datevalue/mod.rs
@@ -5,7 +5,8 @@ use crate::types::{ErrorKind, Value};
 
 /// `DATEVALUE(date_text)` — parses a date string and returns its serial number.
 ///
-/// Supports common formats: ISO (YYYY-MM-DD), US slash (M/D/YYYY), and long/short month names.
+/// Supports common formats: ISO (YYYY-MM-DD), US slash (M/D/YYYY), long/short month names,
+/// slash Y/m/d, and datetime strings (the time component is stripped).
 /// Returns `Value::Error(ErrorKind::Value)` for unparseable or invalid strings.
 pub fn datevalue_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 1, 1) {
@@ -21,10 +22,19 @@ pub fn datevalue_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::Value);
     }
 
+    // Strip trailing time portion (e.g. "2023-06-15 14:30:00" → "2023-06-15")
+    // so ISO-datetime and slash-datetime strings are handled correctly.
+    let date_part = if let Some(idx) = text.find(' ') {
+        &text[..idx]
+    } else {
+        text.as_str()
+    };
+
     let formats = [
         "%m/%d/%Y",
         "%m/%d/%y",
         "%Y-%m-%d",
+        "%Y/%m/%d",
         "%d-%b-%Y",
         "%d-%b-%y",
         "%B %d, %Y",
@@ -34,7 +44,7 @@ pub fn datevalue_fn(args: &[Value]) -> Value {
     ];
 
     for fmt in &formats {
-        if let Ok(date) = NaiveDate::parse_from_str(&text, fmt) {
+        if let Ok(date) = NaiveDate::parse_from_str(date_part, fmt) {
             return Value::Number(date_to_serial(date));
         }
     }

--- a/crates/core/src/eval/functions/date/epochtodate/mod.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/mod.rs
@@ -2,10 +2,11 @@ use crate::eval::coercion::to_number;
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
 
-/// `EPOCHTODATE(timestamp, [unit])` — convert a Unix timestamp to a spreadsheet serial.
+/// `EPOCHTODATE(timestamp, [unit])` -- convert a Unix timestamp to a spreadsheet serial.
 ///
-/// unit: 1 (default) = seconds, 2 = milliseconds, 3 = microseconds
+/// unit: 1 (default) = seconds, 2 = milliseconds, 3 = microseconds.
 /// Unix epoch (1970-01-01) = serial 25569.
+/// Negative timestamps return `#NUM!`.
 pub fn epochtodate_fn(args: &[Value]) -> Value {
     if let Some(e) = check_arity(args, 1, 2) {
         return e;
@@ -16,6 +17,10 @@ pub fn epochtodate_fn(args: &[Value]) -> Value {
     } else {
         1
     };
+
+    if timestamp < 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
 
     let seconds = match unit {
         1 => timestamp,

--- a/crates/core/src/eval/functions/date/epochtodate/tests/edge.rs
+++ b/crates/core/src/eval/functions/date/epochtodate/tests/edge.rs
@@ -13,8 +13,8 @@ fn fractional_seconds_produce_fractional_serial() {
 }
 
 #[test]
-fn negative_timestamp_before_epoch() {
-    // -86400 seconds → one day before 1970-01-01 → serial 25568
+fn negative_timestamp_returns_num_error() {
+    // Negative timestamps are not supported → #NUM!
     let args = [Value::Number(-86400.0), Value::Number(1.0)];
-    assert_eq!(epochtodate_fn(&args), Value::Number(25568.0));
+    assert_eq!(epochtodate_fn(&args), Value::Error(crate::types::ErrorKind::Num));
 }

--- a/crates/core/src/eval/functions/date/holidays.rs
+++ b/crates/core/src/eval/functions/date/holidays.rs
@@ -1,0 +1,66 @@
+//! Holiday argument extraction for NETWORKDAYS / WORKDAY family.
+//!
+//! Google Sheets rules:
+//! - Omitted: no holidays (empty set).
+//! - Empty array `{}`: returns `#REF!`.
+//! - Scalar text string (not coercible to a date serial): returns `#VALUE!`.
+//! - Single number / Date: one holiday.
+//! - Array of numbers / Dates: those days are holidays.
+
+use std::collections::HashSet;
+use crate::eval::coercion::to_number;
+use crate::types::{ErrorKind, Value};
+
+/// Extract a set of integer day-serials from the holidays argument.
+///
+/// Returns `Ok(set)` on success (including `Ok(empty)` when the arg is absent),
+/// or `Err(Value::Error(...))` on bad input.
+pub fn extract_holidays(holiday_arg: Option<&Value>) -> Result<HashSet<i64>, Value> {
+    let arg = match holiday_arg {
+        None => return Ok(HashSet::new()),
+        Some(v) => v,
+    };
+
+    match arg {
+        // Empty array -> #REF!
+        Value::Array(items) if items.is_empty() => {
+            Err(Value::Error(ErrorKind::Ref))
+        }
+        // Non-empty array -> collect numeric serials, ignore text/empty/error elements.
+        Value::Array(items) => {
+            let mut set = HashSet::new();
+            for item in items {
+                match item {
+                    Value::Array(inner) => {
+                        for v in inner {
+                            if let Ok(n) = to_number(v.clone()) {
+                                set.insert(n.floor() as i64);
+                            }
+                        }
+                    }
+                    Value::Text(_) => {
+                        // Text inside an array: skip silently (GS ignores non-numeric holiday cells)
+                    }
+                    Value::Empty => {}
+                    _ => {
+                        if let Ok(n) = to_number(item.clone()) {
+                            set.insert(n.floor() as i64);
+                        }
+                    }
+                }
+            }
+            Ok(set)
+        }
+        // Text scalar -> #VALUE! (can't be a date serial)
+        Value::Text(_) => Err(Value::Error(ErrorKind::Value)),
+        // Single numeric value (including Value::Date) -> one holiday
+        _ => match to_number(arg.clone()) {
+            Ok(n) => {
+                let mut set = HashSet::new();
+                set.insert(n.floor() as i64);
+                Ok(set)
+            }
+            Err(_) => Err(Value::Error(ErrorKind::Value)),
+        },
+    }
+}

--- a/crates/core/src/eval/functions/date/isoweeknum/mod.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/mod.rs
@@ -13,6 +13,9 @@ pub fn isoweeknum_fn(args: &[Value]) -> Value {
         return err;
     }
     let serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    if serial < 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
     let date = match serial_to_date(serial) {
         Some(d) => d,
         None => return Value::Error(ErrorKind::Num),

--- a/crates/core/src/eval/functions/date/isoweeknum/mod.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/mod.rs
@@ -15,7 +15,7 @@ pub fn isoweeknum_fn(args: &[Value]) -> Value {
     let serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
     let date = match serial_to_date(serial) {
         Some(d) => d,
-        None => return Value::Error(ErrorKind::Value),
+        None => return Value::Error(ErrorKind::Num),
     };
     Value::Number(date.iso_week().week() as f64)
 }

--- a/crates/core/src/eval/functions/date/isoweeknum/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/isoweeknum/tests/failure.rs
@@ -18,3 +18,10 @@ fn non_numeric_arg_returns_value_error() {
     let args = [Value::Text("not_a_date".to_string())];
     assert_eq!(isoweeknum_fn(&args), Value::Error(ErrorKind::Value));
 }
+
+#[test]
+fn negative_serial_returns_num_error() {
+    // =ISOWEEKNUM(-1) → #NUM!
+    let args = [Value::Number(-1.0)];
+    assert_eq!(isoweeknum_fn(&args), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/date/mod.rs
+++ b/crates/core/src/eval/functions/date/mod.rs
@@ -1,4 +1,5 @@
 pub mod serial;
+pub mod holidays;
 #[cfg(test)]
 mod serial_tests;
 pub mod weekend;

--- a/crates/core/src/eval/functions/date/networkdays/mod.rs
+++ b/crates/core/src/eval/functions/date/networkdays/mod.rs
@@ -1,18 +1,26 @@
 use chrono::{Datelike, Duration};
 use crate::eval::coercion::to_number;
 use crate::eval::functions::check_arity;
+use crate::eval::functions::date::holidays::extract_holidays;
 use crate::eval::functions::date::serial::serial_to_date;
 use crate::types::{ErrorKind, Value};
 
-/// `NETWORKDAYS(start_date, end_date, [holidays])` — count of working days (Mon–Fri),
+/// `NETWORKDAYS(start_date, end_date, [holidays])` -- count of working days (Mon-Fri),
 /// inclusive of both endpoints.  If start > end, the result is negative.
-/// The optional holidays argument is accepted but ignored (array args unsupported).
+///
+/// holidays: omitted = none; empty array `{}` = #REF!; text scalar = #VALUE!;
+/// number/Date or array of number/Date = those serials are excluded.
 pub fn networkdays_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 3) {
         return err;
     }
     let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
     let end_serial   = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+
+    let holidays = match extract_holidays(args.get(2)) {
+        Ok(h) => h,
+        Err(e) => return e,
+    };
 
     let start = match serial_to_date(start_serial) {
         Some(d) => d,
@@ -34,7 +42,11 @@ pub fn networkdays_fn(args: &[Value]) -> Value {
     while current <= to {
         let wd = current.weekday().num_days_from_monday();
         if wd < 5 {
-            count += 1;
+            let serial = (current - chrono::NaiveDate::from_ymd_opt(1899, 12, 30).unwrap())
+                .num_days();
+            if !holidays.contains(&serial) {
+                count += 1;
+            }
         }
         current += Duration::days(1);
     }

--- a/crates/core/src/eval/functions/date/networkdays_intl/mod.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/mod.rs
@@ -1,13 +1,16 @@
 use chrono::{Datelike, Duration};
 use crate::eval::coercion::to_number;
 use crate::eval::functions::check_arity;
+use crate::eval::functions::date::holidays::extract_holidays;
 use crate::eval::functions::date::serial::serial_to_date;
 use crate::eval::functions::date::weekend::weekend_mask;
 use crate::types::{ErrorKind, Value};
 
-/// `NETWORKDAYS.INTL(start, end, [weekend], [holidays])` — count of working days
+/// `NETWORKDAYS.INTL(start, end, [weekend], [holidays])` -- count of working days
 /// with a configurable weekend pattern.  If start > end, result is negative.
-/// The optional holidays argument is accepted but ignored.
+///
+/// holidays: omitted = none; empty array `{}` = #REF!; text scalar = #VALUE!;
+/// number/Date or array of number/Date = those serials are excluded.
 pub fn networkdays_intl_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 4) {
         return err;
@@ -17,6 +20,11 @@ pub fn networkdays_intl_fn(args: &[Value]) -> Value {
 
     let mask = match weekend_mask(args.get(2)) {
         Ok(m) => m,
+        Err(e) => return e,
+    };
+
+    let holidays = match extract_holidays(args.get(3)) {
+        Ok(h) => h,
         Err(e) => return e,
     };
 
@@ -35,12 +43,16 @@ pub fn networkdays_intl_fn(args: &[Value]) -> Value {
         (end, start, -1i64)
     };
 
+    let base = chrono::NaiveDate::from_ymd_opt(1899, 12, 30).unwrap();
     let mut count = 0i64;
     let mut current = from;
     while current <= to {
         let wd = current.weekday().num_days_from_monday() as usize;
         if !mask[wd] {
-            count += 1;
+            let serial = (current - base).num_days();
+            if !holidays.contains(&serial) {
+                count += 1;
+            }
         }
         current += Duration::days(1);
     }

--- a/crates/core/src/eval/functions/date/networkdays_intl/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/networkdays_intl/tests/failure.rs
@@ -34,3 +34,24 @@ fn invalid_weekend_code() {
     let args = [Value::Number(45292.0), Value::Number(45296.0), Value::Number(99.0)];
     assert_eq!(networkdays_intl_fn(&args), Value::Error(ErrorKind::Value));
 }
+
+#[test]
+fn all_ones_string_weekend_returns_num_error() {
+    // =NETWORKDAYS.INTL(...,"1111111") → #NUM!
+    let args = [Value::Number(45292.0), Value::Number(45298.0), Value::Text("1111111".into())];
+    assert_eq!(networkdays_intl_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn invalid_chars_in_string_weekend_returns_num_error() {
+    // =NETWORKDAYS.INTL(...,"abc0011") → #NUM!
+    let args = [Value::Number(45292.0), Value::Number(45298.0), Value::Text("abc0011".into())];
+    assert_eq!(networkdays_intl_fn(&args), Value::Error(ErrorKind::Num));
+}
+
+#[test]
+fn wrong_length_string_weekend_returns_num_error() {
+    // =NETWORKDAYS.INTL(...,"00011") → #NUM!
+    let args = [Value::Number(45292.0), Value::Number(45298.0), Value::Text("00011".into())];
+    assert_eq!(networkdays_intl_fn(&args), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/src/eval/functions/date/serial.rs
+++ b/crates/core/src/eval/functions/date/serial.rs
@@ -57,15 +57,26 @@ pub fn text_to_date_serial(text: &str) -> Option<f64> {
         text
     };
 
-    let formats = [
-        "%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d", "%Y/%m/%d",
-        "%d-%b-%Y", "%d-%b-%y",
+    let formats_4y = [
+        "%m/%d/%Y", "%Y-%m-%d", "%Y/%m/%d",
+        "%d-%b-%Y",
         "%B %d, %Y", "%b %d, %Y",
         "%B %d %Y",  "%b %d %Y",
     ];
-    for fmt in &formats {
+    for fmt in &formats_4y {
         if let Ok(date) = NaiveDate::parse_from_str(date_part, fmt) {
             return Some(date_to_serial(date));
+        }
+    }
+    // Two-digit-year formats with century remapping (00-29→2000s, 30-99→1900s).
+    let formats_2y: &[&str] = &["%m/%d/%y", "%d-%b-%y"];
+    for fmt in formats_2y {
+        if let Ok(date) = NaiveDate::parse_from_str(date_part, fmt) {
+            let y = date.year();
+            let century_year = if y <= 29 { y + 2000 } else if y <= 99 { y + 1900 } else { y };
+            if let Some(remapped) = NaiveDate::from_ymd_opt(century_year, date.month(), date.day()) {
+                return Some(date_to_serial(remapped));
+            }
         }
     }
     None

--- a/crates/core/src/eval/functions/date/serial.rs
+++ b/crates/core/src/eval/functions/date/serial.rs
@@ -36,9 +36,23 @@ pub fn time_to_serial(h: u32, m: u32, s: u32) -> f64 {
 /// Parse a date text string and return its serial number, or None on failure.
 /// Supports the same formats as DATEVALUE (including datetime strings and Y/m/d slash).
 pub fn text_to_date_serial(text: &str) -> Option<f64> {
-    // Strip trailing time portion (e.g. "2023-06-15 14:30:00" → "2023-06-15")
-    let date_part = if let Some(idx) = text.find(' ') {
-        &text[..idx]
+    // Empty string coerces to serial 0 (Dec 30, 1899) — matches Google Sheets.
+    if text.is_empty() {
+        return Some(0.0);
+    }
+
+    // Strip a trailing time component only when the part after the space looks
+    // like a time string (starts with digit(s) followed by ':').  This avoids
+    // truncating month-name formats such as "January 1, 2023".
+    let date_part: &str = if let Some(idx) = text.find(' ') {
+        let after = &text[idx + 1..];
+        let looks_like_time = after
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+            && after.contains(':');
+        if looks_like_time { &text[..idx] } else { text }
     } else {
         text
     };
@@ -60,9 +74,19 @@ pub fn text_to_date_serial(text: &str) -> Option<f64> {
 /// Parse a time text string and return its fractional day serial, or None on failure.
 /// Supports the same formats as TIMEVALUE, including fractional seconds and datetime strings.
 pub fn text_to_time_serial(text: &str) -> Option<f64> {
-    // If it looks like a datetime (contains a space), extract the time part.
+    // If it looks like a datetime (contains a space AND the part before the space
+    // does not itself look like a time string), extract the time part.
+    // "2023-06-15 14:30:00" → time_part = "14:30:00"
+    // "2:15 PM" → time_part = "2:15 PM"  (kept whole, `:` before the space)
+    // "12:00:00 AM" → time_part = "12:00:00 AM" (kept whole)
     let time_part = if let Some(idx) = text.find(' ') {
-        &text[idx + 1..]
+        let before = &text[..idx];
+        if before.contains(':') {
+            // Part before space already looks like a time component — keep the full string.
+            text
+        } else {
+            &text[idx + 1..]
+        }
     } else {
         text
     };

--- a/crates/core/src/eval/functions/date/serial.rs
+++ b/crates/core/src/eval/functions/date/serial.rs
@@ -1,4 +1,4 @@
-use chrono::{Duration, NaiveDate, NaiveTime, Timelike};
+use chrono::{Datelike, Duration, NaiveDate, NaiveTime, Timelike};
 
 /// Base date for serial number 0 in the **Sheets** date system
 /// (December 30, 1899). Locked per engine flavor — see `engine::Flavor`
@@ -217,7 +217,6 @@ pub fn excel_ymd_to_serial(year: i32, month: u32, day: u32) -> Option<f64> {
 /// which is why this returns a tuple rather than a `NaiveDate`.
 /// Serials below 1 return `None`.
 pub fn excel_serial_to_ymd(serial: f64) -> Option<(i32, u32, u32)> {
-    use chrono::Datelike;
     let days = serial.floor();
     if days < 1.0 {
         return None;

--- a/crates/core/src/eval/functions/date/serial.rs
+++ b/crates/core/src/eval/functions/date/serial.rs
@@ -33,6 +33,20 @@ pub fn time_to_serial(h: u32, m: u32, s: u32) -> f64 {
     (h as f64 * 3600.0 + m as f64 * 60.0 + s as f64) / 86400.0
 }
 
+/// Returns true if `s` looks like a slash-separated date where the year field
+/// (the last `/`-delimited token) is exactly 1 or 2 digits.  Prevents
+/// `%m/%d/%Y` from consuming "01/15/99" as year 99 CE instead of routing
+/// it through the two-digit-year century-remap path.
+fn has_two_digit_slash_year(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('/').collect();
+    if parts.len() == 3 {
+        let y = parts[2].trim();
+        y.len() <= 2 && y.chars().all(|c| c.is_ascii_digit())
+    } else {
+        false
+    }
+}
+
 /// Parse a date text string and return its serial number, or None on failure.
 /// Supports the same formats as DATEVALUE (including datetime strings and Y/m/d slash).
 pub fn text_to_date_serial(text: &str) -> Option<f64> {
@@ -64,6 +78,10 @@ pub fn text_to_date_serial(text: &str) -> Option<f64> {
         "%B %d %Y",  "%b %d %Y",
     ];
     for fmt in &formats_4y {
+        // Guard: don't let %m/%d/%Y swallow two-digit-year slash inputs.
+        if *fmt == "%m/%d/%Y" && has_two_digit_slash_year(date_part) {
+            continue;
+        }
         if let Ok(date) = NaiveDate::parse_from_str(date_part, fmt) {
             return Some(date_to_serial(date));
         }

--- a/crates/core/src/eval/functions/date/serial.rs
+++ b/crates/core/src/eval/functions/date/serial.rs
@@ -34,16 +34,23 @@ pub fn time_to_serial(h: u32, m: u32, s: u32) -> f64 {
 }
 
 /// Parse a date text string and return its serial number, or None on failure.
-/// Supports the same formats as DATEVALUE.
+/// Supports the same formats as DATEVALUE (including datetime strings and Y/m/d slash).
 pub fn text_to_date_serial(text: &str) -> Option<f64> {
+    // Strip trailing time portion (e.g. "2023-06-15 14:30:00" → "2023-06-15")
+    let date_part = if let Some(idx) = text.find(' ') {
+        &text[..idx]
+    } else {
+        text
+    };
+
     let formats = [
-        "%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d",
+        "%m/%d/%Y", "%m/%d/%y", "%Y-%m-%d", "%Y/%m/%d",
         "%d-%b-%Y", "%d-%b-%y",
         "%B %d, %Y", "%b %d, %Y",
         "%B %d %Y",  "%b %d %Y",
     ];
     for fmt in &formats {
-        if let Ok(date) = NaiveDate::parse_from_str(text, fmt) {
+        if let Ok(date) = NaiveDate::parse_from_str(date_part, fmt) {
             return Some(date_to_serial(date));
         }
     }
@@ -51,19 +58,89 @@ pub fn text_to_date_serial(text: &str) -> Option<f64> {
 }
 
 /// Parse a time text string and return its fractional day serial, or None on failure.
-/// Supports the same formats as TIMEVALUE.
+/// Supports the same formats as TIMEVALUE, including fractional seconds and datetime strings.
 pub fn text_to_time_serial(text: &str) -> Option<f64> {
+    // If it looks like a datetime (contains a space), extract the time part.
+    let time_part = if let Some(idx) = text.find(' ') {
+        &text[idx + 1..]
+    } else {
+        text
+    };
+
+    // Try fractional-seconds formats first (e.g. "11:59:59.50 PM").
+    // chrono's %S does not handle fractional seconds, so we strip the sub-second
+    // part manually then delegate to the integer-second path.
+    let stripped = strip_fractional_seconds(time_part);
+    let candidates: &[&str] = if stripped.as_deref() != Some(time_part) {
+        // We did strip something — try the stripped version.
+        &[stripped.as_deref().unwrap_or(time_part), time_part]
+    } else {
+        &[time_part]
+    };
+
     let formats = [
-        "%H:%M:%S", "%H:%M",
-        "%I:%M %p", "%I:%M:%S %p",
-        "%I:%M%p",  "%I:%M:%S%p",
+        "%H:%M:%S",
+        "%H:%M",
+        "%I:%M %p",
+        "%I:%M:%S %p",
+        "%I:%M%p",
+        "%I:%M:%S%p",
     ];
-    for fmt in &formats {
-        if let Ok(t) = NaiveTime::parse_from_str(text, fmt) {
-            return Some(time_to_serial(t.hour(), t.minute(), t.second()));
+
+    // For fractional-seconds inputs, parse the stripped string and add back the
+    // sub-second fraction manually.
+    if let Some(ref stripped_str) = stripped {
+        if stripped_str.as_str() != time_part {
+            // Determine the sub-second value.
+            let sub_second = extract_sub_second(time_part).unwrap_or(0.0);
+            for fmt in &formats {
+                if let Ok(t) = NaiveTime::parse_from_str(stripped_str, fmt) {
+                    let serial = time_to_serial(t.hour(), t.minute(), t.second());
+                    return Some(serial + sub_second / 86400.0);
+                }
+            }
+        }
+    }
+
+    for candidate in candidates {
+        for fmt in &formats {
+            if let Ok(t) = NaiveTime::parse_from_str(candidate, fmt) {
+                return Some(time_to_serial(t.hour(), t.minute(), t.second()));
+            }
+        }
+    }
+
+    None
+}
+
+/// Remove a sub-second component from a time string so chrono can parse it.
+/// "11:59:59.50 PM" → Some("11:59:59 PM"), "14:15:30" → None (no change needed).
+fn strip_fractional_seconds(s: &str) -> Option<String> {
+    // Look for a decimal point that follows two digits (the seconds field).
+    if let Some(dot_pos) = s.find('.') {
+        // Make sure there are at least 2 chars before the dot (the seconds digits).
+        if dot_pos >= 2 {
+            // Find where the sub-second digits end (next non-digit character or end of string).
+            let after_dot = &s[dot_pos + 1..];
+            let frac_len = after_dot.chars().take_while(|c| c.is_ascii_digit()).count();
+            let end = dot_pos + 1 + frac_len;
+            let result = format!("{}{}", &s[..dot_pos], &s[end..]);
+            return Some(result);
         }
     }
     None
+}
+
+/// Extract the sub-second value (0.0..1.0) from a time string containing a decimal point.
+fn extract_sub_second(s: &str) -> Option<f64> {
+    if let Some(dot_pos) = s.find('.') {
+        let after_dot = &s[dot_pos..]; // ".50 PM" etc.
+        let frac_end = 1 + after_dot[1..].chars().take_while(|c| c.is_ascii_digit()).count();
+        let frac_str = &after_dot[..frac_end]; // ".50"
+        frac_str.parse::<f64>().ok()
+    } else {
+        None
+    }
 }
 
 // ── Excel 1900 date system (flavor-locked, P1.4 issue #526) ─────────────────

--- a/crates/core/src/eval/functions/date/timevalue/mod.rs
+++ b/crates/core/src/eval/functions/date/timevalue/mod.rs
@@ -1,12 +1,12 @@
-use chrono::{NaiveTime, Timelike};
 use crate::eval::functions::check_arity;
-use crate::eval::functions::date::serial::time_to_serial;
+use crate::eval::functions::date::serial::text_to_time_serial;
 use crate::types::{ErrorKind, Value};
 
-/// `TIMEVALUE(time_text)` — parses a time string and returns a fractional day serial.
+/// `TIMEVALUE(time_text)` -- parses a time string and returns a fractional day serial.
 ///
-/// Supports HH:MM:SS, HH:MM, and 12-hour formats with AM/PM.
-/// Returns `Value::Error(ErrorKind::Value)` for unparseable strings.
+/// Supports HH:MM:SS, HH:MM, 12-hour AM/PM, fractional seconds ("11:59:59.50 PM"),
+/// and datetime strings (date part is discarded, e.g. "2023-06-15 14:30:00").
+/// Returns `Value::Error(ErrorKind::Value)` for unparseable strings or non-text inputs.
 pub fn timevalue_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 1, 1) {
         return err;
@@ -17,23 +17,14 @@ pub fn timevalue_fn(args: &[Value]) -> Value {
         _ => return Value::Error(ErrorKind::Value),
     };
 
-    let formats = [
-        "%H:%M:%S",
-        "%H:%M",
-        "%I:%M %p",
-        "%I:%M:%S %p",
-        "%I:%M%p",
-        "%I:%M:%S%p",
-    ];
-
-    for fmt in &formats {
-        if let Ok(t) = NaiveTime::parse_from_str(&text, fmt) {
-            let serial = time_to_serial(t.hour(), t.minute(), t.second());
-            return Value::Number(serial);
-        }
+    if text.is_empty() {
+        return Value::Error(ErrorKind::Value);
     }
 
-    Value::Error(ErrorKind::Value)
+    match text_to_time_serial(&text) {
+        Some(serial) => Value::Number(serial),
+        None => Value::Error(ErrorKind::Value),
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/date/timevalue/tests/success.rs
+++ b/crates/core/src/eval/functions/date/timevalue/tests/success.rs
@@ -35,3 +35,24 @@ fn pm_notation() {
     let args = [Value::Text("2:30 PM".to_string())];
     assert!(approx(timevalue_fn(&args), (14.0 * 3600.0 + 30.0 * 60.0) / 86400.0));
 }
+
+#[test]
+fn midnight_am() {
+    // "12:00:00 AM" = midnight = 0.0
+    let args = [Value::Text("12:00:00 AM".to_string())];
+    assert_eq!(timevalue_fn(&args), Value::Number(0.0));
+}
+
+#[test]
+fn noon_pm() {
+    // "12:00:00 PM" = noon = 0.5
+    let args = [Value::Text("12:00:00 PM".to_string())];
+    assert_eq!(timevalue_fn(&args), Value::Number(0.5));
+}
+
+#[test]
+fn two_fifteen_pm() {
+    // "2:15 PM" = 14:15 = 51300/86400 = 0.59375
+    let args = [Value::Text("2:15 PM".to_string())];
+    assert_eq!(timevalue_fn(&args), Value::Number(0.59375));
+}

--- a/crates/core/src/eval/functions/date/weekend.rs
+++ b/crates/core/src/eval/functions/date/weekend.rs
@@ -30,12 +30,25 @@ pub fn weekend_mask(weekend: Option<&Value>) -> Result<[bool; 7], Value> {
             };
             Ok(mask)
         }
-        Some(Value::Text(s)) if s.len() == 7 => {
+        Some(Value::Text(s)) => {
+            // Wrong length → #NUM!
+            if s.len() != 7 {
+                return Err(Value::Error(ErrorKind::Num));
+            }
             let b = s.as_bytes();
-            Ok([
+            // Invalid characters (not '0' or '1') → #NUM!
+            if b.iter().any(|&c| c != b'0' && c != b'1') {
+                return Err(Value::Error(ErrorKind::Num));
+            }
+            let mask = [
                 b[0] == b'1', b[1] == b'1', b[2] == b'1',
                 b[3] == b'1', b[4] == b'1', b[5] == b'1', b[6] == b'1',
-            ])
+            ];
+            // All-ones → every day is a weekend → #NUM!
+            if mask.iter().all(|&x| x) {
+                return Err(Value::Error(ErrorKind::Num));
+            }
+            Ok(mask)
         }
         _ => Err(Value::Error(ErrorKind::Value)),
     }
@@ -143,9 +156,9 @@ mod tests {
     }
 
     #[test]
-    fn string_bitmask_all_ones_all_weekend() {
-        let mask = weekend_mask(Some(&Value::Text("1111111".into()))).unwrap();
-        assert_eq!(mask, [true; 7]);
+    fn string_bitmask_all_ones_returns_num_error() {
+        let result = weekend_mask(Some(&Value::Text("1111111".into())));
+        assert_eq!(result, Err(Value::Error(ErrorKind::Num)));
     }
 
     #[test]
@@ -167,8 +180,8 @@ mod tests {
     }
 
     #[test]
-    fn wrong_string_length_returns_value_error() {
+    fn wrong_string_length_returns_num_error() {
         let result = weekend_mask(Some(&Value::Text("011".into())));
-        assert_eq!(result, Err(Value::Error(ErrorKind::Value)));
+        assert_eq!(result, Err(Value::Error(ErrorKind::Num)));
     }
 }

--- a/crates/core/src/eval/functions/date/workday/mod.rs
+++ b/crates/core/src/eval/functions/date/workday/mod.rs
@@ -1,18 +1,27 @@
 use chrono::{Datelike, Duration};
 use crate::eval::coercion::to_number;
 use crate::eval::functions::check_arity;
+use crate::eval::functions::date::holidays::extract_holidays;
 use crate::eval::functions::date::serial::{date_to_serial, serial_to_date};
 use crate::types::{ErrorKind, Value};
 
-/// `WORKDAY(start_date, days, [holidays])` — date serial that is `days` working days
-/// (Mon–Fri) from `start_date`.  Negative `days` moves backward.  The start date
-/// itself is not counted.  The optional holidays argument is accepted but ignored.
+/// `WORKDAY(start_date, days, [holidays])` -- date serial that is `days` working days
+/// (Mon-Fri) from `start_date`.  Negative `days` moves backward.  The start date
+/// itself is not counted.
+///
+/// holidays: omitted = none; empty array `{}` = #REF!; text scalar = #VALUE!;
+/// number/Date or array of number/Date = those serials are skipped.
 pub fn workday_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 3) {
         return err;
     }
     let start_serial = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
     let days_raw     = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+
+    let holidays = match extract_holidays(args.get(2)) {
+        Ok(h) => h,
+        Err(e) => return e,
+    };
 
     let start = match serial_to_date(start_serial) {
         Some(d) => d,
@@ -24,6 +33,7 @@ pub fn workday_fn(args: &[Value]) -> Value {
         return Value::Number(date_to_serial(start));
     }
 
+    let base = chrono::NaiveDate::from_ymd_opt(1899, 12, 30).unwrap();
     let step = if days > 0 { 1i64 } else { -1i64 };
     let mut remaining = days.abs();
     let mut current = start;
@@ -32,7 +42,10 @@ pub fn workday_fn(args: &[Value]) -> Value {
         current += Duration::days(step);
         let wd = current.weekday().num_days_from_monday();
         if wd < 5 {
-            remaining -= 1;
+            let serial = (current - base).num_days();
+            if !holidays.contains(&serial) {
+                remaining -= 1;
+            }
         }
     }
 

--- a/crates/core/src/eval/functions/date/workday_intl/mod.rs
+++ b/crates/core/src/eval/functions/date/workday_intl/mod.rs
@@ -1,14 +1,17 @@
 use chrono::{Datelike, Duration};
 use crate::eval::coercion::to_number;
 use crate::eval::functions::check_arity;
+use crate::eval::functions::date::holidays::extract_holidays;
 use crate::eval::functions::date::serial::{date_to_serial, serial_to_date};
 use crate::eval::functions::date::weekend::weekend_mask;
 use crate::types::{ErrorKind, Value};
 
-/// `WORKDAY.INTL(start, days, [weekend], [holidays])` — date serial that is `days`
+/// `WORKDAY.INTL(start, days, [weekend], [holidays])` -- date serial that is `days`
 /// working days from `start`, with a configurable weekend pattern.
 /// Negative `days` moves backward.  The start date itself is not counted.
-/// The optional holidays argument is accepted but ignored.
+///
+/// holidays: omitted = none; empty array `{}` = #REF!; text scalar = #VALUE!;
+/// number/Date or array of number/Date = those serials are skipped.
 pub fn workday_intl_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 4) {
         return err;
@@ -21,12 +24,17 @@ pub fn workday_intl_fn(args: &[Value]) -> Value {
         Err(e) => return e,
     };
 
+    let holidays = match extract_holidays(args.get(3)) {
+        Ok(h) => h,
+        Err(e) => return e,
+    };
+
     let start = match serial_to_date(start_serial) {
         Some(d) => d,
         None => return Value::Error(ErrorKind::Value),
     };
 
-    // All-weekend mask makes it impossible to advance — return #NUM!
+    // All-weekend mask makes it impossible to advance -- return #NUM!
     if mask.iter().all(|&w| w) {
         return Value::Error(ErrorKind::Num);
     }
@@ -36,6 +44,7 @@ pub fn workday_intl_fn(args: &[Value]) -> Value {
         return Value::Number(date_to_serial(start));
     }
 
+    let base = chrono::NaiveDate::from_ymd_opt(1899, 12, 30).unwrap();
     let step = if days > 0 { 1i64 } else { -1i64 };
     let mut remaining = days.abs();
     let mut current = start;
@@ -44,7 +53,10 @@ pub fn workday_intl_fn(args: &[Value]) -> Value {
         current += Duration::days(step);
         let wd = current.weekday().num_days_from_monday() as usize;
         if !mask[wd] {
-            remaining -= 1;
+            let serial = (current - base).num_days();
+            if !holidays.contains(&serial) {
+                remaining -= 1;
+            }
         }
     }
 

--- a/crates/core/src/eval/functions/date/yearfrac/mod.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/mod.rs
@@ -83,7 +83,7 @@ pub fn yearfrac_fn(args: &[Value]) -> Value {
         None => return Value::Error(ErrorKind::Value),
     };
 
-    if basis < 0.0 || basis > 4.0 {
+    if !(0.0..=4.0).contains(&basis) {
         return Value::Error(ErrorKind::Num);
     }
     let result = match basis as u32 {

--- a/crates/core/src/eval/functions/date/yearfrac/mod.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/mod.rs
@@ -83,6 +83,9 @@ pub fn yearfrac_fn(args: &[Value]) -> Value {
         None => return Value::Error(ErrorKind::Value),
     };
 
+    if basis < 0.0 || basis > 4.0 {
+        return Value::Error(ErrorKind::Num);
+    }
     let result = match basis as u32 {
         0 => days_30_360_us(start, end) as f64 / 360.0,
         1 => yearfrac_actual_actual(start, end),

--- a/crates/core/src/eval/functions/date/yearfrac/tests/failure.rs
+++ b/crates/core/src/eval/functions/date/yearfrac/tests/failure.rs
@@ -31,3 +31,10 @@ fn invalid_basis_5_returns_num_error() {
     let args = [Value::Number(45292.0), Value::Number(45658.0), Value::Number(5.0)];
     assert_eq!(yearfrac_fn(&args), Value::Error(ErrorKind::Num));
 }
+
+#[test]
+fn negative_basis_returns_num_error() {
+    // =YEARFRAC(DATE(2023,1,1),DATE(2023,12,31),-1) → #NUM!
+    let args = [Value::Number(44927.0), Value::Number(45291.0), Value::Number(-1.0)];
+    assert_eq!(yearfrac_fn(&args), Value::Error(ErrorKind::Num));
+}

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -456,7 +456,7 @@ conformance_tsv_test_report!(info_conformance,        "info.tsv");
 conformance_tsv_test_report!(statistical_conformance, "statistical.tsv");
 conformance_tsv_test!(operator_conformance,         "operator.tsv");
 conformance_tsv_test_report!(text_conformance,        "text.tsv");
-conformance_tsv_test_report!(date_conformance,        "date.tsv");
+conformance_tsv_test!(date_conformance,        "date.tsv");
 conformance_tsv_test_report!(engineering_conformance, "engineering.tsv");
 conformance_tsv_test_report!(lookup_conformance,      "lookup.tsv");
 conformance_tsv_test!(parser_conformance,      "parser.tsv");


### PR DESCRIPTION
Fixes all deterministic failures in date.tsv and flips date_conformance to blocking.

Closes #592

See commit message for full change list.