### PR TITLE
fix(eval): text conformance -- align with 2026-06-08 fixtures

### DIFF
--- a/crates/core/src/eval/functions/text/asc/mod.rs
+++ b/crates/core/src/eval/functions/text/asc/mod.rs
@@ -2,21 +2,109 @@ use crate::eval::coercion::to_string_val;
 use crate::eval::functions::check_arity;
 use crate::types::Value;
 
-/// Convert a full-width Unicode character to its half-width equivalent.
-/// U+FF01–U+FF5E → U+0021–U+007E (full-width ASCII variants)
-/// U+3000 → U+0020 (ideographic space → ASCII space)
-fn to_halfwidth(c: char) -> char {
-    let cp = c as u32;
-    if cp == 0x3000 {
-        ' '
-    } else if (0xFF01..=0xFF5E).contains(&cp) {
-        char::from_u32(cp - 0xFEE0).unwrap_or(c)
-    } else {
-        c
+/// Full-width katakana / punctuation to half-width mapping.
+fn kata_to_halfwidth(cp: u32) -> Option<&'static [u32]> {
+    match cp {
+        0x30A1 => Some(&[0xFF67]),
+        0x30A2 => Some(&[0xFF71]),
+        0x30A3 => Some(&[0xFF68]),
+        0x30A4 => Some(&[0xFF72]),
+        0x30A5 => Some(&[0xFF69]),
+        0x30A6 => Some(&[0xFF73]),
+        0x30A7 => Some(&[0xFF6A]),
+        0x30A8 => Some(&[0xFF74]),
+        0x30A9 => Some(&[0xFF6B]),
+        0x30AA => Some(&[0xFF75]),
+        0x30AB => Some(&[0xFF76]),
+        0x30AC => Some(&[0xFF76, 0xFF9E]),
+        0x30AD => Some(&[0xFF77]),
+        0x30AE => Some(&[0xFF77, 0xFF9E]),
+        0x30AF => Some(&[0xFF78]),
+        0x30B0 => Some(&[0xFF78, 0xFF9E]),
+        0x30B1 => Some(&[0xFF79]),
+        0x30B2 => Some(&[0xFF79, 0xFF9E]),
+        0x30B3 => Some(&[0xFF7A]),
+        0x30B4 => Some(&[0xFF7A, 0xFF9E]),
+        0x30B5 => Some(&[0xFF7B]),
+        0x30B6 => Some(&[0xFF7B, 0xFF9E]),
+        0x30B7 => Some(&[0xFF7C]),
+        0x30B8 => Some(&[0xFF7C, 0xFF9E]),
+        0x30B9 => Some(&[0xFF7D]),
+        0x30BA => Some(&[0xFF7D, 0xFF9E]),
+        0x30BB => Some(&[0xFF7E]),
+        0x30BC => Some(&[0xFF7E, 0xFF9E]),
+        0x30BD => Some(&[0xFF7F]),
+        0x30BE => Some(&[0xFF7F, 0xFF9E]),
+        0x30BF => Some(&[0xFF80]),
+        0x30C0 => Some(&[0xFF80, 0xFF9E]),
+        0x30C1 => Some(&[0xFF81]),
+        0x30C2 => Some(&[0xFF81, 0xFF9E]),
+        0x30C3 => Some(&[0xFF6F]),
+        0x30C4 => Some(&[0xFF82]),
+        0x30C5 => Some(&[0xFF82, 0xFF9E]),
+        0x30C6 => Some(&[0xFF83]),
+        0x30C7 => Some(&[0xFF83, 0xFF9E]),
+        0x30C8 => Some(&[0xFF84]),
+        0x30C9 => Some(&[0xFF84, 0xFF9E]),
+        0x30CA => Some(&[0xFF85]),
+        0x30CB => Some(&[0xFF86]),
+        0x30CC => Some(&[0xFF87]),
+        0x30CD => Some(&[0xFF88]),
+        0x30CE => Some(&[0xFF89]),
+        0x30CF => Some(&[0xFF8A]),
+        0x30D0 => Some(&[0xFF8A, 0xFF9E]),
+        0x30D1 => Some(&[0xFF8A, 0xFF9F]),
+        0x30D2 => Some(&[0xFF8B]),
+        0x30D3 => Some(&[0xFF8B, 0xFF9E]),
+        0x30D4 => Some(&[0xFF8B, 0xFF9F]),
+        0x30D5 => Some(&[0xFF8C]),
+        0x30D6 => Some(&[0xFF8C, 0xFF9E]),
+        0x30D7 => Some(&[0xFF8C, 0xFF9F]),
+        0x30D8 => Some(&[0xFF8D]),
+        0x30D9 => Some(&[0xFF8D, 0xFF9E]),
+        0x30DA => Some(&[0xFF8D, 0xFF9F]),
+        0x30DB => Some(&[0xFF8E]),
+        0x30DC => Some(&[0xFF8E, 0xFF9E]),
+        0x30DD => Some(&[0xFF8E, 0xFF9F]),
+        0x30DE => Some(&[0xFF8F]),
+        0x30DF => Some(&[0xFF90]),
+        0x30E0 => Some(&[0xFF91]),
+        0x30E1 => Some(&[0xFF92]),
+        0x30E2 => Some(&[0xFF93]),
+        0x30E3 => Some(&[0xFF6C]),
+        0x30E4 => Some(&[0xFF94]),
+        0x30E5 => Some(&[0xFF6D]),
+        0x30E6 => Some(&[0xFF95]),
+        0x30E7 => Some(&[0xFF6E]),
+        0x30E8 => Some(&[0xFF96]),
+        0x30E9 => Some(&[0xFF97]),
+        0x30EA => Some(&[0xFF98]),
+        0x30EB => Some(&[0xFF99]),
+        0x30EC => Some(&[0xFF9A]),
+        0x30ED => Some(&[0xFF9B]),
+        0x30EF => Some(&[0xFF9C]),
+        0x30F0 => Some(&[0xFF72]),
+        0x30F1 => Some(&[0xFF74]),
+        0x30F2 => Some(&[0xFF66]),
+        0x30F3 => Some(&[0xFF9D]),
+        0x30F4 => Some(&[0xFF73, 0xFF9E]),
+        0x30F5 => Some(&[0xFF76]),
+        0x30F6 => Some(&[0xFF79]),
+        0x30FB => Some(&[0xFF65]),
+        0x30FC => Some(&[0xFF70]),
+        0x3001 => Some(&[0xFF64]),
+        0x3002 => Some(&[0xFF61]),
+        0x300C => Some(&[0xFF62]),
+        0x300D => Some(&[0xFF63]),
+        0x3000 => Some(&[0x0020]),
+        _ => None,
     }
 }
 
 /// `ASC(text)` — converts full-width characters to half-width equivalents.
+/// Full-width ASCII variants (U+FF01-U+FF5E) map to ASCII counterparts.
+/// Full-width katakana maps to half-width katakana (voiced kana decompose into
+/// base + combining voiced/semi-voiced mark).
 pub fn asc_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 1, 1) {
         return err;
@@ -25,7 +113,26 @@ pub fn asc_fn(args: &[Value]) -> Value {
         Ok(s) => s,
         Err(e) => return e,
     };
-    Value::Text(text.chars().map(to_halfwidth).collect())
+    let mut result = String::with_capacity(text.len() * 2);
+    for c in text.chars() {
+        let cp = c as u32;
+        if let Some(halfs) = kata_to_halfwidth(cp) {
+            for &h in halfs {
+                if let Some(hc) = char::from_u32(h) {
+                    result.push(hc);
+                }
+            }
+        } else if (0xFF01..=0xFF5E).contains(&cp) {
+            if let Some(hc) = char::from_u32(cp - 0xFEE0) {
+                result.push(hc);
+            } else {
+                result.push(c);
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    Value::Text(result)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/findb/mod.rs
+++ b/crates/core/src/eval/functions/text/findb/mod.rs
@@ -1,10 +1,35 @@
 use crate::eval::coercion::{to_number, to_string_val};
 use crate::eval::functions::check_arity;
+use crate::eval::functions::text::lenb::dbcs_char_width;
 use crate::types::{ErrorKind, Value};
 
-/// `FINDB(find_text, within_text, [start_num])` — returns the 1-based byte position of find_text.
-/// Case-sensitive. For ASCII text this is identical to FIND.
-/// Returns `#VALUE!` if not found or start_num < 1.
+/// Convert a 1-based DBCS start byte to a char index, snapping forward if inside a char.
+fn dbcs_start_to_char_idx(s: &str, start_1based: usize) -> usize {
+    if start_1based <= 1 {
+        return 0;
+    }
+    let target = start_1based - 1; // 0-based
+    let mut pos = 0usize;
+    for (i, c) in s.chars().enumerate() {
+        let w = dbcs_char_width(c);
+        if pos >= target {
+            return i;
+        }
+        if pos < target && pos + w > target {
+            // target is inside this char: snap to next char
+            return i + 1;
+        }
+        pos += w;
+    }
+    s.chars().count()
+}
+
+/// Convert a char index to a 1-based DBCS byte position.
+fn char_idx_to_dbcs_byte(s: &str, char_idx: usize) -> usize {
+    s.chars().take(char_idx).map(dbcs_char_width).sum::<usize>() + 1
+}
+
+/// `FINDB(find_text, within_text, [start_num])` — case-sensitive DBCS byte-position search.
 pub fn findb_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 3) {
         return err;
@@ -28,21 +53,27 @@ pub fn findb_fn(args: &[Value]) -> Value {
     if start_num < 1.0 {
         return Value::Error(ErrorKind::Value);
     }
-    let start_byte = (start_num as usize) - 1;
-    let total = within_text.len();
-    if start_byte > total {
+    let start_dbcs = start_num as usize; // 1-based DBCS byte
+    let chars: Vec<char> = within_text.chars().collect();
+    let char_start = dbcs_start_to_char_idx(&within_text, start_dbcs);
+    if char_start > chars.len() {
         return Value::Error(ErrorKind::Value);
     }
-    // Snap start to char boundary
-    let start_byte = (start_byte..=total)
-        .find(|&i| within_text.is_char_boundary(i))
-        .unwrap_or(total);
-    let search_in = &within_text[start_byte..];
     if find_text.is_empty() {
-        return Value::Number((start_byte + 1) as f64);
+        // Empty search: return the snapped DBCS position
+        let snapped_byte = char_idx_to_dbcs_byte(&within_text, char_start);
+        return Value::Number(snapped_byte as f64);
     }
-    match search_in.find(find_text.as_str()) {
-        Some(rel_byte_pos) => Value::Number((start_byte + rel_byte_pos + 1) as f64),
+    // Search the substring from char_start
+    let substr: String = chars[char_start..].iter().collect();
+    match substr.find(find_text.as_str()) {
+        Some(utf8_pos) => {
+            // Count chars in the matched prefix
+            let prefix_chars = substr[..utf8_pos].chars().count();
+            let match_char_idx = char_start + prefix_chars;
+            let match_dbcs = char_idx_to_dbcs_byte(&within_text, match_char_idx);
+            Value::Number(match_dbcs as f64)
+        }
         None => Value::Error(ErrorKind::Value),
     }
 }

--- a/crates/core/src/eval/functions/text/leftb/mod.rs
+++ b/crates/core/src/eval/functions/text/leftb/mod.rs
@@ -25,15 +25,15 @@ pub fn leftb_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::Value);
     }
     let budget = n as usize;
+    // Include chars until budget is exhausted; if a char would only partially
+    // fit (used < budget but used + w > budget), snap UP and include it.
     let mut used = 0usize;
     let result: String = text.chars().take_while(|&c| {
-        let w = dbcs_char_width(c);
-        if used + w <= budget {
-            used += w;
-            true
-        } else {
-            false
+        if used >= budget {
+            return false;
         }
+        used += dbcs_char_width(c);
+        true
     }).collect();
     Value::Text(result)
 }

--- a/crates/core/src/eval/functions/text/leftb/mod.rs
+++ b/crates/core/src/eval/functions/text/leftb/mod.rs
@@ -1,39 +1,40 @@
 use crate::eval::coercion::{to_number, to_string_val};
 use crate::eval::functions::check_arity;
+use crate::eval::functions::text::lenb::dbcs_char_width;
 use crate::types::{ErrorKind, Value};
 
-/// `LEFTB(text, num_bytes)` — returns the first N bytes of a string.
-/// For ASCII text this is identical to LEFT. Returns `#VALUE!` if num_bytes < 0.
+/// `LEFTB(text, [num_bytes=1])` — returns the first N DBCS bytes of text.
+/// Partial double-byte characters at the boundary are excluded.
 pub fn leftb_fn(args: &[Value]) -> Value {
-    if let Some(err) = check_arity(args, 2, 2) {
+    if let Some(err) = check_arity(args, 1, 2) {
         return err;
     }
     let text = match to_string_val(args[0].clone()) {
         Ok(s) => s,
         Err(e) => return e,
     };
-    let n = match to_number(args[1].clone()) {
-        Ok(n) => n,
-        Err(e) => return e,
+    let n = if args.len() >= 2 {
+        match to_number(args[1].clone()) {
+            Ok(v) => v,
+            Err(e) => return e,
+        }
+    } else {
+        1.0
     };
     if n < 0.0 {
         return Value::Error(ErrorKind::Value);
     }
-    let n = n as usize;
-    // For ASCII, byte count == char count. Take chars until byte budget exhausted.
-    let mut byte_count = 0usize;
-    let result: String = text
-        .chars()
-        .take_while(|c| {
-            let cb = c.len_utf8();
-            if byte_count + cb <= n {
-                byte_count += cb;
-                true
-            } else {
-                false
-            }
-        })
-        .collect();
+    let budget = n as usize;
+    let mut used = 0usize;
+    let result: String = text.chars().take_while(|&c| {
+        let w = dbcs_char_width(c);
+        if used + w <= budget {
+            used += w;
+            true
+        } else {
+            false
+        }
+    }).collect();
     Value::Text(result)
 }
 

--- a/crates/core/src/eval/functions/text/leftb/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/leftb/tests/failure.rs
@@ -16,8 +16,9 @@ fn wrong_arity_zero_args() {
 
 #[test]
 fn wrong_arity_one_arg() {
+    // one arg is valid: defaults to 1 byte (GS behaviour)
     assert_eq!(
         leftb_fn(&[Value::Text("Hello".to_string())]),
-        Value::Error(ErrorKind::NA)
+        Value::Text("H".to_string())
     );
 }

--- a/crates/core/src/eval/functions/text/lenb/mod.rs
+++ b/crates/core/src/eval/functions/text/lenb/mod.rs
@@ -2,8 +2,35 @@ use crate::eval::coercion::to_string_val;
 use crate::eval::functions::check_arity;
 use crate::types::Value;
 
-/// `LENB(text)` — returns the number of bytes in a string.
-/// For ASCII text this is identical to LEN.
+/// DBCS byte width: codepoints >= U+0100 count as 2 bytes, others as 1.
+/// Matches Google Sheets / Excel DBCS semantics.
+pub(crate) fn dbcs_char_width(c: char) -> usize {
+    if (c as u32) >= 256 { 2 } else { 1 }
+}
+
+pub(crate) fn dbcs_len(s: &str) -> usize {
+    s.chars().map(dbcs_char_width).sum()
+}
+
+/// Convert a 1-based DBCS byte offset to a char-index boundary.
+/// If the byte offset falls inside a 2-byte char, snap forward to the next char boundary.
+pub(crate) fn dbcs_byte_to_char_idx(s: &str, dbcs_byte_1based: usize) -> usize {
+    if dbcs_byte_1based == 0 {
+        return 0;
+    }
+    let target = dbcs_byte_1based - 1; // 0-based
+    let mut pos = 0usize;
+    for (i, c) in s.chars().enumerate() {
+        if pos >= target {
+            return i;
+        }
+        pos += dbcs_char_width(c);
+    }
+    s.chars().count()
+}
+
+/// `LENB(text)` — returns the DBCS byte count of a string.
+/// Non-Latin-1 characters (codepoint >= 256) count as 2 bytes; others count as 1.
 pub fn lenb_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 1, 1) {
         return err;
@@ -12,7 +39,7 @@ pub fn lenb_fn(args: &[Value]) -> Value {
         Ok(s) => s,
         Err(e) => return e,
     };
-    Value::Number(text.len() as f64)
+    Value::Number(dbcs_len(&text) as f64)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/lenb/mod.rs
+++ b/crates/core/src/eval/functions/text/lenb/mod.rs
@@ -12,23 +12,6 @@ pub(crate) fn dbcs_len(s: &str) -> usize {
     s.chars().map(dbcs_char_width).sum()
 }
 
-/// Convert a 1-based DBCS byte offset to a char-index boundary.
-/// If the byte offset falls inside a 2-byte char, snap forward to the next char boundary.
-pub(crate) fn dbcs_byte_to_char_idx(s: &str, dbcs_byte_1based: usize) -> usize {
-    if dbcs_byte_1based == 0 {
-        return 0;
-    }
-    let target = dbcs_byte_1based - 1; // 0-based
-    let mut pos = 0usize;
-    for (i, c) in s.chars().enumerate() {
-        if pos >= target {
-            return i;
-        }
-        pos += dbcs_char_width(c);
-    }
-    s.chars().count()
-}
-
 /// `LENB(text)` — returns the DBCS byte count of a string.
 /// Non-Latin-1 characters (codepoint >= 256) count as 2 bytes; others count as 1.
 pub fn lenb_fn(args: &[Value]) -> Value {

--- a/crates/core/src/eval/functions/text/midb/mod.rs
+++ b/crates/core/src/eval/functions/text/midb/mod.rs
@@ -1,10 +1,11 @@
 use crate::eval::coercion::{to_number, to_string_val};
 use crate::eval::functions::check_arity;
+use crate::eval::functions::text::lenb::dbcs_char_width;
 use crate::types::{ErrorKind, Value};
 
-/// `MIDB(text, start_byte, num_bytes)` — returns a substring by byte position.
-/// start_byte is 1-based. For ASCII text this is identical to MID.
-/// Returns `#VALUE!` if start_byte < 1 or num_bytes < 0.
+/// `MIDB(text, start_byte, num_bytes)` — returns a substring by DBCS byte position.
+/// start_byte is 1-based. Partial double-byte characters are excluded.
+/// If start_byte falls inside a double-byte char, returns empty string.
 pub fn midb_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 3, 3) {
         return err;
@@ -27,21 +28,41 @@ pub fn midb_fn(args: &[Value]) -> Value {
     if num_bytes < 0.0 {
         return Value::Error(ErrorKind::Value);
     }
-    let start_byte = (start as usize) - 1;
-    let num_bytes = num_bytes as usize;
-    let total = text.len();
-    if start_byte >= total {
+    if num_bytes == 0.0 {
         return Value::Text(String::new());
     }
-    // Snap to char boundary
-    let start_byte = (start_byte..=total)
-        .find(|&i| text.is_char_boundary(i))
-        .unwrap_or(total);
-    let end_byte = (start_byte + num_bytes).min(total);
-    let end_byte = (end_byte..=total)
-        .find(|&i| text.is_char_boundary(i))
-        .unwrap_or(total);
-    Value::Text(text[start_byte..end_byte].to_string())
+    let start_dbcs = (start as usize) - 1; // 0-based DBCS byte
+    let budget = num_bytes as usize;
+    let mut pos = 0usize;
+    let mut result = String::new();
+    let mut bytes_taken = 0usize;
+    let mut collecting = false;
+    for c in text.chars() {
+        let w = dbcs_char_width(c);
+        let char_end = pos + w;
+        if !collecting {
+            if pos == start_dbcs {
+                collecting = true;
+            } else if pos < start_dbcs && char_end > start_dbcs {
+                // start_dbcs is inside this char — return empty (partial char boundary)
+                return Value::Text(String::new());
+            }
+        }
+        if collecting {
+            if bytes_taken + w <= budget {
+                result.push(c);
+                bytes_taken += w;
+                if bytes_taken == budget {
+                    break;
+                }
+            } else {
+                // Partial char at end — skip
+                break;
+            }
+        }
+        pos += w;
+    }
+    Value::Text(result)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/regexextract/mod.rs
+++ b/crates/core/src/eval/functions/text/regexextract/mod.rs
@@ -10,9 +10,11 @@ pub fn regexextract_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 2) {
         return err;
     }
-    let text = match to_string_val(args[0].clone()) {
-        Ok(s) => s,
-        Err(e) => return e,
+    let text = match &args[0] {
+        Value::Text(s) => s.clone(),
+        Value::Empty => String::new(),
+        Value::Error(e) => return Value::Error(*e),
+        _ => return Value::Error(ErrorKind::Value),
     };
     let pattern = match to_string_val(args[1].clone()) {
         Ok(s) => s,
@@ -20,7 +22,7 @@ pub fn regexextract_fn(args: &[Value]) -> Value {
     };
     let re = match Regex::new(&pattern) {
         Ok(r) => r,
-        Err(_) => return Value::Error(ErrorKind::Value),
+        Err(_) => return Value::Error(ErrorKind::Ref),
     };
     match re.captures(&text) {
         Some(caps) => {

--- a/crates/core/src/eval/functions/text/regexextract/mod.rs
+++ b/crates/core/src/eval/functions/text/regexextract/mod.rs
@@ -13,7 +13,7 @@ pub fn regexextract_fn(args: &[Value]) -> Value {
     let text = match &args[0] {
         Value::Text(s) => s.clone(),
         Value::Empty => String::new(),
-        Value::Error(e) => return Value::Error(*e),
+        Value::Error(e) => return Value::Error(e.clone()),
         _ => return Value::Error(ErrorKind::Value),
     };
     let pattern = match to_string_val(args[1].clone()) {

--- a/crates/core/src/eval/functions/text/regexmatch/mod.rs
+++ b/crates/core/src/eval/functions/text/regexmatch/mod.rs
@@ -12,7 +12,7 @@ pub fn regexmatch_fn(args: &[Value]) -> Value {
     let text = match &args[0] {
         Value::Text(s) => s.clone(),
         Value::Empty => String::new(),
-        Value::Error(e) => return Value::Error(*e),
+        Value::Error(e) => return Value::Error(e.clone()),
         _ => return Value::Error(ErrorKind::Value),
     };
     let pattern = match to_string_val(args[1].clone()) {

--- a/crates/core/src/eval/functions/text/regexmatch/mod.rs
+++ b/crates/core/src/eval/functions/text/regexmatch/mod.rs
@@ -9,9 +9,11 @@ pub fn regexmatch_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 2) {
         return err;
     }
-    let text = match to_string_val(args[0].clone()) {
-        Ok(s) => s,
-        Err(e) => return e,
+    let text = match &args[0] {
+        Value::Text(s) => s.clone(),
+        Value::Empty => String::new(),
+        Value::Error(e) => return Value::Error(*e),
+        _ => return Value::Error(ErrorKind::Value),
     };
     let pattern = match to_string_val(args[1].clone()) {
         Ok(s) => s,
@@ -19,7 +21,7 @@ pub fn regexmatch_fn(args: &[Value]) -> Value {
     };
     let re = match Regex::new(&pattern) {
         Ok(r) => r,
-        Err(_) => return Value::Error(ErrorKind::Value),
+        Err(_) => return Value::Error(ErrorKind::Ref),
     };
     Value::Bool(re.is_match(&text))
 }

--- a/crates/core/src/eval/functions/text/regexmatch/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/regexmatch/tests/failure.rs
@@ -17,7 +17,7 @@ fn too_many_args_returns_na() {
 }
 
 #[test]
-fn invalid_pattern_returns_value_error() {
+fn invalid_pattern_returns_ref_error() {
     assert_eq!(
         regexmatch_fn(&[Value::Text("hello".into()), Value::Text("[invalid".into())]),
         Value::Error(ErrorKind::Value)

--- a/crates/core/src/eval/functions/text/regexmatch/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/regexmatch/tests/failure.rs
@@ -20,6 +20,6 @@ fn too_many_args_returns_na() {
 fn invalid_pattern_returns_ref_error() {
     assert_eq!(
         regexmatch_fn(&[Value::Text("hello".into()), Value::Text("[invalid".into())]),
-        Value::Error(ErrorKind::Value)
+        Value::Error(ErrorKind::Ref)
     );
 }

--- a/crates/core/src/eval/functions/text/regexreplace/mod.rs
+++ b/crates/core/src/eval/functions/text/regexreplace/mod.rs
@@ -9,9 +9,11 @@ pub fn regexreplace_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 3, 3) {
         return err;
     }
-    let text = match to_string_val(args[0].clone()) {
-        Ok(s) => s,
-        Err(e) => return e,
+    let text = match &args[0] {
+        Value::Text(s) => s.clone(),
+        Value::Empty => String::new(),
+        Value::Error(e) => return Value::Error(*e),
+        _ => return Value::Error(ErrorKind::Value),
     };
     let pattern = match to_string_val(args[1].clone()) {
         Ok(s) => s,
@@ -23,7 +25,7 @@ pub fn regexreplace_fn(args: &[Value]) -> Value {
     };
     let re = match Regex::new(&pattern) {
         Ok(r) => r,
-        Err(_) => return Value::Error(ErrorKind::Value),
+        Err(_) => return Value::Error(ErrorKind::Ref),
     };
     Value::Text(re.replace_all(&text, replacement.as_str()).into_owned())
 }

--- a/crates/core/src/eval/functions/text/regexreplace/mod.rs
+++ b/crates/core/src/eval/functions/text/regexreplace/mod.rs
@@ -27,7 +27,37 @@ pub fn regexreplace_fn(args: &[Value]) -> Value {
         Ok(r) => r,
         Err(_) => return Value::Error(ErrorKind::Ref),
     };
-    Value::Text(re.replace_all(&text, replacement.as_str()).into_owned())
+    // GS behaviour: after a non-empty match, skip any zero-length match at the
+    // same position so that e.g. REGEXREPLACE("hello",".*","world") -> "world"
+    // (not "worldworld" which regex_lite::replace_all would produce).
+    let text_bytes = text.as_bytes();
+    let mut result = String::new();
+    let mut last_end = 0usize;
+    let mut prev_match_end: Option<usize> = None;
+    for m in re.find_iter(&text) {
+        // Skip a zero-length match at the same byte offset as the previous match end
+        if m.start() == m.end() {
+            if let Some(prev) = prev_match_end {
+                if m.start() == prev {
+                    continue;
+                }
+            }
+        }
+        result.push_str(&text[last_end..m.start()]);
+        result.push_str(&replacement);
+        last_end = m.end();
+        prev_match_end = Some(m.end());
+        // After a zero-length match, advance by one byte to avoid infinite loop
+        if m.start() == m.end() {
+            if last_end < text_bytes.len() {
+                result.push(text_bytes[last_end] as char);
+                last_end += 1;
+            }
+        }
+    }
+    result.push_str(&text[last_end..]);
+    let _ = text_bytes; // suppress unused warning
+    Value::Text(result)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/regexreplace/mod.rs
+++ b/crates/core/src/eval/functions/text/regexreplace/mod.rs
@@ -12,7 +12,7 @@ pub fn regexreplace_fn(args: &[Value]) -> Value {
     let text = match &args[0] {
         Value::Text(s) => s.clone(),
         Value::Empty => String::new(),
-        Value::Error(e) => return Value::Error(*e),
+        Value::Error(e) => return Value::Error(e.clone()),
         _ => return Value::Error(ErrorKind::Value),
     };
     let pattern = match to_string_val(args[1].clone()) {

--- a/crates/core/src/eval/functions/text/regexreplace/mod.rs
+++ b/crates/core/src/eval/functions/text/regexreplace/mod.rs
@@ -3,12 +3,11 @@ use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
 use regex_lite::Regex;
 
-/// `REGEXREPLACE(text, pattern, replacement)` — replaces ALL non-overlapping matches
-/// of pattern in text with replacement.
+/// `REGEXREPLACE(text, pattern, replacement)` -- replaces ALL non-overlapping matches
+/// of pattern in text with replacement. Matches GS semantics: zero-length matches
+/// after non-empty matches are included (unlike regex_lite default behaviour).
 pub fn regexreplace_fn(args: &[Value]) -> Value {
-    if let Some(err) = check_arity(args, 3, 3) {
-        return err;
-    }
+    if let Some(err) = check_arity(args, 3, 3) { return err; }
     let text = match &args[0] {
         Value::Text(s) => s.clone(),
         Value::Empty => String::new(),
@@ -27,7 +26,41 @@ pub fn regexreplace_fn(args: &[Value]) -> Value {
         Ok(r) => r,
         Err(_) => return Value::Error(ErrorKind::Ref),
     };
-    Value::Text(re.replace_all(&text, replacement.as_str()).into_owned())
+    // GS includes zero-length matches after non-empty matches.
+    // regex_lite skips them; we scan manually to match GS semantics.
+    let text_bytes = text.as_bytes();
+    let text_len = text_bytes.len();
+    let mut result = String::new();
+    let mut pos = 0usize;
+    while pos <= text_len {
+        let slice = &text[pos..];
+        if let Some(m) = re.find(slice) {
+            let abs_start = pos + m.start();
+            let abs_end = pos + m.end();
+            result.push_str(&text[pos..abs_start]);
+            result.push_str(&replacement);
+            if m.start() == m.end() {
+                // Zero-length match: copy current byte to advance
+                if abs_end < text_len {
+                    // Safety: abs_end is a valid UTF-8 char boundary because
+                    // regex_lite only matches at char boundaries.
+                    let next_char_end = text[abs_end..].chars().next()
+                        .map(|c| abs_end + c.len_utf8())
+                        .unwrap_or(text_len);
+                    result.push_str(&text[abs_end..next_char_end]);
+                    pos = next_char_end;
+                } else {
+                    pos = abs_end + 1;
+                }
+            } else {
+                pos = abs_end;
+            }
+        } else {
+            result.push_str(&text[pos..]);
+            break;
+        }
+    }
+    Value::Text(result)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/regexreplace/mod.rs
+++ b/crates/core/src/eval/functions/text/regexreplace/mod.rs
@@ -27,37 +27,7 @@ pub fn regexreplace_fn(args: &[Value]) -> Value {
         Ok(r) => r,
         Err(_) => return Value::Error(ErrorKind::Ref),
     };
-    // GS behaviour: after a non-empty match, skip any zero-length match at the
-    // same position so that e.g. REGEXREPLACE("hello",".*","world") -> "world"
-    // (not "worldworld" which regex_lite::replace_all would produce).
-    let text_bytes = text.as_bytes();
-    let mut result = String::new();
-    let mut last_end = 0usize;
-    let mut prev_match_end: Option<usize> = None;
-    for m in re.find_iter(&text) {
-        // Skip a zero-length match at the same byte offset as the previous match end
-        if m.start() == m.end() {
-            if let Some(prev) = prev_match_end {
-                if m.start() == prev {
-                    continue;
-                }
-            }
-        }
-        result.push_str(&text[last_end..m.start()]);
-        result.push_str(&replacement);
-        last_end = m.end();
-        prev_match_end = Some(m.end());
-        // After a zero-length match, advance by one byte to avoid infinite loop
-        if m.start() == m.end() {
-            if last_end < text_bytes.len() {
-                result.push(text_bytes[last_end] as char);
-                last_end += 1;
-            }
-        }
-    }
-    result.push_str(&text[last_end..]);
-    let _ = text_bytes; // suppress unused warning
-    Value::Text(result)
+    Value::Text(re.replace_all(&text, replacement.as_str()).into_owned())
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/regexreplace/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/regexreplace/tests/failure.rs
@@ -24,7 +24,7 @@ fn too_many_args_returns_na() {
 }
 
 #[test]
-fn invalid_pattern_returns_value_error() {
+fn invalid_pattern_returns_ref_error() {
     assert_eq!(
         regexreplace_fn(&[
             Value::Text("hello".into()),

--- a/crates/core/src/eval/functions/text/regexreplace/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/regexreplace/tests/failure.rs
@@ -31,6 +31,6 @@ fn invalid_pattern_returns_ref_error() {
             Value::Text("[invalid".into()),
             Value::Text("X".into()),
         ]),
-        Value::Error(ErrorKind::Value)
+        Value::Error(ErrorKind::Ref)
     );
 }

--- a/crates/core/src/eval/functions/text/replaceb/mod.rs
+++ b/crates/core/src/eval/functions/text/replaceb/mod.rs
@@ -1,10 +1,34 @@
 use crate::eval::coercion::{to_number, to_string_val};
 use crate::eval::functions::check_arity;
+use crate::eval::functions::text::lenb::dbcs_char_width;
 use crate::types::{ErrorKind, Value};
 
-/// `REPLACEB(old_text, start_byte, num_bytes, new_text)` — replaces N bytes starting at byte position.
-/// start_byte is 1-based. For ASCII text this is identical to REPLACE.
-/// Returns `#VALUE!` if start_byte < 1 or num_bytes < 0.
+/// Convert a 1-based DBCS start byte to a char index, snapping forward if inside a char.
+fn dbcs_start_to_char_idx(s: &str, start_1based: usize) -> usize {
+    if start_1based <= 1 {
+        return 0;
+    }
+    let target = start_1based - 1; // 0-based
+    let mut pos = 0usize;
+    for (i, c) in s.chars().enumerate() {
+        let w = dbcs_char_width(c);
+        if pos >= target {
+            return i;
+        }
+        if pos < target && pos + w > target {
+            return i + 1; // snap forward past partial char
+        }
+        pos += w;
+    }
+    s.chars().count()
+}
+
+/// Convert a char index to a 1-based DBCS byte position.
+fn char_idx_to_dbcs_byte_end(s: &str, char_idx: usize) -> usize {
+    s.chars().take(char_idx).map(dbcs_char_width).sum::<usize>()
+}
+
+/// `REPLACEB(old_text, start_byte, num_bytes, new_text)` — DBCS byte-position replacement.
 pub fn replaceb_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 4, 4) {
         return err;
@@ -28,19 +52,33 @@ pub fn replaceb_fn(args: &[Value]) -> Value {
     if start_num < 1.0 || num_bytes < 0.0 {
         return Value::Error(ErrorKind::Value);
     }
-    let start_byte = (start_num as usize) - 1;
-    let num_bytes = num_bytes as usize;
-    let total = text.len();
-    let start_byte = start_byte.min(total);
-    // Snap to char boundary
-    let start_byte = (start_byte..=total)
-        .find(|&i| text.is_char_boundary(i))
-        .unwrap_or(total);
-    let end_byte = (start_byte + num_bytes).min(total);
-    let end_byte = (end_byte..=total)
-        .find(|&i| text.is_char_boundary(i))
-        .unwrap_or(total);
-    Value::Text(format!("{}{}{}", &text[..start_byte], new_text, &text[end_byte..]))
+    let start_dbcs = start_num as usize; // 1-based
+    let num = num_bytes as usize;
+    let chars: Vec<char> = text.chars().collect();
+    // Snap start forward to char boundary
+    let start_char = dbcs_start_to_char_idx(&text, start_dbcs);
+    // end DBCS byte = (snapped start DBCS byte) + num_bytes
+    let start_dbcs_snapped = char_idx_to_dbcs_byte_end(&text, start_char) + 1; // 1-based
+    let end_dbcs_target = start_dbcs_snapped.saturating_sub(1) + num; // 0-based end exclusive
+    // Find end char: walk from start_char taking num_bytes
+    let mut taken = 0usize;
+    let mut end_char = start_char;
+    for c in chars[start_char..].iter() {
+        let w = dbcs_char_width(*c);
+        if taken + w <= num {
+            taken += w;
+            end_char += 1;
+            if taken == num { break; }
+        } else {
+            // Partial char: skip (exclude from replacement range)
+            break;
+        }
+    }
+    // Build result: prefix + new_text + suffix
+    let prefix: String = chars[..start_char].iter().collect();
+    let suffix: String = chars[end_char..].iter().collect();
+    let _ = end_dbcs_target; // used for clarity only
+    Value::Text(format!("{}{}{}", prefix, new_text, suffix))
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/rept/mod.rs
+++ b/crates/core/src/eval/functions/text/rept/mod.rs
@@ -2,23 +2,19 @@ use crate::eval::coercion::{to_number, to_string_val};
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
 
-/// `REPT(text, number_times)` — repeats text N times. Returns `#VALUE!` if N < 0.
+const MAX_REPT: usize = 32767;
+
+/// `REPT(text, number_times)` -- repeats text N times.
+/// Returns `#VALUE!` if N < 0 or result would exceed 32767 characters.
 pub fn rept_fn(args: &[Value]) -> Value {
-    if let Some(err) = check_arity(args, 2, 2) {
-        return err;
-    }
-    let text = match to_string_val(args[0].clone()) {
-        Ok(s) => s,
-        Err(e) => return e,
-    };
-    let n = match to_number(args[1].clone()) {
-        Ok(n) => n,
-        Err(e) => return e,
-    };
-    if n < 0.0 {
-        return Value::Error(ErrorKind::Value);
-    }
-    Value::Text(text.repeat(n as usize))
+    if let Some(err) = check_arity(args, 2, 2) { return err; }
+    let text = match to_string_val(args[0].clone()) { Ok(s) => s, Err(e) => return e };
+    let n = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    if n < 0.0 { return Value::Error(ErrorKind::Value); }
+    let times = n as usize;
+    if times == 0 { return Value::Text(String::new()); }
+    if text.chars().count() * times > MAX_REPT { return Value::Error(ErrorKind::Value); }
+    Value::Text(text.repeat(times))
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/rightb/mod.rs
+++ b/crates/core/src/eval/functions/text/rightb/mod.rs
@@ -26,7 +26,7 @@ pub fn rightb_fn(args: &[Value]) -> Value {
     }
     let budget = n as usize;
     let total = dbcs_len(&text);
-    let skip = if budget >= total { 0 } else { total - budget };
+    let skip = total.saturating_sub(budget);
     // Walk forward snapping to char boundary if skip lands inside a char.
     let chars: Vec<char> = text.chars().collect();
     let mut pos = 0usize;

--- a/crates/core/src/eval/functions/text/rightb/mod.rs
+++ b/crates/core/src/eval/functions/text/rightb/mod.rs
@@ -38,8 +38,8 @@ pub fn rightb_fn(args: &[Value]) -> Value {
             break;
         }
         if pos < skip && pos + w > skip {
-            // skip falls inside this char: snap forward to next char
-            char_start = i + 1;
+            // skip lands inside this char: snap back to include it (GS behaviour)
+            char_start = i;
             break;
         }
         pos += w;

--- a/crates/core/src/eval/functions/text/rightb/mod.rs
+++ b/crates/core/src/eval/functions/text/rightb/mod.rs
@@ -1,32 +1,54 @@
 use crate::eval::coercion::{to_number, to_string_val};
 use crate::eval::functions::check_arity;
+use crate::eval::functions::text::lenb::{dbcs_len, dbcs_char_width};
 use crate::types::{ErrorKind, Value};
 
-/// `RIGHTB(text, num_bytes)` — returns the last N bytes of a string.
-/// For ASCII text this is identical to RIGHT. Returns `#VALUE!` if num_bytes < 0.
+/// `RIGHTB(text, [num_bytes=1])` — returns the last N DBCS bytes of text.
+/// Partial double-byte characters at the leading boundary are excluded.
 pub fn rightb_fn(args: &[Value]) -> Value {
-    if let Some(err) = check_arity(args, 2, 2) {
+    if let Some(err) = check_arity(args, 1, 2) {
         return err;
     }
     let text = match to_string_val(args[0].clone()) {
         Ok(s) => s,
         Err(e) => return e,
     };
-    let n = match to_number(args[1].clone()) {
-        Ok(n) => n,
-        Err(e) => return e,
+    let n = if args.len() >= 2 {
+        match to_number(args[1].clone()) {
+            Ok(v) => v,
+            Err(e) => return e,
+        }
+    } else {
+        1.0
     };
     if n < 0.0 {
         return Value::Error(ErrorKind::Value);
     }
-    let n = n as usize;
-    let total_bytes = text.len();
-    let skip_bytes = total_bytes.saturating_sub(n);
-    // Find the char boundary at or after skip_bytes
-    let start = (skip_bytes..=total_bytes)
-        .find(|&i| text.is_char_boundary(i))
-        .unwrap_or(total_bytes);
-    Value::Text(text[start..].to_string())
+    let budget = n as usize;
+    let total = dbcs_len(&text);
+    let skip = if budget >= total { 0 } else { total - budget };
+    // Walk forward snapping to char boundary if skip lands inside a char.
+    let chars: Vec<char> = text.chars().collect();
+    let mut pos = 0usize;
+    let mut char_start = chars.len();
+    for (i, &c) in chars.iter().enumerate() {
+        let w = dbcs_char_width(c);
+        if pos == skip {
+            char_start = i;
+            break;
+        }
+        if pos < skip && pos + w > skip {
+            // skip falls inside this char: snap forward to next char
+            char_start = i + 1;
+            break;
+        }
+        pos += w;
+        if pos == skip {
+            char_start = i + 1;
+            break;
+        }
+    }
+    Value::Text(chars[char_start..].iter().collect())
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/rightb/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/rightb/tests/failure.rs
@@ -16,8 +16,9 @@ fn wrong_arity_zero_args() {
 
 #[test]
 fn wrong_arity_one_arg() {
+    // one arg is valid: defaults to 1 byte (GS behaviour)
     assert_eq!(
         rightb_fn(&[Value::Text("Hello".to_string())]),
-        Value::Error(ErrorKind::NA)
+        Value::Text("o".to_string())
     );
 }

--- a/crates/core/src/eval/functions/text/searchb/mod.rs
+++ b/crates/core/src/eval/functions/text/searchb/mod.rs
@@ -1,9 +1,8 @@
 use crate::eval::coercion::{to_number, to_string_val};
 use crate::eval::functions::check_arity;
+use crate::eval::functions::text::lenb::dbcs_char_width;
 use crate::types::{ErrorKind, Value};
 
-/// Match `pattern` as a prefix of `text` (prefix match, not full match).
-/// `?` matches any single char; `*` matches any sequence of chars.
 fn wildcard_match(pattern: &[char], text: &[char]) -> bool {
     match pattern.first() {
         None => true,
@@ -41,8 +40,33 @@ fn wildcard_find(pattern: &[char], text: &[char], start_idx: usize) -> Option<us
     None
 }
 
-/// `SEARCHB(find_text, within_text, [start_num])` — case-insensitive byte-position search with wildcards.
-/// For ASCII text this is identical to SEARCH. Returns 1-based position or `#VALUE!` if not found.
+/// Convert a 1-based DBCS start byte to a char index, snapping forward if inside a char.
+fn dbcs_start_to_char_idx(s: &str, start_1based: usize) -> usize {
+    if start_1based <= 1 {
+        return 0;
+    }
+    let target = start_1based - 1;
+    let mut pos = 0usize;
+    for (i, c) in s.chars().enumerate() {
+        let w = dbcs_char_width(c);
+        if pos >= target {
+            return i;
+        }
+        if pos < target && pos + w > target {
+            return i + 1;
+        }
+        pos += w;
+    }
+    s.chars().count()
+}
+
+/// Convert a char index to a 1-based DBCS byte position.
+fn char_idx_to_dbcs_byte(s: &str, char_idx: usize) -> usize {
+    s.chars().take(char_idx).map(dbcs_char_width).sum::<usize>() + 1
+}
+
+/// `SEARCHB(find_text, within_text, [start_num])` — case-insensitive DBCS byte-position search
+/// with wildcard support (`?` = any char, `*` = any sequence, `~` escapes).
 pub fn searchb_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 3) {
         return err;
@@ -66,14 +90,35 @@ pub fn searchb_fn(args: &[Value]) -> Value {
     if start_num < 1.0 {
         return Value::Error(ErrorKind::Value);
     }
-    let start_idx = (start_num as usize).saturating_sub(1);
+    let start_dbcs = start_num as usize; // 1-based DBCS byte
     let within_chars: Vec<char> = within_text.chars().collect();
-    if start_idx > within_chars.len() {
+    let char_start = dbcs_start_to_char_idx(&within_text, start_dbcs);
+    if char_start > within_chars.len() {
         return Value::Error(ErrorKind::Value);
     }
-    let pattern_chars: Vec<char> = find_text.chars().collect();
-    match wildcard_find(&pattern_chars, &within_chars, start_idx) {
-        Some(pos) => Value::Number((pos + 1) as f64),
+    // Unescape tilde sequences in pattern
+    let pattern_raw: Vec<char> = find_text.chars().collect();
+    let mut pattern: Vec<char> = Vec::with_capacity(pattern_raw.len());
+    let mut i = 0;
+    while i < pattern_raw.len() {
+        if pattern_raw[i] == '~' && i + 1 < pattern_raw.len() {
+            match pattern_raw[i + 1] {
+                '?' | '*' | '~' => {
+                    pattern.push(pattern_raw[i + 1]);
+                    i += 2;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        pattern.push(pattern_raw[i]);
+        i += 1;
+    }
+    match wildcard_find(&pattern, &within_chars, char_start) {
+        Some(char_idx) => {
+            let dbcs_pos = char_idx_to_dbcs_byte(&within_text, char_idx);
+            Value::Number(dbcs_pos as f64)
+        }
         None => Value::Error(ErrorKind::Value),
     }
 }

--- a/crates/core/src/eval/functions/text/searchb/mod.rs
+++ b/crates/core/src/eval/functions/text/searchb/mod.rs
@@ -3,74 +3,71 @@ use crate::eval::functions::check_arity;
 use crate::eval::functions::text::lenb::dbcs_char_width;
 use crate::types::{ErrorKind, Value};
 
-fn wildcard_match(pattern: &[char], text: &[char]) -> bool {
-    match pattern.first() {
-        None => true,
-        Some('*') => {
-            for i in 0..=text.len() {
-                if wildcard_match(&pattern[1..], &text[i..]) {
-                    return true;
-                }
-            }
-            false
-        }
-        Some(_) => match text.first() {
-            None => false,
-            Some(t) => {
-                let p = &pattern[0];
-                if *p == '?' || p.to_lowercase().next() == t.to_lowercase().next() {
-                    wildcard_match(&pattern[1..], &text[1..])
-                } else {
-                    false
-                }
-            }
-        },
+// Pattern token: (char, is_wildcard). Tilde-escaped chars have is_wildcard=false.
+type Pat = (char, bool);
+
+fn wc_match(pat: &[Pat], text: &[char]) -> bool {
+    if pat.is_empty() { return text.is_empty(); }
+    let (pc, is_wc) = pat[0];
+    if is_wc && pc == '*' {
+        return (0..=text.len()).any(|i| wc_match(&pat[1..], &text[i..]));
+    }
+    if is_wc {
+        return !text.is_empty() && wc_match(&pat[1..], &text[1..]);
+    }
+    match text.first() {
+        None => false,
+        Some(t) => pc.to_lowercase().next() == t.to_lowercase().next() && wc_match(&pat[1..], &text[1..]),
     }
 }
 
-fn wildcard_find(pattern: &[char], text: &[char], start_idx: usize) -> Option<usize> {
-    if pattern.is_empty() {
-        return if start_idx <= text.len() { Some(start_idx) } else { None };
-    }
-    for i in start_idx..=text.len() {
-        if wildcard_match(pattern, &text[i..]) {
-            return Some(i);
-        }
-    }
-    None
+fn wc_find(pat: &[Pat], text: &[char], start: usize) -> Option<usize> {
+    (start..=text.len()).find(|&i| wc_match(pat, &text[i..]))
 }
 
-/// Convert a 1-based DBCS start byte to a char index, snapping forward if inside a char.
-fn dbcs_start_to_char_idx(s: &str, start_1based: usize) -> usize {
-    if start_1based <= 1 {
-        return 0;
-    }
-    let target = start_1based - 1;
+fn dbcs_to_char_idx(s: &str, byte_1based: usize) -> usize {
+    if byte_1based <= 1 { return 0; }
+    let target = byte_1based - 1;
     let mut pos = 0usize;
     for (i, c) in s.chars().enumerate() {
         let w = dbcs_char_width(c);
-        if pos >= target {
-            return i;
-        }
-        if pos < target && pos + w > target {
-            return i + 1;
-        }
+        if pos >= target { return i; }
+        if pos < target && pos + w > target { return i + 1; }
         pos += w;
     }
     s.chars().count()
 }
 
-/// Convert a char index to a 1-based DBCS byte position.
-fn char_idx_to_dbcs_byte(s: &str, char_idx: usize) -> usize {
+fn char_to_dbcs_byte(s: &str, char_idx: usize) -> usize {
     s.chars().take(char_idx).map(dbcs_char_width).sum::<usize>() + 1
 }
 
-/// `SEARCHB(find_text, within_text, [start_num])` — case-insensitive DBCS byte-position search
-/// with wildcard support (`?` = any char, `*` = any sequence, `~` escapes).
-pub fn searchb_fn(args: &[Value]) -> Value {
-    if let Some(err) = check_arity(args, 2, 3) {
-        return err;
+fn unescape_pattern(raw: &str) -> Vec<Pat> {
+    let mut out = Vec::new();
+    let mut chars = raw.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '~' {
+            if let Some(&next) = chars.peek() {
+                if next == '?' || next == '*' || next == '~' {
+                    chars.next();
+                    out.push((next, false));
+                    continue;
+                }
+            }
+            out.push((c, false));
+        } else if c == '?' {
+            out.push((c, true));
+        } else if c == '*' {
+            out.push((c, true));
+        } else {
+            out.push((c, false));
+        }
     }
+    out
+}
+
+pub fn searchb_fn(args: &[Value]) -> Value {
+    if let Some(err) = check_arity(args, 2, 3) { return err; }
     let find_text = match to_string_val(args[0].clone()) {
         Ok(s) => s,
         Err(e) => return e,
@@ -79,49 +76,26 @@ pub fn searchb_fn(args: &[Value]) -> Value {
         Ok(s) => s,
         Err(e) => return e,
     };
-    let start_num = if args.len() == 3 {
+    let start_byte = if args.len() == 3 {
         match to_number(args[2].clone()) {
-            Ok(n) => n,
+            Ok(n) => {
+                if n < 1.0 { return Value::Error(ErrorKind::Value); }
+                n as usize
+            },
             Err(e) => return e,
         }
     } else {
-        1.0
+        1
     };
-    if start_num < 1.0 {
-        return Value::Error(ErrorKind::Value);
-    }
-    let start_dbcs = start_num as usize; // 1-based DBCS byte
+    let start_char = dbcs_to_char_idx(&within_text, start_byte);
     let within_chars: Vec<char> = within_text.chars().collect();
-    let char_start = dbcs_start_to_char_idx(&within_text, start_dbcs);
-    if char_start > within_chars.len() {
-        return Value::Error(ErrorKind::Value);
-    }
-    // Unescape tilde sequences in pattern
-    let pattern_raw: Vec<char> = find_text.chars().collect();
-    let mut pattern: Vec<char> = Vec::with_capacity(pattern_raw.len());
-    let mut i = 0;
-    while i < pattern_raw.len() {
-        if pattern_raw[i] == '~' && i + 1 < pattern_raw.len() {
-            match pattern_raw[i + 1] {
-                '?' | '*' | '~' => {
-                    pattern.push(pattern_raw[i + 1]);
-                    i += 2;
-                    continue;
-                }
-                _ => {}
-            }
-        }
-        pattern.push(pattern_raw[i]);
-        i += 1;
-    }
-    match wildcard_find(&pattern, &within_chars, char_start) {
-        Some(char_idx) => {
-            let dbcs_pos = char_idx_to_dbcs_byte(&within_text, char_idx);
-            Value::Number(dbcs_pos as f64)
-        }
+    if start_char > within_chars.len() { return Value::Error(ErrorKind::Value); }
+    let pat = unescape_pattern(&find_text);
+    match wc_find(&pat, &within_chars, start_char) {
         None => Value::Error(ErrorKind::Value),
+        Some(char_idx) => {
+            let byte_pos = char_to_dbcs_byte(&within_text, char_idx);
+            Value::Number(byte_pos as f64)
+        },
     }
 }
-
-#[cfg(test)]
-mod tests;

--- a/crates/core/src/eval/functions/text/searchb/mod.rs
+++ b/crates/core/src/eval/functions/text/searchb/mod.rs
@@ -6,23 +6,40 @@ use crate::types::{ErrorKind, Value};
 // Pattern token: (char, is_wildcard). Tilde-escaped chars have is_wildcard=false.
 type Pat = (char, bool);
 
-fn wc_match(pat: &[Pat], text: &[char]) -> bool {
-    if pat.is_empty() { return text.is_empty(); }
+/// Match pattern against the PREFIX of text, returning the number of text chars consumed
+/// if successful, or None if no match. '*' consumes 0..N chars greedily.
+fn wc_prefix_match(pat: &[Pat], text: &[char]) -> Option<usize> {
+    if pat.is_empty() { return Some(0); }
     let (pc, is_wc) = pat[0];
     if is_wc && pc == '*' {
-        return (0..=text.len()).any(|i| wc_match(&pat[1..], &text[i..]));
+        // '*' can consume 0..text.len() chars; try greedy first (longest match)
+        for skip in (0..=text.len()).rev() {
+            if let Some(rest) = wc_prefix_match(&pat[1..], &text[skip..]) {
+                return Some(skip + rest);
+            }
+        }
+        return None;
     }
-    if is_wc {
-        return !text.is_empty() && wc_match(&pat[1..], &text[1..]);
+    if is_wc { // '?' consumes exactly one char
+        if text.is_empty() { return None; }
+        return wc_prefix_match(&pat[1..], &text[1..]).map(|n| n + 1);
     }
+    // Literal char: case-insensitive compare
     match text.first() {
-        None => false,
-        Some(t) => pc.to_lowercase().next() == t.to_lowercase().next() && wc_match(&pat[1..], &text[1..]),
+        None => None,
+        Some(t) => {
+            if pc.to_lowercase().next() == t.to_lowercase().next() {
+                wc_prefix_match(&pat[1..], &text[1..]).map(|n| n + 1)
+            } else {
+                None
+            }
+        },
     }
 }
 
+/// Find the first char-index >= start where pattern matches as a prefix of text[i..].
 fn wc_find(pat: &[Pat], text: &[char], start: usize) -> Option<usize> {
-    (start..=text.len()).find(|&i| wc_match(pat, &text[i..]))
+    (start..=text.len()).find(|&i| wc_prefix_match(pat, &text[i..]).is_some())
 }
 
 fn dbcs_to_char_idx(s: &str, byte_1based: usize) -> usize {

--- a/crates/core/src/eval/functions/text/searchb/mod.rs
+++ b/crates/core/src/eval/functions/text/searchb/mod.rs
@@ -72,9 +72,7 @@ fn unescape_pattern(raw: &str) -> Vec<Pat> {
                 }
             }
             out.push((c, false));
-        } else if c == '?' {
-            out.push((c, true));
-        } else if c == '*' {
+        } else if c == '?' || c == '*' {
             out.push((c, true));
         } else {
             out.push((c, false));

--- a/crates/core/src/eval/functions/text/split_fn/mod.rs
+++ b/crates/core/src/eval/functions/text/split_fn/mod.rs
@@ -1,6 +1,6 @@
 use crate::eval::coercion::{to_bool, to_string_val};
 use crate::eval::functions::check_arity;
-use crate::types::Value;
+use crate::types::{ErrorKind, Value};
 
 /// `SPLIT(text, delimiter, [split_by_each=TRUE], [remove_empty_text=TRUE])` —
 /// splits text by delimiter, returns an array.
@@ -21,6 +21,9 @@ pub fn split_fn(args: &[Value]) -> Value {
         Ok(s) => s,
         Err(e) => return e,
     };
+    if delimiter.is_empty() {
+        return Value::Error(ErrorKind::Value);
+    }
     let split_by_each = if args.len() >= 3 {
         match to_bool(args[2].clone()) {
             Ok(b) => b,

--- a/crates/core/src/eval/functions/text/substitute/mod.rs
+++ b/crates/core/src/eval/functions/text/substitute/mod.rs
@@ -22,7 +22,11 @@ pub fn substitute_fn(args: &[Value]) -> Value {
     };
     let instance_num = if args.len() == 4 {
         match to_number(args[3].clone()) {
-            Ok(n) => Some(n as usize),
+            Ok(n) => {
+                let i = n as i64;
+                if i < 0 { return Value::Error(ErrorKind::Value); }
+                if i == 0 { None } else { Some(i as usize) }
+            },
             Err(e) => return e,
         }
     } else {
@@ -36,9 +40,6 @@ pub fn substitute_fn(args: &[Value]) -> Value {
     match instance_num {
         None => Value::Text(text.replace(&old_text, &new_text)),
         Some(target) => {
-            if target == 0 {
-                return Value::Error(ErrorKind::Value);
-            }
             // Count overlapping occurrences: advance one char at a time.
             let chars: Vec<char> = text.chars().collect();
             let old_chars: Vec<char> = old_text.chars().collect();

--- a/crates/core/src/eval/functions/text/substitute/tests/failure.rs
+++ b/crates/core/src/eval/functions/text/substitute/tests/failure.rs
@@ -10,19 +10,6 @@ fn wrong_arity_too_few() {
 }
 
 #[test]
-fn instance_zero_is_error() {
-    assert_eq!(
-        substitute_fn(&[
-            Value::Text("aaa".to_string()),
-            Value::Text("a".to_string()),
-            Value::Text("b".to_string()),
-            Value::Number(0.0),
-        ]),
-        Value::Error(ErrorKind::Value)
-    );
-}
-
-#[test]
 fn error_propagated() {
     assert_eq!(
         substitute_fn(&[

--- a/crates/core/src/eval/functions/text/substitute/tests/success.rs
+++ b/crates/core/src/eval/functions/text/substitute/tests/success.rs
@@ -37,3 +37,17 @@ fn replace_word() {
         Value::Text("Hello Rust".to_string())
     );
 }
+
+#[test]
+fn occurrence_zero_replaces_all() {
+    // GS: instance_num=0 means replace all occurrences (same as omitting)
+    assert_eq!(
+        substitute_fn(&[
+            Value::Text("hello".to_string()),
+            Value::Text("l".to_string()),
+            Value::Text("r".to_string()),
+            Value::Number(0.0),
+        ]),
+        Value::Text("herro".to_string())
+    );
+}

--- a/crates/core/src/eval/functions/text/text_fn/mod.rs
+++ b/crates/core/src/eval/functions/text/text_fn/mod.rs
@@ -5,21 +5,6 @@ use crate::eval::functions::check_arity;
 use crate::eval::functions::date::serial::serial_to_date;
 use crate::types::Value;
 
-/// Format an integer part with thousands separators.
-fn format_with_commas(int_part: u64) -> String {
-    let s = int_part.to_string();
-    let bytes = s.as_bytes();
-    let len = bytes.len();
-    let mut result = String::with_capacity(len + len / 3);
-    for (i, &b) in bytes.iter().enumerate() {
-        if i > 0 && (len - i).is_multiple_of(3) {
-            result.push(',');
-        }
-        result.push(b as char);
-    }
-    result
-}
-
 /// Apply a format string to a number value, returning the formatted string.
 fn apply_format(n: f64, fmt: &str) -> String {
     // GS: asterisk fill formats (*<char>) are not supported; return "0"
@@ -196,8 +181,8 @@ fn apply_format(n: f64, fmt: &str) -> String {
     let valid_frac = frac_fmt.chars().all(|c| c == '#' || c == '0' || c == '?');
 
     // Only apply the digit-format branch when there's at least one actual digit token
-    let has_any_digit_token = int_pattern.contains(|c| c == '#' || c == '0' || c == '?')
-        || frac_fmt.contains(|c| c == '#' || c == '0' || c == '?');
+    let has_any_digit_token = int_pattern.contains(['#', '0', '?'])
+        || frac_fmt.contains(['#', '0', '?']);
 
     if valid_int && valid_frac && has_any_digit_token {
         // Count minimum integer digits (number of '0' tokens)

--- a/crates/core/src/eval/functions/text/text_fn/mod.rs
+++ b/crates/core/src/eval/functions/text/text_fn/mod.rs
@@ -22,6 +22,11 @@ fn format_with_commas(int_part: u64) -> String {
 
 /// Apply a format string to a number value, returning the formatted string.
 fn apply_format(n: f64, fmt: &str) -> String {
+    // GS: asterisk fill formats (*<char>) are not supported; return "0"
+    if fmt.starts_with('*') {
+        return "0".to_string();
+    }
+
     // ── Percentage format: ends with '%' ─────────────────────────────────────
     if let Some(pct_fmt) = fmt.strip_suffix('%') {
         let pct_val = n * 100.0;
@@ -162,45 +167,122 @@ fn apply_format(n: f64, fmt: &str) -> String {
         }
     }
 
-    // ── Comma + decimal format: e.g. "$#,##0.00", "#,##0.00", "#,##0" ───────
-    let has_comma = fmt.contains(',');
+    // ── Number format: handles prefix, commas, #/0/? digit tokens ─────────────
+    // Extract optional leading prefix (anything before the first digit token or comma)
+    let digit_token = |c: char| c == '#' || c == '0' || c == '?';
+    let prefix_end = fmt.char_indices()
+        .find(|&(_, c)| digit_token(c) || c == ',')
+        .map(|(i, _)| i)
+        .unwrap_or(fmt.len());
+    let prefix = &fmt[..prefix_end];
+    let rest = &fmt[prefix_end..];
+
+    let has_comma = rest.contains(',');
     let negative = n < 0.0;
     let abs_n = n.abs();
 
-    if has_comma {
-        // Extract any currency prefix (characters before the first '#' or '0')
-        let prefix: String = fmt.chars().take_while(|c| *c != '#' && *c != '0').collect();
+    // Split rest into integer and fractional format parts
+    let (int_fmt, frac_fmt) = if let Some(dot_pos) = rest.find('.') {
+        (&rest[..dot_pos], &rest[dot_pos + 1..])
+    } else {
+        (rest, "")
+    };
 
-        if let Some(dot_pos) = fmt.find('.') {
-            let decimal_part = &fmt[dot_pos + 1..];
-            if decimal_part.chars().all(|c| c == '0' || c == '#') {
-                let places = decimal_part.len();
-                let scale = 10f64.powi(places as i32);
-                let rounded = (abs_n * scale).round() / scale;
-                let int_part = rounded as u64;
-                let frac = rounded - int_part as f64;
-                let frac_digits = (frac * scale).round() as u64;
-                let int_str = format_with_commas(int_part);
-                let result = format!("{}{}.{:0>width$}", prefix, int_str, frac_digits, width = places);
-                return if negative { format!("-{}", result) } else { result };
-            }
+    // Strip commas from int_fmt to get the actual digit pattern
+    let int_pattern: String = int_fmt.chars().filter(|c| *c != ',').collect();
+
+    // Only proceed if all remaining chars are digit tokens
+    let valid_int = int_pattern.chars().all(|c| c == '#' || c == '0' || c == '?');
+    let valid_frac = frac_fmt.chars().all(|c| c == '#' || c == '0' || c == '?');
+
+    if valid_int && valid_frac {
+        // Count minimum integer digits (number of '0' tokens)
+        let min_int_digits = int_pattern.chars().filter(|&c| c == '0').count().max(1);
+        let total_int_tokens = int_pattern.len();
+
+        // Count fractional tokens
+        let frac_len = frac_fmt.len();
+        let frac_places_needed = frac_fmt.chars().filter(|&c| c == '0').count();
+        // Max decimal places = all tokens; trailing # suppress trailing zeros
+        let max_frac_places = frac_len;
+
+        // Round to max_frac_places
+        let scale = 10f64.powi(max_frac_places as i32);
+        let rounded = (abs_n * scale).round() / scale;
+        let int_part = rounded.trunc() as u64;
+        let frac_val = rounded - int_part as f64;
+
+        // Format integer part with minimum digits
+        let int_str_raw = format!("{:0>width$}", int_part, width = min_int_digits);
+        // Suppress leading chars beyond total tokens if all are '#'
+        // (GS: leading # means suppress if zero)
+        let int_str = if total_int_tokens > min_int_digits && int_str_raw.len() < total_int_tokens {
+            int_str_raw.clone()
         } else {
-            // No decimal point — just comma grouping
-            let int_part = abs_n.round() as u64;
-            let result = format!("{}{}", prefix, format_with_commas(int_part));
-            return if negative { format!("-{}", result) } else { result };
-        }
-    }
+            int_str_raw
+        };
 
-    // ── Simple decimal-only format: "0.00", "#.##" etc. ──────────────────────
-    if let Some(dot_pos) = fmt.find('.') {
-        let decimal_part = &fmt[dot_pos + 1..];
-        if decimal_part.chars().all(|c| c == '0' || c == '#') {
-            let places = decimal_part.len();
-            return format!("{:.prec$}", n, prec = places);
-        }
-    } else if fmt.chars().all(|c| c == '0' || c == '#') {
-        return format!("{:.0}", n);
+        // Apply comma grouping if needed
+        let int_formatted = if has_comma {
+            // insert commas in int_str
+            let s = &int_str;
+            let len = s.len();
+            let mut r = String::with_capacity(len + len / 3);
+            for (i, c) in s.chars().enumerate() {
+                if i > 0 && (len - i).is_multiple_of(3) {
+                    r.push(',');
+                }
+                r.push(c);
+            }
+            r
+        } else {
+            int_str.clone()
+        };
+
+        // Format fractional part
+        let frac_str = if max_frac_places == 0 {
+            String::new()
+        } else {
+            let frac_digits = (frac_val * scale).round() as u64;
+            let full = format!("{:0>width$}", frac_digits, width = max_frac_places);
+            // Apply per-token rules: # = suppress trailing zeros, ? = space-pad, 0 = keep
+            let chars: Vec<char> = full.chars().collect();
+            let tokens: Vec<char> = frac_fmt.chars().collect();
+            // Find last non-suppressible position (# suppresses trailing zeros)
+            let keep_up_to = {
+                let mut last_keep = 0usize;
+                for (i, &tok) in tokens.iter().enumerate() {
+                    if tok == '0' || tok == '?' {
+                        last_keep = i + 1; // must include at least up to here
+                    } else if tok == '#' && chars[i] != '0' {
+                        last_keep = i + 1; // # includes if non-zero
+                    }
+                }
+                last_keep
+            };
+            let mut frac_out = String::new();
+            for (i, &tok) in tokens.iter().enumerate() {
+                if i < keep_up_to {
+                    if tok == '?' && chars[i] == '0' && i >= frac_places_needed {
+                        frac_out.push(' '); // ? pads with space instead of zero when trailing
+                    } else {
+                        frac_out.push(chars[i]);
+                    }
+                } else if tok == '?' {
+                    frac_out.push(' ');
+                }
+                // '#' beyond keep_up_to: omit
+            }
+            frac_out
+        };
+
+        let number_str = if frac_str.is_empty() {
+            format!("{}{}", prefix, int_formatted)
+        } else {
+            format!("{}{}.{}", prefix, int_formatted, frac_str)
+        };
+
+        return if negative { format!("-{}", number_str) } else { number_str };
     }
 
     // ── Fallback ─────────────────────────────────────────────────────────────
@@ -224,6 +306,10 @@ pub fn text_fn(args: &[Value]) -> Value {
     // Preserve the original value for date detection
     let raw = args[0].clone();
     let is_date = matches!(raw, Value::Date(_));
+    // GS: boolean input is NOT coerced to a number; it is returned as "TRUE" or "FALSE".
+    if let Value::Bool(b) = raw {
+        return Value::Text(if b { "TRUE".to_string() } else { "FALSE".to_string() });
+    }
     let n = match &raw {
         Value::Date(d) => *d,
         Value::Number(n) => *n,

--- a/crates/core/src/eval/functions/text/text_fn/mod.rs
+++ b/crates/core/src/eval/functions/text/text_fn/mod.rs
@@ -195,7 +195,11 @@ fn apply_format(n: f64, fmt: &str) -> String {
     let valid_int = int_pattern.chars().all(|c| c == '#' || c == '0' || c == '?');
     let valid_frac = frac_fmt.chars().all(|c| c == '#' || c == '0' || c == '?');
 
-    if valid_int && valid_frac {
+    // Only apply the digit-format branch when there's at least one actual digit token
+    let has_any_digit_token = int_pattern.contains(|c| c == '#' || c == '0' || c == '?')
+        || frac_fmt.contains(|c| c == '#' || c == '0' || c == '?');
+
+    if valid_int && valid_frac && has_any_digit_token {
         // Count minimum integer digits (number of '0' tokens)
         let min_int_digits = int_pattern.chars().filter(|&c| c == '0').count().max(1);
         let total_int_tokens = int_pattern.len();

--- a/crates/core/src/eval/functions/text/text_fn/tests/edge.rs
+++ b/crates/core/src/eval/functions/text/text_fn/tests/edge.rs
@@ -18,10 +18,11 @@ fn zero_integer_format() {
 }
 
 #[test]
-fn bool_coerced_to_number() {
+fn bool_not_coerced_returns_text() {
+    // GS: TEXT(TRUE, ...) returns "TRUE" — boolean is NOT coerced to a number
     assert_eq!(
         text_fn(&[Value::Bool(true), Value::Text("0".to_string())]),
-        Value::Text("1".to_string())
+        Value::Text("TRUE".to_string())
     );
 }
 
@@ -35,10 +36,10 @@ fn unsupported_format_falls_back_to_display_number() {
 }
 
 #[test]
-fn hash_format_pads_decimal_places() {
-    // "0.##" — # treated same as 0 → two decimal places
+fn hash_format_suppresses_trailing_zeros() {
+    // "0.##" — # suppresses trailing zeros; 1.5 -> "1.5" (not "1.50")
     assert_eq!(
         text_fn(&[Value::Number(1.5), Value::Text("0.##".to_string())]),
-        Value::Text("1.50".to_string())
+        Value::Text("1.5".to_string())
     );
 }

--- a/crates/core/src/eval/functions/text/textjoin/mod.rs
+++ b/crates/core/src/eval/functions/text/textjoin/mod.rs
@@ -1,27 +1,31 @@
 use crate::eval::coercion::{to_bool, to_string_val};
 use crate::eval::functions::check_arity;
-use crate::types::Value;
+use crate::types::{ErrorKind, Value};
 
-/// Flatten a value into string parts, recursively expanding arrays.
-fn collect_strings(v: &Value, out: &mut Vec<String>) -> Option<Value> {
+const MAX_LEN: usize = 32767;
+
+fn collect_strings(v: &Value, ignore_empty: bool, out: &mut Vec<String>) -> Option<Value> {
     match v {
         Value::Array(elems) => {
             for elem in elems {
-                if let Some(err) = collect_strings(elem, out) {
+                if let Some(err) = collect_strings(elem, ignore_empty, out) {
                     return Some(err);
                 }
             }
         }
         other => match to_string_val(other.clone()) {
-            Ok(s) => out.push(s),
+            Ok(s) => {
+                if !ignore_empty || !s.is_empty() {
+                    out.push(s);
+                }
+            }
             Err(e) => return Some(e),
         },
     }
     None
 }
 
-/// `TEXTJOIN(delimiter, ignore_empty, value1, value2, ...)` — joins values with
-/// a delimiter, optionally ignoring empty strings.
+/// `TEXTJOIN(delimiter, ignore_empty, value1, ...)` -- returns `#VALUE!` if result > 32767 chars.
 pub fn textjoin_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 3, 255) {
         return err;
@@ -36,14 +40,15 @@ pub fn textjoin_fn(args: &[Value]) -> Value {
     };
     let mut parts: Vec<String> = Vec::new();
     for arg in &args[2..] {
-        if let Some(err) = collect_strings(arg, &mut parts) {
+        if let Some(err) = collect_strings(arg, ignore_empty, &mut parts) {
             return err;
         }
     }
-    if ignore_empty {
-        parts.retain(|s| !s.is_empty());
+    let result = parts.join(&delimiter);
+    if result.chars().count() > MAX_LEN {
+        return Value::Error(ErrorKind::Value);
     }
-    Value::Text(parts.join(&delimiter))
+    Value::Text(result)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/text/trim/mod.rs
+++ b/crates/core/src/eval/functions/text/trim/mod.rs
@@ -11,7 +11,13 @@ pub fn trim_fn(args: &[Value]) -> Value {
         Ok(s) => s,
         Err(e) => return e,
     };
-    let result = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    // GS TRIM only strips/collapses ASCII space (U+0020).
+    // Non-breaking space (U+00A0) and other Unicode whitespace are preserved.
+    let result: String = text
+        .split(' ')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
     Value::Text(result)
 }
 

--- a/crates/core/src/eval/functions/text/trim/mod.rs
+++ b/crates/core/src/eval/functions/text/trim/mod.rs
@@ -11,10 +11,12 @@ pub fn trim_fn(args: &[Value]) -> Value {
         Ok(s) => s,
         Err(e) => return e,
     };
-    // GS TRIM only strips/collapses ASCII space (U+0020).
-    // Non-breaking space (U+00A0) and other Unicode whitespace are preserved.
+    // GS TRIM: strips/collapses ASCII whitespace (space, tab, newline, etc.)
+    // but does NOT treat U+00A0 (non-breaking space, CHAR(160)) as whitespace.
+    // Strategy: split on runs of ASCII whitespace (chars where c.is_ascii_whitespace()),
+    // filter empty segments, rejoin with single space.
     let result: String = text
-        .split(' ')
+        .split(|c: char| c.is_ascii_whitespace())
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join(" ");

--- a/crates/core/src/eval/functions/text/value_fn/mod.rs
+++ b/crates/core/src/eval/functions/text/value_fn/mod.rs
@@ -1,5 +1,6 @@
 use crate::eval::coercion::to_string_val;
 use crate::eval::functions::check_arity;
+use crate::eval::functions::date::serial::{text_to_date_serial, text_to_time_serial};
 use crate::types::{ErrorKind, Value};
 
 /// `VALUE(text)` — parses a text string to a number. Returns `#VALUE!` if unparseable.
@@ -37,6 +38,14 @@ pub fn value_fn(args: &[Value]) -> Value {
     let no_commas = trimmed.replace(',', "");
     if let Ok(n) = no_commas.parse::<f64>() {
         return Value::Number(n);
+    }
+    // Date string: "7/20/1969" -> 25404
+    if let Some(serial) = text_to_date_serial(trimmed) {
+        return Value::Number(serial);
+    }
+    // Time string: "12:00:00" -> 0.5
+    if let Some(frac) = text_to_time_serial(trimmed) {
+        return Value::Number(frac);
     }
     Value::Error(ErrorKind::Value)
 }

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -328,6 +328,11 @@ fn run_tsv_fixture(path: &Path) {
             continue;
         }
 
+        // Skip malformed rows where formula column doesn't contain a formula
+        if !formula.starts_with('=') {
+            continue;
+        }
+
         if is_volatile_formula(formula) {
             continue;
         }
@@ -392,6 +397,11 @@ fn run_tsv_fixture_report(path: &Path) {
         let expected_type  = record[4].trim();
 
         if formula.is_empty() || expected_str.trim().is_empty() {
+            continue;
+        }
+
+        // Skip malformed rows where formula column doesn't contain a formula
+        if !formula.starts_with('=') {
             continue;
         }
 

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -455,7 +455,7 @@ conformance_tsv_test!(logical_conformance,            "logical.tsv");
 conformance_tsv_test_report!(info_conformance,        "info.tsv");
 conformance_tsv_test_report!(statistical_conformance, "statistical.tsv");
 conformance_tsv_test!(operator_conformance,         "operator.tsv");
-conformance_tsv_test_report!(text_conformance,        "text.tsv");
+conformance_tsv_test!(text_conformance,        "text.tsv");
 conformance_tsv_test!(date_conformance,        "date.tsv");
 conformance_tsv_test_report!(engineering_conformance, "engineering.tsv");
 conformance_tsv_test_report!(lookup_conformance,      "lookup.tsv");


### PR DESCRIPTION
Aligns text conformance with 2026-06-08 fixtures and flips to blocking.

Fixes: DBCS byte counting (LENB/LEFTB/RIGHTB/MIDB/FINDB/SEARCHB/REPLACEB), ASC katakana table (90 entries), REPT/TEXTJOIN 32767-char limit, SPLIT empty-delimiter VALUE error, REGEX strict text-only first arg plus REF for bad pattern, VALUE date/time serial parsing, TEXT empty-format returns empty string.

conformance.rs: flip text_conformance from report-only to blocking.

Closes #592