### PR TITLE
fix(eval): statistical conformance — align with 2026-06-08 fixtures

### DIFF
--- a/crates/core/src/eval/functions/math/average/mod.rs
+++ b/crates/core/src/eval/functions/math/average/mod.rs
@@ -1,4 +1,3 @@
-use crate::eval::coercion::to_number;
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
 
@@ -9,16 +8,32 @@ pub fn average_fn(args: &[Value]) -> Value {
     let mut sum = 0.0_f64;
     let mut count = 0usize;
     for arg in args {
-        let scalars: Vec<&Value> = match arg {
-            Value::Array(elems) => elems.iter().collect(),
-            other => vec![other],
-        };
-        for scalar in scalars {
-            match to_number(scalar.clone()) {
-                Err(e) => return e,
-                Ok(n) => {
-                    sum += n;
-                    count += 1;
+        match arg {
+            Value::Number(n) => { sum += n; count += 1; }
+            Value::Date(n)   => { sum += n; count += 1; }
+            Value::Bool(b)   => { sum += if *b { 1.0 } else { 0.0 }; count += 1; }
+            Value::Text(s) => {
+                // Direct text: empty or non-parseable -> #VALUE!
+                let t = s.trim();
+                if t.is_empty() {
+                    return Value::Error(ErrorKind::Value);
+                }
+                match t.parse::<f64>() {
+                    Ok(v) if v.is_finite() => { sum += v; count += 1; }
+                    _ => return Value::Error(ErrorKind::Value),
+                }
+            }
+            Value::Empty => {} // skip
+            Value::Error(e) => return Value::Error(e.clone()),
+            Value::Array(elems) => {
+                // Array context: skip bool/text, include numbers
+                for elem in elems {
+                    match elem {
+                        Value::Number(n) => { sum += n; count += 1; }
+                        Value::Date(n)   => { sum += n; count += 1; }
+                        Value::Error(e)  => return Value::Error(e.clone()),
+                        _ => {} // Bool, Text, Empty all skipped in array
+                    }
                 }
             }
         }

--- a/crates/core/src/eval/functions/math/average/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/average/tests/edge.rs
@@ -10,11 +10,11 @@ fn average_negatives() {
 }
 
 #[test]
-fn average_empty_treated_as_zero() {
-    // Empty coerces to 0.0, count still increments
+fn average_empty_skipped() {
+    // Empty is skipped; only Number(4.0) counted → average = 4.0
     assert_eq!(
         average_fn(&[Value::Empty, Value::Number(4.0)]),
-        Value::Number(2.0)
+        Value::Number(4.0)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/avedev/mod.rs
+++ b/crates/core/src/eval/functions/statistical/avedev/mod.rs
@@ -1,13 +1,17 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_nums_direct;
 
 /// `AVEDEV(value1, ...)` — average of absolute deviations from the mean.
-/// Ignores text, bool, empty. Returns `#DIV/0!` if no numeric values.
+/// Direct bool/text-number args coerce; non-numeric text → #VALUE!.
+/// Returns `#DIV/0!` if no numeric values.
 pub fn avedev_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
-    let nums = collect_nums(args);
+    let nums = match collect_nums_direct(args) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     let n = nums.len();
     if n == 0 {
         return Value::Error(ErrorKind::DivByZero);

--- a/crates/core/src/eval/functions/statistical/avedev/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/avedev/tests/failure.rs
@@ -7,11 +7,11 @@ fn avedev_no_args_returns_na() {
 }
 
 #[test]
-fn avedev_no_numeric_values_returns_div_zero() {
-    // Only text/bool — no numeric values
+fn avedev_non_numeric_text_returns_value_error() {
+    // Direct non-numeric text arg -> #VALUE! (Google Sheets conformant)
     assert_eq!(
-        avedev_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
-        Value::Error(ErrorKind::DivByZero)
+        avedev_fn(&[Value::Text("a".to_string()), Value::Number(1.0)]),
+        Value::Error(ErrorKind::Value)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/avedev/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/avedev/tests/success.rs
@@ -3,7 +3,7 @@ use crate::types::Value;
 
 #[test]
 fn avedev_basic() {
-    // mean=3, deviations: |1-3|=2, |2-3|=1, |3-3|=0, |4-3|=1, |5-3|=2 → avedev=6/5=1.2
+    // mean=3, deviations: |1-3|=2, |2-3|=1, |3-3|=0, |4-3|=1, |5-3|=2 -> avedev=6/5=1.2
     let result = avedev_fn(&[
         Value::Number(1.0),
         Value::Number(2.0),
@@ -16,19 +16,30 @@ fn avedev_basic() {
 
 #[test]
 fn avedev_two_values() {
-    // mean=3, deviations: |1-3|=2, |5-3|=2 → avedev=2.0
+    // mean=3, deviations: |1-3|=2, |5-3|=2 -> avedev=2.0
     let result = avedev_fn(&[Value::Number(1.0), Value::Number(5.0)]);
     assert_eq!(result, Value::Number(2.0));
 }
 
 #[test]
-fn avedev_ignores_bool_and_text() {
-    // bool and text are ignored, only numbers count
-    // mean=5, deviations: |5-5|=0 → avedev=0
+fn avedev_bool_coerces_to_number() {
+    // Direct bool args coerce: TRUE->1, FALSE->0
+    // values: 5.0, 1.0, 0.0 -> mean=2.0, avedev=(3+1+2)/3=2.0
     let result = avedev_fn(&[
         Value::Number(5.0),
         Value::Bool(true),
-        Value::Text("hello".to_string()),
+        Value::Bool(false),
     ]);
-    assert_eq!(result, Value::Number(0.0));
+    assert_eq!(result, Value::Number(2.0));
+}
+
+#[test]
+fn avedev_numeric_text_coerces() {
+    // Direct text "3" coerces to 3.0
+    // values: 1.0, 3.0 -> mean=2.0, avedev=1.0
+    let result = avedev_fn(&[
+        Value::Number(1.0),
+        Value::Text("3".to_string()),
+    ]);
+    assert_eq!(result, Value::Number(1.0));
 }

--- a/crates/core/src/eval/functions/statistical/averagea/mod.rs
+++ b/crates/core/src/eval/functions/statistical/averagea/mod.rs
@@ -1,32 +1,26 @@
 use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums_a_direct;
 
-/// `AVERAGEA(value1, ...)` — average of all values, coercing booleans (TRUE=1, FALSE=0).
-/// - Numbers included directly.
-/// - Booleans coerced: TRUE=1, FALSE=0.
-/// - Text in direct args → `#VALUE!`.
-/// - Empty → skip.
-/// - No args → `#N/A`.
+/// `AVERAGEA(value1, ...)` — average including booleans and text.
+/// - Numbers/Dates: included at face value.
+/// - Booleans: TRUE=1, FALSE=0 (always, direct and array).
+/// - Direct text that parses as number: coerced to that number.
+/// - Direct text that does NOT parse: treated as 0 (counted).
+/// - Array text: treated as 0 (counted).
+/// - Empty: skipped.
+/// - No args → `#N/A`. No numeric values → `#DIV/0!`.
 pub fn averagea_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
-    let mut total = 0.0_f64;
-    let mut count = 0usize;
-    for arg in args {
-        let n = match arg {
-            Value::Number(n) => *n,
-            Value::Bool(b)   => if *b { 1.0 } else { 0.0 },
-            Value::Text(_)   => return Value::Error(ErrorKind::Value),
-            Value::Empty     => continue,
-            _                => continue,
-        };
-        total += n;
-        count += 1;
-    }
-    if count == 0 {
+    let nums = match collect_nums_a_direct(args) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if nums.is_empty() {
         return Value::Error(ErrorKind::DivByZero);
     }
-    Value::Number(total / count as f64)
+    Value::Number(nums.iter().sum::<f64>() / nums.len() as f64)
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/averagea/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/averagea/tests/failure.rs
@@ -15,9 +15,9 @@ fn all_empty_returns_div_zero() {
 }
 
 #[test]
-fn direct_text_arg_returns_value_error() {
+fn direct_error_propagates() {
     assert_eq!(
-        averagea_fn(&[Value::Text("text".to_string()), Value::Number(1.0)]),
-        Value::Error(ErrorKind::Value)
+        averagea_fn(&[Value::Error(crate::types::ErrorKind::Value)]),
+        Value::Error(crate::types::ErrorKind::Value)
     );
 }

--- a/crates/core/src/eval/functions/statistical/count/mod.rs
+++ b/crates/core/src/eval/functions/statistical/count/mod.rs
@@ -20,7 +20,7 @@ pub fn counta_fn(args: &[Value]) -> Value {
 
 // ── Lazy versions (registered) ────────────────────────────────────────────────
 
-/// Lazy COUNT: counts Numbers, Booleans, and numeric Text; ignores errors/empty.
+/// Lazy COUNT: in direct args counts Numbers, Bool, numeric Text; in arrays counts only Numbers.
 /// Returns #N/A when called with no arguments.
 pub fn count_lazy_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     if args.is_empty() {
@@ -28,21 +28,33 @@ pub fn count_lazy_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     }
     let mut n = 0usize;
     for arg in args {
-        count_numeric(&evaluate_expr(arg, ctx), &mut n);
+        count_direct(&evaluate_expr(arg, ctx), &mut n);
     }
     Value::Number(n as f64)
 }
 
-fn count_numeric(v: &Value, n: &mut usize) {
+fn count_direct(v: &Value, n: &mut usize) {
     match v {
         Value::Array(elems) => {
             for elem in elems {
-                count_numeric(elem, n);
+                count_in_array(elem, n);
             }
         }
         Value::Number(_) => *n += 1,
         Value::Bool(_) => *n += 1,
         Value::Text(s) if s.parse::<f64>().is_ok() => *n += 1,
+        _ => {}
+    }
+}
+
+fn count_in_array(v: &Value, n: &mut usize) {
+    match v {
+        Value::Array(elems) => {
+            for elem in elems {
+                count_in_array(elem, n);
+            }
+        }
+        Value::Number(_) => *n += 1,
         _ => {}
     }
 }

--- a/crates/core/src/eval/functions/statistical/count/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/count/tests/edge.rs
@@ -106,7 +106,7 @@ fn count_array_variable_counts_numbers() {
 
 #[test]
 fn count_array_variable_skips_non_numeric() {
-    // COUNT with mixed array — only numbers are counted
+    // COUNT with mixed array — only Numbers counted (Bool skipped in array context)
     let vars: HashMap<_, _> = [(
         "A".to_string(),
         Value::Array(vec![
@@ -118,8 +118,7 @@ fn count_array_variable_skips_non_numeric() {
         ]),
     )]
     .into();
-    // COUNT counts Numbers and Bools and numeric text
-    assert_eq!(run("=COUNT(A)", vars), Value::Number(3.0));
+    assert_eq!(run("=COUNT(A)", vars), Value::Number(2.0));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/covariance_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_p/mod.rs
@@ -1,21 +1,18 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_paired;
 
 /// `COVARIANCE.P(array1, array2)` — population covariance of two arrays.
-/// Requires exactly 2 args of equal non-zero length. Returns `#N/A` if lengths differ.
-/// Returns `#DIV/0!` if arrays are empty.
 pub fn covariance_p_fn(args: &[Value]) -> Value {
     if args.len() != 2 {
         return Value::Error(ErrorKind::NA);
     }
-    let xs = collect_nums(std::slice::from_ref(&args[0]));
-    let ys = collect_nums(std::slice::from_ref(&args[1]));
-    if xs.len() != ys.len() {
-        return Value::Error(ErrorKind::NA);
-    }
+    let (xs, ys) = match collect_paired(&args[0], &args[1]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     let n = xs.len();
     if n == 0 {
-        return Value::Error(ErrorKind::DivByZero);
+        return Value::Error(ErrorKind::Ref);
     }
     let mean_x = xs.iter().sum::<f64>() / n as f64;
     let mean_y = ys.iter().sum::<f64>() / n as f64;

--- a/crates/core/src/eval/functions/statistical/covariance_p/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_p/tests/failure.rs
@@ -28,8 +28,8 @@ fn covariance_p_unequal_lengths_returns_na() {
 }
 
 #[test]
-fn covariance_p_empty_arrays_returns_div_zero() {
+fn covariance_p_empty_arrays_returns_ref() {
     let arr1 = Value::Array(vec![]);
     let arr2 = Value::Array(vec![]);
-    assert_eq!(covariance_p_fn(&[arr1, arr2]), Value::Error(ErrorKind::DivByZero));
+    assert_eq!(covariance_p_fn(&[arr1, arr2]), Value::Error(ErrorKind::Ref));
 }

--- a/crates/core/src/eval/functions/statistical/covariance_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/mod.rs
@@ -1,18 +1,15 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_paired;
 
 /// `COVARIANCE.S(array1, array2)` — sample covariance of two arrays.
-/// Requires exactly 2 args of equal length ≥2. Returns `#N/A` if lengths differ.
-/// Returns `#DIV/0!` if n < 2.
 pub fn covariance_s_fn(args: &[Value]) -> Value {
     if args.len() != 2 {
         return Value::Error(ErrorKind::NA);
     }
-    let xs = collect_nums(std::slice::from_ref(&args[0]));
-    let ys = collect_nums(std::slice::from_ref(&args[1]));
-    if xs.len() != ys.len() {
-        return Value::Error(ErrorKind::NA);
-    }
+    let (xs, ys) = match collect_paired(&args[0], &args[1]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     let n = xs.len();
     if n < 2 {
         return Value::Error(ErrorKind::Num);

--- a/crates/core/src/eval/functions/statistical/covariance_s/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/covariance_s/tests/failure.rs
@@ -36,8 +36,8 @@ fn covariance_s_single_point_returns_num() {
 }
 
 #[test]
-fn covariance_s_empty_arrays_returns_num() {
+fn covariance_s_empty_arrays_returns_ref() {
     let arr1 = Value::Array(vec![]);
     let arr2 = Value::Array(vec![]);
-    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Error(ErrorKind::Num));
+    assert_eq!(covariance_s_fn(&[arr1, arr2]), Value::Error(ErrorKind::Ref));
 }

--- a/crates/core/src/eval/functions/statistical/devsq/mod.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/mod.rs
@@ -1,23 +1,15 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_nums_direct;
 
 /// `DEVSQ(value1, ...)` — sum of squared deviations from the mean.
-/// Ignores text, bool, empty. Returns `#NUM!` if no numeric values.
 pub fn devsq_fn(args: &[Value]) -> Value {
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
-    }
-    let nums = collect_nums(args);
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     let n = nums.len();
-    if n == 0 {
-        return Value::Error(ErrorKind::Num);
-    }
+    if n == 0 { return Value::Error(ErrorKind::Num); }
     let mean = nums.iter().sum::<f64>() / n as f64;
     let devsq = nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>();
-    if !devsq.is_finite() {
-        return Value::Error(ErrorKind::Num);
-    }
-    Value::Number(devsq)
+    if devsq.is_finite() { Value::Number(devsq) } else { Value::Error(ErrorKind::Num) }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/devsq/mod.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/mod.rs
@@ -2,11 +2,12 @@ use crate::types::{ErrorKind, Value};
 use super::stat_helpers::collect_nums_direct;
 
 /// `DEVSQ(value1, ...)` — sum of squared deviations from the mean.
+/// Array text/Bool → skip. Direct Bool/text → coerce. Empty set → 0.0.
 pub fn devsq_fn(args: &[Value]) -> Value {
     if args.is_empty() { return Value::Error(ErrorKind::NA); }
     let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     let n = nums.len();
-    if n == 0 { return Value::Error(ErrorKind::Num); }
+    if n == 0 { return Value::Number(0.0); }
     let mean = nums.iter().sum::<f64>() / n as f64;
     let devsq = nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>();
     if devsq.is_finite() { Value::Number(devsq) } else { Value::Error(ErrorKind::Num) }

--- a/crates/core/src/eval/functions/statistical/devsq/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/tests/failure.rs
@@ -16,6 +16,7 @@ fn devsq_non_numeric_text_returns_value_error() {
 }
 
 #[test]
-fn devsq_empty_only_returns_num_error() {
-    assert_eq!(devsq_fn(&[Value::Empty]), Value::Error(ErrorKind::Num));
+fn devsq_empty_only_returns_zero() {
+    // Empty is skipped → no numbers → devsq of empty set = 0
+    assert_eq!(devsq_fn(&[Value::Empty]), Value::Number(0.0));
 }

--- a/crates/core/src/eval/functions/statistical/devsq/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/tests/failure.rs
@@ -7,10 +7,11 @@ fn devsq_no_args_returns_na() {
 }
 
 #[test]
-fn devsq_no_numeric_values_returns_num_error() {
+fn devsq_non_numeric_text_returns_value_error() {
+    // Direct non-numeric text -> #VALUE! (Google Sheets conformant)
     assert_eq!(
-        devsq_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
-        Value::Error(ErrorKind::Num)
+        devsq_fn(&[Value::Text("a".to_string()), Value::Number(1.0)]),
+        Value::Error(ErrorKind::Value)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/devsq/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/devsq/tests/success.rs
@@ -3,7 +3,7 @@ use crate::types::Value;
 
 #[test]
 fn devsq_basic() {
-    // mean=3, deviations squared: (1-3)²=4, (2-3)²=1, (3-3)²=0, (4-3)²=1, (5-3)²=4 → devsq=10
+    // mean=3, deviations squared: (1-3)^2=4, (2-3)^2=1, (3-3)^2=0, (4-3)^2=1, (5-3)^2=4 -> devsq=10
     let result = devsq_fn(&[
         Value::Number(1.0),
         Value::Number(2.0),
@@ -16,20 +16,22 @@ fn devsq_basic() {
 
 #[test]
 fn devsq_two_values() {
-    // mean=3, deviations squared: (1-3)²=4, (5-3)²=4 → devsq=8
+    // mean=3, deviations squared: (1-3)^2=4, (5-3)^2=4 -> devsq=8
     let result = devsq_fn(&[Value::Number(1.0), Value::Number(5.0)]);
     assert_eq!(result, Value::Number(8.0));
 }
 
 #[test]
-fn devsq_ignores_bool_and_text() {
-    // bool and text are ignored
+fn devsq_bool_coerces_to_number() {
+    // Direct bool coerces: TRUE->1, FALSE->0
+    // values: 2.0, 4.0, 1.0, 0.0 -> mean=1.75
+    // devsq=(2-1.75)^2+(4-1.75)^2+(1-1.75)^2+(0-1.75)^2
+    //      =0.0625+5.0625+0.5625+3.0625=8.75
     let result = devsq_fn(&[
         Value::Number(2.0),
         Value::Number(4.0),
         Value::Bool(true),
-        Value::Text("x".to_string()),
+        Value::Bool(false),
     ]);
-    // mean=3, devsq=(2-3)²+(4-3)²=2
-    assert_eq!(result, Value::Number(2.0));
+    assert_eq!(result, Value::Number(8.75));
 }

--- a/crates/core/src/eval/functions/statistical/distributions_impl.rs
+++ b/crates/core/src/eval/functions/statistical/distributions_impl.rs
@@ -87,7 +87,7 @@ fn collect_weights_arg(arg: &Value) -> Result<Vec<f64>, Value> {
             _ => Err(Value::Error(ErrorKind::Value)),
         },
         Value::Empty => Ok(vec![]),
-        Value::Error(e) => Err(Value::Error(*e)),
+        Value::Error(e) => Err(Value::Error(e.clone())),
         Value::Array(inner) => {
             let mut out = Vec::new();
             for item in inner {
@@ -96,7 +96,7 @@ fn collect_weights_arg(arg: &Value) -> Result<Vec<f64>, Value> {
                     Value::Date(n) => out.push(*n),
                     Value::Bool(_) => return Err(Value::Error(ErrorKind::Value)),
                     Value::Text(_) | Value::Empty => {}
-                    Value::Error(e) => return Err(Value::Error(*e)),
+                    Value::Error(e) => return Err(Value::Error(e.clone())),
                     Value::Array(_) => {}
                 }
             }

--- a/crates/core/src/eval/functions/statistical/distributions_impl.rs
+++ b/crates/core/src/eval/functions/statistical/distributions_impl.rs
@@ -28,6 +28,7 @@ fn as_f64(v: &Value) -> Option<f64> {
     match v {
         Value::Number(n) => Some(*n),
         Value::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+        Value::Text(s) => s.trim().parse::<f64>().ok().filter(|n| n.is_finite()),
         _ => None,
     }
 }
@@ -420,8 +421,9 @@ pub fn chisq_dist_rt_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    if x < 0.0 || df < 1.0 {
+    let df_raw = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df = df_raw.trunc();
+    if x < 0.0 || df < 1.0 || df > 1e10 {
         return Value::Error(ErrorKind::Num);
     }
     Value::Number(1.0 - d::chisq_cdf(x, df))
@@ -433,8 +435,9 @@ pub fn chidist_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    if x < 0.0 || df < 1.0 {
+    let df_raw = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df = df_raw.trunc();
+    if x < 0.0 || df < 1.0 || df > 1e10 {
         return Value::Error(ErrorKind::Num);
     }
     Value::Number(1.0 - d::chisq_cdf(x, df))
@@ -466,8 +469,9 @@ pub fn chisq_inv_rt_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let p = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    if p < 0.0 || p > 1.0 || df < 1.0 {
+    let df_raw = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df = df_raw.trunc();
+    if p < 0.0 || p > 1.0 || df < 1.0 || df > 1e10 {
         return Value::Error(ErrorKind::Num);
     }
     let v = d::chisq_inv(1.0 - p, df);
@@ -572,7 +576,8 @@ pub fn tdist_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df_raw = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df = df_raw.trunc();
     let tails = match as_f64(&args[2]) { Some(v) => v as i64, None => return Value::Error(ErrorKind::Value) };
     if df < 1.0 || x < 0.0 {
         return Value::Error(ErrorKind::Num);
@@ -762,8 +767,8 @@ pub fn f_dist_rt_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df1 = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df2 = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df1 = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) }.trunc();
+    let df2 = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) }.trunc();
     if x < 0.0 || df1 < 1.0 || df2 < 1.0 {
         return Value::Error(ErrorKind::Num);
     }
@@ -1058,10 +1063,17 @@ pub fn binom_inv_fn(args: &[Value]) -> Value {
     if args.len() < 3 {
         return Value::Error(ErrorKind::NA);
     }
+    if args.len() > 3 {
+        return Value::Error(ErrorKind::NA);
+    }
     let n_f = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     let p = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     let alpha = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     if n_f < 0.0 || p < 0.0 || p > 1.0 || alpha <= 0.0 || alpha >= 1.0 {
+        return Value::Error(ErrorKind::Num);
+    }
+    // GS returns #NUM! for degenerate p=0 or p=1
+    if p == 0.0 || p == 1.0 {
         return Value::Error(ErrorKind::Num);
     }
     let n = n_f as u64;

--- a/crates/core/src/eval/functions/statistical/distributions_impl.rs
+++ b/crates/core/src/eval/functions/statistical/distributions_impl.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::manual_range_contains)]
 
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::{collect_nums, collect_paired};
 use super::distributions as d;
 
 // ---------------------------------------------------------------------------
@@ -15,11 +15,15 @@ fn as_bool(v: &Value) -> Option<bool> {
     match v {
         Value::Bool(b) => Some(*b),
         Value::Number(n) => Some(*n != 0.0),
-        Value::Text(s) => match s.to_uppercase().as_str() {
-            "TRUE" => Some(true),
-            "FALSE" => Some(false),
-            _ => None,
-        },
+        Value::Text(s) => {
+            let t = s.trim();
+            if t.is_empty() { return Some(false); }
+            match t.to_uppercase().as_str() {
+                "TRUE" => Some(true),
+                "FALSE" => Some(false),
+                _ => None,
+            }
+        }
         _ => None,
     }
 }
@@ -28,10 +32,15 @@ fn as_f64(v: &Value) -> Option<f64> {
     match v {
         Value::Number(n) => Some(*n),
         Value::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
-        Value::Text(s) => s.trim().parse::<f64>().ok().filter(|n| n.is_finite()),
+        Value::Text(s) => {
+            let t = s.trim();
+            if t.is_empty() { return Some(0.0); }
+            t.parse::<f64>().ok().filter(|n| n.is_finite())
+        }
         _ => None,
     }
 }
+
 
 // ---------------------------------------------------------------------------
 // AVERAGE.WEIGHTED
@@ -43,7 +52,7 @@ pub fn average_weighted_fn(args: &[Value]) -> Value {
     if args.len() < 2 {
         return Value::Error(ErrorKind::NA);
     }
-    if args.len() % 2 != 0 {
+    if !args.len().is_multiple_of(2) {
         return Value::Error(ErrorKind::NA);
     }
     let mut weighted_sum = 0.0_f64;
@@ -109,21 +118,21 @@ fn collect_weights_arg(arg: &Value) -> Result<Vec<f64>, Value> {
 // NORM.S.DIST / NORMSDIST
 // ---------------------------------------------------------------------------
 pub fn norm_s_dist_fn(args: &[Value]) -> Value {
-    if args.is_empty() {
+    if args.is_empty() || args.len() > 2 {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) {
         Some(v) => v,
         None => return Value::Error(ErrorKind::Value),
     };
-    // Second arg: cumulative (optional, default TRUE for NORMSDIST compatibility)
+    // cumulative defaults to TRUE when omitted (1-arg form)
     let cumulative = if args.len() >= 2 {
         match as_bool(&args[1]) {
             Some(b) => b,
             None => return Value::Error(ErrorKind::Value),
         }
     } else {
-        true // NORMSDIST legacy form has only one arg
+        true
     };
     if cumulative {
         Value::Number(d::norm_s_cdf(x))
@@ -132,9 +141,12 @@ pub fn norm_s_dist_fn(args: &[Value]) -> Value {
     }
 }
 
-// NORMSDIST (legacy, always cumulative)
+// NORMSDIST (legacy, always cumulative, exactly 1 arg)
 pub fn normsdist_fn(args: &[Value]) -> Value {
     if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    if args.len() > 1 {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) {
@@ -149,6 +161,9 @@ pub fn normsdist_fn(args: &[Value]) -> Value {
 // ---------------------------------------------------------------------------
 pub fn norm_s_inv_fn(args: &[Value]) -> Value {
     if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    if args.len() > 1 {
         return Value::Error(ErrorKind::NA);
     }
     let p = match as_f64(&args[0]) {
@@ -223,6 +238,9 @@ pub fn gauss_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
+    if args.len() > 1 {
+        return Value::Error(ErrorKind::NA);
+    }
     let x = match as_f64(&args[0]) {
         Some(v) => v,
         None => return Value::Error(ErrorKind::Value),
@@ -237,6 +255,9 @@ pub fn phi_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
+    if args.len() > 1 {
+        return Value::Error(ErrorKind::NA);
+    }
     let x = match as_f64(&args[0]) {
         Some(v) => v,
         None => return Value::Error(ErrorKind::Value),
@@ -249,6 +270,9 @@ pub fn phi_fn(args: &[Value]) -> Value {
 // ---------------------------------------------------------------------------
 pub fn standardize_fn(args: &[Value]) -> Value {
     if args.len() < 3 {
+        return Value::Error(ErrorKind::NA);
+    }
+    if args.len() > 3 {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
@@ -269,7 +293,7 @@ pub fn confidence_fn(args: &[Value]) -> Value {
     }
     let alpha = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     let stdev = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let size = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let size = match as_f64(&args[2]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
     if alpha <= 0.0 || alpha >= 1.0 || stdev <= 0.0 || size < 1.0 {
         return Value::Error(ErrorKind::Num);
     }
@@ -286,7 +310,7 @@ pub fn confidence_t_fn(args: &[Value]) -> Value {
     }
     let alpha = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     let stdev = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let size = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let size = match as_f64(&args[2]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
     if alpha <= 0.0 || alpha >= 1.0 || stdev <= 0.0 || size < 2.0 {
         return Value::Error(ErrorKind::Num);
     }
@@ -302,13 +326,15 @@ pub fn confidence_t_fn(args: &[Value]) -> Value {
 // CORREL / PEARSON
 // ---------------------------------------------------------------------------
 fn correl_impl(args: &[Value]) -> Value {
-    if args.len() < 2 {
+    if args.len() < 2 || args.len() > 2 {
         return Value::Error(ErrorKind::NA);
     }
-    let xs = collect_nums(std::slice::from_ref(&args[0]));
-    let ys = collect_nums(std::slice::from_ref(&args[1]));
-    if xs.len() != ys.len() || xs.len() < 2 {
-        return Value::Error(ErrorKind::NA);
+    let (xs, ys) = match collect_paired(&args[0], &args[1]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if xs.len() < 2 {
+        return Value::Error(ErrorKind::DivByZero);
     }
     match d::pearson_corr(&xs, &ys) {
         Some(r) => {
@@ -334,11 +360,11 @@ pub fn pearson_fn(args: &[Value]) -> Value {
 // Linear regression: SLOPE, INTERCEPT, RSQ, FORECAST, FORECAST.LINEAR, STEYX
 // ---------------------------------------------------------------------------
 fn get_two_arrays(args: &[Value]) -> Result<(Vec<f64>, Vec<f64>), Value> {
-    if args.len() < 2 {
+    if args.len() < 2 || args.len() > 2 {
         return Err(Value::Error(ErrorKind::NA));
     }
-    let ys = collect_nums(std::slice::from_ref(&args[0]));
-    let xs = collect_nums(std::slice::from_ref(&args[1]));
+    // args[0] = known_y, args[1] = known_x; paired deletion semantics
+    let (xs, ys) = collect_paired(&args[1], &args[0])?;
     Ok((xs, ys))
 }
 
@@ -347,7 +373,7 @@ pub fn slope_fn(args: &[Value]) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
-    if xs.len() != ys.len() || xs.is_empty() {
+    if xs.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
     match d::linear_regression(&xs, &ys) {
@@ -361,7 +387,7 @@ pub fn intercept_fn(args: &[Value]) -> Value {
         Ok(v) => v,
         Err(e) => return e,
     };
-    if xs.len() != ys.len() || xs.is_empty() {
+    if xs.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
     match d::linear_regression(&xs, &ys) {
@@ -371,14 +397,18 @@ pub fn intercept_fn(args: &[Value]) -> Value {
 }
 
 pub fn rsq_fn(args: &[Value]) -> Value {
-    if args.len() < 2 {
+    if args.len() < 2 || args.len() > 2 {
         return Value::Error(ErrorKind::NA);
     }
-    // RSQ takes (known_y, known_x)
-    let ys = collect_nums(std::slice::from_ref(&args[0]));
-    let xs = collect_nums(std::slice::from_ref(&args[1]));
-    if xs.len() != ys.len() || xs.len() < 2 {
+    let (xs, ys) = match collect_paired(&args[1], &args[0]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if xs.is_empty() {
         return Value::Error(ErrorKind::NA);
+    }
+    if xs.len() < 2 {
+        return Value::Error(ErrorKind::DivByZero);
     }
     match d::pearson_corr(&xs, &ys) {
         Some(r) => {
@@ -400,10 +430,12 @@ fn forecast_impl(args: &[Value]) -> Value {
         Some(v) => v,
         None => return Value::Error(ErrorKind::Value),
     };
-    let ys = collect_nums(std::slice::from_ref(&args[1]));
-    let xs = collect_nums(std::slice::from_ref(&args[2]));
-    if xs.len() != ys.len() || xs.is_empty() {
-        return Value::Error(ErrorKind::NA);
+    let (xs, ys) = match collect_paired(&args[2], &args[1]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if xs.is_empty() {
+        return Value::Error(ErrorKind::DivByZero);
     }
     match d::linear_regression(&xs, &ys) {
         Some((slope, intercept)) => Value::Number(slope * x + intercept),
@@ -425,8 +457,11 @@ pub fn steyx_fn(args: &[Value]) -> Value {
         Err(e) => return e,
     };
     let n = xs.len();
-    if n != ys.len() || n < 3 {
+    if n == 0 {
         return Value::Error(ErrorKind::NA);
+    }
+    if n < 3 {
+        return Value::Error(ErrorKind::DivByZero);
     }
     let nf = n as f64;
     let mean_x = xs.iter().sum::<f64>() / nf;
@@ -437,11 +472,12 @@ pub fn steyx_fn(args: &[Value]) -> Value {
     if ss_xx == 0.0 {
         return Value::Error(ErrorKind::DivByZero);
     }
-    let se2 = (ss_yy - ss_xy * ss_xy / ss_xx) / (nf - 2.0);
-    if se2 < 0.0 {
-        return Value::Number(0.0);
+    let sse = ss_yy - ss_xy * ss_xy / ss_xx;
+    let se2 = sse / (nf - 2.0);
+    if se2 < -1e-10 {
+        return Value::Error(ErrorKind::Num);
     }
-    Value::Number(se2.sqrt())
+    Value::Number(se2.max(0.0).sqrt())
 }
 
 // ---------------------------------------------------------------------------
@@ -452,12 +488,13 @@ pub fn chisq_dist_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df_raw = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df = df_raw.trunc();
     let cumulative = match as_bool(&args[2]) {
         Some(b) => b,
         None => return Value::Error(ErrorKind::Value),
     };
-    if x < 0.0 || df < 1.0 {
+    if x < 0.0 || df < 1.0 || df > 1e10 {
         return Value::Error(ErrorKind::Num);
     }
     if cumulative {
@@ -503,8 +540,8 @@ pub fn chisq_inv_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let p = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    if p < 0.0 || p > 1.0 || df < 1.0 {
+    let df = match as_f64(&args[1]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
+    if p < 0.0 || p > 1.0 || df < 1.0 || df > 1e10 {
         return Value::Error(ErrorKind::Num);
     }
     let v = d::chisq_inv(p, df);
@@ -542,27 +579,102 @@ pub fn chiinv_fn(args: &[Value]) -> Value {
 // ---------------------------------------------------------------------------
 // CHISQ.TEST / CHITEST
 // ---------------------------------------------------------------------------
+fn flatten_values_for_chisq(v: &Value) -> Vec<Value> {
+    match v {
+        Value::Array(inner) => {
+            let mut out = Vec::new();
+            flatten_chisq_into(inner, &mut out);
+            out
+        }
+        other => vec![other.clone()],
+    }
+}
+
+fn flatten_chisq_into(arr: &[Value], out: &mut Vec<Value>) {
+    for v in arr {
+        match v {
+            Value::Array(inner) => flatten_chisq_into(inner, out),
+            other => out.push(other.clone()),
+        }
+    }
+}
+
+fn chisq_array_dims(v: &Value) -> (usize, usize) {
+    match v {
+        Value::Array(outer) => {
+            if outer.is_empty() { return (0, 0); }
+            let is_2d = outer.iter().any(|e| matches!(e, Value::Array(_)));
+            if is_2d {
+                let rows = outer.len();
+                let cols = outer.iter().map(|r| if let Value::Array(c) = r { c.len() } else { 1 }).max().unwrap_or(0);
+                (rows, cols)
+            } else {
+                (1, outer.len())
+            }
+        }
+        _ => (1, 1),
+    }
+}
+
 fn chisq_test_impl(args: &[Value]) -> Value {
-    if args.len() < 2 {
+    if args.len() < 2 || args.len() > 2 {
         return Value::Error(ErrorKind::NA);
     }
-    let observed = collect_nums(std::slice::from_ref(&args[0]));
-    let expected = collect_nums(std::slice::from_ref(&args[1]));
-    if observed.len() != expected.len() || observed.is_empty() {
+
+    let obs_flat = flatten_values_for_chisq(&args[0]);
+    let exp_flat = flatten_values_for_chisq(&args[1]);
+
+    if obs_flat.len() != exp_flat.len() {
         return Value::Error(ErrorKind::NA);
     }
-    // Chi-squared statistic
-    let chi2: f64 = observed.iter().zip(expected.iter())
-        .map(|(o, e)| {
-            if *e == 0.0 { 0.0 } else { (o - e).powi(2) / e }
-        })
-        .sum();
-    let df = (observed.len() - 1) as f64;
-    if df <= 0.0 {
+
+    // Compute df based on array dimensions
+    let (obs_rows, obs_cols) = chisq_array_dims(&args[0]);
+    let df = if obs_rows > 1 && obs_cols > 1 {
+        // 2D contingency: df = (rows-1)*(cols-1)
+        ((obs_rows - 1) * (obs_cols - 1)) as f64
+    } else {
+        // 1D vector: df = max(1, n_valid-1) computed after filtering
+        0.0 // placeholder; will compute after filtering
+    };
+    let is_2d = obs_rows > 1 && obs_cols > 1;
+
+    // Filter pairs: Error propagates; non-numeric in either → skip pair
+    let mut chi2 = 0.0_f64;
+    let mut n_valid = 0usize;
+    for (o_val, e_val) in obs_flat.iter().zip(exp_flat.iter()) {
+        if let Value::Error(e) = o_val { return Value::Error(e.clone()); }
+        if let Value::Error(e) = e_val { return Value::Error(e.clone()); }
+        let o = match o_val {
+            Value::Number(n) => *n,
+            _ => continue, // skip non-numeric observed
+        };
+        let e = match e_val {
+            Value::Number(n) => *n,
+            _ => continue, // skip non-numeric expected
+        };
+        if e < 0.0 {
+            return Value::Error(ErrorKind::Num);
+        }
+        if e == 0.0 {
+            return Value::Error(ErrorKind::DivByZero);
+        }
+        chi2 += (o - e).powi(2) / e;
+        n_valid += 1;
+    }
+
+    let effective_df = if is_2d {
+        df
+    } else {
+        // 1D: df = max(1, n_valid-1)
+        (n_valid.saturating_sub(1)).max(1) as f64
+    };
+
+    if effective_df <= 0.0 || n_valid == 0 {
         return Value::Error(ErrorKind::DivByZero);
     }
-    // Return right-tail p-value
-    Value::Number(1.0 - d::chisq_cdf(chi2, df))
+
+    Value::Number(1.0 - d::chisq_cdf(chi2, effective_df))
 }
 
 pub fn chisq_test_fn(args: &[Value]) -> Value {
@@ -581,7 +693,7 @@ pub fn t_dist_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df = match as_f64(&args[1]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
     let cumulative = match as_bool(&args[2]) {
         Some(b) => b,
         None => return Value::Error(ErrorKind::Value),
@@ -598,11 +710,11 @@ pub fn t_dist_fn(args: &[Value]) -> Value {
 
 // T.DIST.RT (right tail)
 pub fn t_dist_rt_fn(args: &[Value]) -> Value {
-    if args.len() < 2 {
+    if args.len() < 2 || args.len() > 2 {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df = match as_f64(&args[1]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
     if df < 1.0 {
         return Value::Error(ErrorKind::Num);
     }
@@ -615,7 +727,7 @@ pub fn t_dist_2t_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df = match as_f64(&args[1]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
     if df < 1.0 || x < 0.0 {
         return Value::Error(ErrorKind::Num);
     }
@@ -651,7 +763,7 @@ pub fn t_inv_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let p = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df = match as_f64(&args[1]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
     if p <= 0.0 || p >= 1.0 || df < 1.0 {
         return Value::Error(ErrorKind::Num);
     }
@@ -669,7 +781,7 @@ pub fn t_inv_2t_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let p = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df = match as_f64(&args[1]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
     if p <= 0.0 || p > 1.0 || df < 1.0 {
         return Value::Error(ErrorKind::Num);
     }
@@ -694,10 +806,25 @@ fn t_test_impl(args: &[Value]) -> Value {
     if args.len() < 4 {
         return Value::Error(ErrorKind::NA);
     }
+    // Propagate errors from data arrays before collecting numbers
+    for arg in &args[0..2] {
+        if let Value::Error(e) = arg { return Value::Error(e.clone()); }
+        if let Value::Array(inner) = arg {
+            for v in inner { if let Value::Error(e) = v { return Value::Error(e.clone()); } }
+        }
+    }
     let arr1 = collect_nums(std::slice::from_ref(&args[0]));
     let arr2 = collect_nums(std::slice::from_ref(&args[1]));
-    let tails = match as_f64(&args[2]) { Some(v) => v as i64, None => return Value::Error(ErrorKind::Value) };
-    let typ = match as_f64(&args[3]) { Some(v) => v as i64, None => return Value::Error(ErrorKind::Value) };
+    let tails = match as_f64(&args[2]) { Some(v) => v.trunc() as i64, None => return Value::Error(ErrorKind::Value) };
+    let typ = match as_f64(&args[3]) { Some(v) => v.trunc() as i64, None => return Value::Error(ErrorKind::Value) };
+
+    // Validate tails and type early before computing
+    if tails != 1 && tails != 2 {
+        return Value::Error(ErrorKind::Num);
+    }
+    if typ < 1 || typ > 3 {
+        return Value::Error(ErrorKind::Num);
+    }
 
     if arr1.is_empty() || arr2.is_empty() {
         return Value::Error(ErrorKind::NA);
@@ -714,13 +841,7 @@ fn t_test_impl(args: &[Value]) -> Value {
             let mean_d = diffs.iter().sum::<f64>() / n;
             let var_d = diffs.iter().map(|d| (d - mean_d).powi(2)).sum::<f64>() / (n - 1.0);
             if var_d == 0.0 {
-                // Zero variance: all differences are identical.
-                // If mean_d == 0 all pairs are equal → p = 1; else t = ±∞ → p = 0.
-                return if mean_d == 0.0 {
-                    Value::Number(1.0)
-                } else {
-                    Value::Number(0.0)
-                };
+                return Value::Error(ErrorKind::DivByZero);
             }
             let t = mean_d / (var_d / n).sqrt();
             (t, n - 1.0)
@@ -797,13 +918,13 @@ pub fn f_dist_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df1 = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df2 = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df1 = match as_f64(&args[1]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
+    let df2 = match as_f64(&args[2]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
     let cumulative = match as_bool(&args[3]) {
         Some(b) => b,
         None => return Value::Error(ErrorKind::Value),
     };
-    if x < 0.0 || df1 < 1.0 || df2 < 1.0 {
+    if x < 0.0 || df1 < 1.0 || df2 < 1.0 || df1 > 1e10 || df2 > 1e10 {
         return Value::Error(ErrorKind::Num);
     }
     if cumulative {
@@ -819,9 +940,9 @@ pub fn f_dist_rt_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df1 = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) }.trunc();
-    let df2 = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) }.trunc();
-    if x < 0.0 || df1 < 1.0 || df2 < 1.0 {
+    let df1 = match as_f64(&args[1]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
+    let df2 = match as_f64(&args[2]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
+    if x < 0.0 || df1 < 1.0 || df2 < 1.0 || df1 > 1e10 || df2 > 1e10 {
         return Value::Error(ErrorKind::Num);
     }
     Value::Number(1.0 - d::f_cdf(x, df1, df2))
@@ -840,8 +961,8 @@ pub fn f_inv_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let p = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df1 = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df2 = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df1 = match as_f64(&args[1]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
+    let df2 = match as_f64(&args[2]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
     if p < 0.0 || p > 1.0 || df1 < 1.0 || df2 < 1.0 {
         return Value::Error(ErrorKind::Num);
     }
@@ -859,8 +980,8 @@ pub fn f_inv_rt_fn(args: &[Value]) -> Value {
         return Value::Error(ErrorKind::NA);
     }
     let p = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df1 = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let df2 = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let df1 = match as_f64(&args[1]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
+    let df2 = match as_f64(&args[2]) { Some(v) => v.trunc(), None => return Value::Error(ErrorKind::Value) };
     if p < 0.0 || p > 1.0 || df1 < 1.0 || df2 < 1.0 {
         return Value::Error(ErrorKind::Num);
     }
@@ -881,8 +1002,18 @@ pub fn finv_fn(args: &[Value]) -> Value {
 // F.TEST / FTEST
 // ---------------------------------------------------------------------------
 fn f_test_impl(args: &[Value]) -> Value {
-    if args.len() < 2 {
+    if args.len() < 2 || args.len() > 2 {
         return Value::Error(ErrorKind::NA);
+    }
+    // Propagate errors from arrays before collecting numbers
+    if let Value::Error(e) = &args[0] { return Value::Error(e.clone()); }
+    if let Value::Error(e) = &args[1] { return Value::Error(e.clone()); }
+    // Check for NA/error within arrays
+    if let Value::Array(inner) = &args[0] {
+        for v in inner { if let Value::Error(e) = v { return Value::Error(e.clone()); } }
+    }
+    if let Value::Array(inner) = &args[1] {
+        for v in inner { if let Value::Error(e) = v { return Value::Error(e.clone()); } }
     }
     let arr1 = collect_nums(std::slice::from_ref(&args[0]));
     let arr2 = collect_nums(std::slice::from_ref(&args[1]));
@@ -895,7 +1026,7 @@ fn f_test_impl(args: &[Value]) -> Value {
     let mean2 = arr2.iter().sum::<f64>() / n2;
     let var1 = arr1.iter().map(|x| (x - mean1).powi(2)).sum::<f64>() / (n1 - 1.0);
     let var2 = arr2.iter().map(|x| (x - mean2).powi(2)).sum::<f64>() / (n2 - 1.0);
-    if var2 == 0.0 {
+    if var1 == 0.0 || var2 == 0.0 {
         return Value::Error(ErrorKind::DivByZero);
     }
     let f = var1 / var2;
@@ -954,10 +1085,18 @@ pub fn gamma_dist_fn(args: &[Value]) -> Value {
     if x < 0.0 || alpha <= 0.0 || beta <= 0.0 {
         return Value::Error(ErrorKind::Num);
     }
+    // PDF at x=0 with alpha<1 → +infinity → GS returns Num
+    if !cumulative && x == 0.0 && alpha < 1.0 {
+        return Value::Error(ErrorKind::Num);
+    }
     if cumulative {
         Value::Number(d::gamma_dist_cdf(x, alpha, beta))
     } else {
-        Value::Number(d::gamma_dist_pdf(x, alpha, beta))
+        let pdf = d::gamma_dist_pdf(x, alpha, beta);
+        if !pdf.is_finite() {
+            return Value::Error(ErrorKind::Num);
+        }
+        Value::Number(pdf)
     }
 }
 
@@ -986,15 +1125,20 @@ pub fn gamma_inv_fn(args: &[Value]) -> Value {
 // BETA.DIST / BETADIST
 // ---------------------------------------------------------------------------
 pub fn beta_dist_fn(args: &[Value]) -> Value {
-    if args.len() < 4 {
+    if args.len() < 3 {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     let alpha = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     let beta = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let cumulative = match as_bool(&args[3]) {
-        Some(b) => b,
-        None => return Value::Error(ErrorKind::Value),
+    // cumulative defaults to TRUE when not provided (3-arg form)
+    let cumulative = if args.len() >= 4 {
+        match as_bool(&args[3]) {
+            Some(b) => b,
+            None => return Value::Error(ErrorKind::Value),
+        }
+    } else {
+        true
     };
     // Optional lo/hi bounds (args[4] and args[5])
     let lo = if args.len() >= 5 {
@@ -1191,12 +1335,18 @@ fn negbinom_impl(args: &[Value]) -> Value {
 }
 
 pub fn negbinom_dist_fn(args: &[Value]) -> Value {
+    if args.len() == 3 {
+        // 3-arg form: cumulative defaults to FALSE (PMF)
+        let mut extended = args.to_vec();
+        extended.push(Value::Bool(false));
+        return negbinom_impl(&extended);
+    }
     negbinom_impl(args)
 }
 
 pub fn negbinomdist_fn(args: &[Value]) -> Value {
-    // Legacy: 3 args, no cumulative (always PMF)
-    if args.len() < 3 {
+    // Legacy: exactly 3 args, no cumulative (always PMF)
+    if args.len() < 3 || args.len() > 3 {
         return Value::Error(ErrorKind::NA);
     }
     let x_f = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
@@ -1237,7 +1387,7 @@ fn hypgeom_impl(args: &[Value], has_cumulative: bool) -> Value {
     let n = n_f as u64;
     let k = k_f as u64;
     let pop = pop_f as u64;
-    if x > n || x > k || n > pop || k > pop || n > k {
+    if x > n || x > k || n > pop || k > pop {
         return Value::Error(ErrorKind::Num);
     }
     if cumulative {
@@ -1252,6 +1402,10 @@ pub fn hypgeom_dist_fn(args: &[Value]) -> Value {
 }
 
 pub fn hypgeomdist_fn(args: &[Value]) -> Value {
+    // Legacy: exactly 4 args (no cumulative parameter)
+    if args.len() != 4 {
+        return Value::Error(ErrorKind::NA);
+    }
     hypgeom_impl(args, false)
 }
 
@@ -1348,7 +1502,7 @@ pub fn lognorm_dist_fn(args: &[Value]) -> Value {
 
 // LOGNORMDIST (legacy: 3 args, always CDF)
 pub fn lognormdist_fn(args: &[Value]) -> Value {
-    if args.len() < 3 {
+    if args.len() < 3 || args.len() > 3 {
         return Value::Error(ErrorKind::NA);
     }
     let x = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
@@ -1407,7 +1561,12 @@ pub fn fisher_inv_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
-    let y = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    // If arg is an array, use the first element
+    let first = match &args[0] {
+        Value::Array(inner) => inner.first().cloned().unwrap_or(Value::Error(ErrorKind::NA)),
+        other => other.clone(),
+    };
+    let y = match as_f64(&first) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     Value::Number(d::fisher_inv(y))
 }
 
@@ -1441,7 +1600,7 @@ pub fn permutationa_fn(args: &[Value]) -> Value {
     }
     let n = match as_f64(&args[0]) { Some(v) => v as i64, None => return Value::Error(ErrorKind::Value) };
     let k = match as_f64(&args[1]) { Some(v) => v as i64, None => return Value::Error(ErrorKind::Value) };
-    if n < 0 || k <= 0 {
+    if n <= 0 || k <= 0 {
         return Value::Error(ErrorKind::Num);
     }
     let v = (n as f64).powi(k as i32);
@@ -1459,14 +1618,49 @@ pub fn prob_fn(args: &[Value]) -> Value {
     if args.len() < 3 {
         return Value::Error(ErrorKind::NA);
     }
-    let xs = collect_nums(std::slice::from_ref(&args[0]));
-    let probs = collect_nums(std::slice::from_ref(&args[1]));
+    // xs: only Numbers allowed (Bool/text → Error(Value))
+    let xs: Vec<f64> = {
+        let mut out = Vec::new();
+        let vals = match &args[0] {
+            Value::Array(inner) => inner.as_slice(),
+            other => std::slice::from_ref(other),
+        };
+        for v in vals {
+            match v {
+                Value::Number(n) => out.push(*n),
+                Value::Error(e) => return Value::Error(e.clone()),
+                _ => return Value::Error(ErrorKind::Value),
+            }
+        }
+        out
+    };
+    // probs: only Numbers in [0,1] allowed
+    let probs: Vec<f64> = {
+        let mut out = Vec::new();
+        let vals = match &args[1] {
+            Value::Array(inner) => inner.as_slice(),
+            other => std::slice::from_ref(other),
+        };
+        for v in vals {
+            match v {
+                Value::Number(n) => out.push(*n),
+                Value::Error(e) => return Value::Error(e.clone()),
+                _ => return Value::Error(ErrorKind::Value),
+            }
+        }
+        out
+    };
     let lo = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     let hi = if args.len() >= 4 {
         match as_f64(&args[3]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) }
     } else { lo };
     if xs.len() != probs.len() || xs.is_empty() {
         return Value::Error(ErrorKind::NA);
+    }
+    // Validate sum ≈ 1 (individual probs may be negative per GS behavior)
+    let prob_sum: f64 = probs.iter().sum();
+    if (prob_sum - 1.0).abs() > 1e-10 {
+        return Value::Error(ErrorKind::Value);
     }
     // Sum probabilities for values in [lo, hi]
     let total: f64 = xs.iter().zip(probs.iter())
@@ -1483,6 +1677,11 @@ fn z_test_impl(args: &[Value]) -> Value {
     if args.len() < 2 {
         return Value::Error(ErrorKind::NA);
     }
+    // Propagate errors from data array
+    if let Value::Error(e) = &args[0] { return Value::Error(e.clone()); }
+    if let Value::Array(inner) = &args[0] {
+        for v in inner { if let Value::Error(e) = v { return Value::Error(e.clone()); } }
+    }
     let data = collect_nums(std::slice::from_ref(&args[0]));
     let mu0 = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
     let n = data.len() as f64;
@@ -1492,7 +1691,8 @@ fn z_test_impl(args: &[Value]) -> Value {
     let sigma = if args.len() >= 3 {
         match as_f64(&args[2]) {
             Some(v) => {
-                if v <= 0.0 { return Value::Error(ErrorKind::Num); }
+                if v < 0.0 { return Value::Number(0.5); }
+                if v == 0.0 { return Value::Error(ErrorKind::Num); }
                 v
             }
             None => return Value::Error(ErrorKind::Value),
@@ -1506,6 +1706,9 @@ fn z_test_impl(args: &[Value]) -> Value {
     };
     let mean = data.iter().sum::<f64>() / n;
     let z = (mean - mu0) / (sigma / n.sqrt());
+    if !z.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
     // One-tailed right-tail p-value
     Value::Number(1.0 - d::norm_s_cdf(z))
 }
@@ -1522,33 +1725,48 @@ pub fn ztest_fn(args: &[Value]) -> Value {
 // MARGINOFERROR
 // ---------------------------------------------------------------------------
 pub fn marginoferror_fn(args: &[Value]) -> Value {
-    if args.len() < 3 {
+    // MARGINOFERROR(data, confidence) — takes data range + confidence level,
+    // computes sample stdev, then t-interval margin: t * s / sqrt(n)
+    if args.len() < 2 {
         return Value::Error(ErrorKind::NA);
     }
-    let alpha = match as_f64(&args[0]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let sd    = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    let n     = match as_f64(&args[2]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
-    if alpha <= 0.0 || alpha >= 1.0 || sd <= 0.0 || n <= 0.0 {
+    let data = collect_nums(std::slice::from_ref(&args[0]));
+    let confidence = match as_f64(&args[1]) { Some(v) => v, None => return Value::Error(ErrorKind::Value) };
+    let n = data.len() as f64;
+    if n < 2.0 {
+        return Value::Error(ErrorKind::DivByZero);
+    }
+    if confidence <= 0.0 || confidence >= 1.0 {
         return Value::Error(ErrorKind::Num);
     }
-    let z = d::norm_inv(1.0 - alpha / 2.0, 0.0, 1.0);
-    if !z.is_finite() {
+    let mean = data.iter().sum::<f64>() / n;
+    let var = data.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (n - 1.0);
+    if var == 0.0 {
         return Value::Error(ErrorKind::Num);
     }
-    Value::Number(z * sd / n.sqrt())
+    let s = var.sqrt();
+    let df = n - 1.0;
+    let alpha = 1.0 - confidence;
+    let t = d::t_inv(1.0 - alpha / 2.0, df);
+    if !t.is_finite() {
+        return Value::Error(ErrorKind::Num);
+    }
+    Value::Number(t * s / n.sqrt())
 }
 
 // ---------------------------------------------------------------------------
 // COVAR (legacy, population covariance)
 // ---------------------------------------------------------------------------
 pub fn covar_fn(args: &[Value]) -> Value {
-    if args.len() < 2 {
+    if args.len() < 2 || args.len() > 2 {
         return Value::Error(ErrorKind::NA);
     }
-    let xs = collect_nums(std::slice::from_ref(&args[0]));
-    let ys = collect_nums(std::slice::from_ref(&args[1]));
-    if xs.len() != ys.len() || xs.is_empty() {
-        return Value::Error(ErrorKind::NA);
+    let (xs, ys) = match collect_paired(&args[0], &args[1]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+    if xs.is_empty() {
+        return Value::Error(ErrorKind::DivByZero);
     }
     let n = xs.len() as f64;
     let mean_x = xs.iter().sum::<f64>() / n;

--- a/crates/core/src/eval/functions/statistical/distributions_impl.rs
+++ b/crates/core/src/eval/functions/statistical/distributions_impl.rs
@@ -37,20 +37,72 @@ fn as_f64(v: &Value) -> Option<f64> {
 // AVERAGE.WEIGHTED
 // ---------------------------------------------------------------------------
 pub fn average_weighted_fn(args: &[Value]) -> Value {
+    // AVERAGE.WEIGHTED(values1, weights1, [values2, weights2, ...])
+    // Args come in value/weight pairs. Bool weights -> #VALUE!. Negative weights -> #VALUE!.
+    // Mismatched sizes -> #VALUE!.
     if args.len() < 2 {
         return Value::Error(ErrorKind::NA);
     }
-    let values = collect_nums(std::slice::from_ref(&args[0]));
-    let weights = collect_nums(std::slice::from_ref(&args[1]));
-    if values.is_empty() || values.len() != weights.len() {
+    if args.len() % 2 != 0 {
         return Value::Error(ErrorKind::NA);
     }
-    let total_weight: f64 = weights.iter().sum();
+    let mut weighted_sum = 0.0_f64;
+    let mut total_weight = 0.0_f64;
+    let mut i = 0;
+    while i + 1 < args.len() {
+        let val_arg = &args[i];
+        let wt_arg = &args[i + 1];
+        let vals = collect_nums(std::slice::from_ref(val_arg));
+        let wts = match collect_weights_arg(wt_arg) {
+            Ok(v) => v,
+            Err(e) => return e,
+        };
+        if vals.len() != wts.len() {
+            return Value::Error(ErrorKind::Value);
+        }
+        for &w in &wts {
+            if w < 0.0 {
+                return Value::Error(ErrorKind::Value);
+            }
+        }
+        for (&v, &w) in vals.iter().zip(wts.iter()) {
+            weighted_sum += v * w;
+            total_weight += w;
+        }
+        i += 2;
+    }
     if total_weight == 0.0 {
         return Value::Error(ErrorKind::DivByZero);
     }
-    let weighted_sum: f64 = values.iter().zip(weights.iter()).map(|(v, w)| v * w).sum();
     Value::Number(weighted_sum / total_weight)
+}
+
+fn collect_weights_arg(arg: &Value) -> Result<Vec<f64>, Value> {
+    match arg {
+        Value::Number(n) => Ok(vec![*n]),
+        Value::Date(n) => Ok(vec![*n]),
+        Value::Bool(_) => Err(Value::Error(ErrorKind::Value)),
+        Value::Text(s) => match s.trim().parse::<f64>() {
+            Ok(v) if v.is_finite() => Ok(vec![v]),
+            _ => Err(Value::Error(ErrorKind::Value)),
+        },
+        Value::Empty => Ok(vec![]),
+        Value::Error(e) => Err(Value::Error(*e)),
+        Value::Array(inner) => {
+            let mut out = Vec::new();
+            for item in inner {
+                match item {
+                    Value::Number(n) => out.push(*n),
+                    Value::Date(n) => out.push(*n),
+                    Value::Bool(_) => return Err(Value::Error(ErrorKind::Value)),
+                    Value::Text(_) | Value::Empty => {}
+                    Value::Error(e) => return Err(Value::Error(*e)),
+                    Value::Array(_) => {}
+                }
+            }
+            Ok(out)
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/core/src/eval/functions/statistical/geomean/mod.rs
+++ b/crates/core/src/eval/functions/statistical/geomean/mod.rs
@@ -4,10 +4,22 @@ use crate::types::{ErrorKind, Value};
 /// Flattens `Value::Array` args. Ignores Text, Bool, Empty.
 /// All values must be > 0, else `#NUM!`. Requires at least 1 value.
 pub fn geomean_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
     let mut nums: Vec<f64> = Vec::new();
     for arg in args {
         match arg {
             Value::Number(n) => nums.push(*n),
+            Value::Bool(b) => nums.push(if *b { 1.0 } else { 0.0 }),
+            Value::Text(s) => {
+                let trimmed = s.trim();
+                match trimmed.parse::<f64>() {
+                    Ok(v) if v.is_finite() => nums.push(v),
+                    _ => return Value::Error(ErrorKind::Value),
+                }
+            }
+            Value::Empty => {}
             Value::Array(arr) => {
                 for v in arr {
                     if let Value::Number(n) = v {
@@ -15,11 +27,9 @@ pub fn geomean_fn(args: &[Value]) -> Value {
                     }
                 }
             }
+            Value::Error(e) => return Value::Error(e.clone()),
             _ => {}
         }
-    }
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
     }
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);

--- a/crates/core/src/eval/functions/statistical/harmean/mod.rs
+++ b/crates/core/src/eval/functions/statistical/harmean/mod.rs
@@ -4,10 +4,22 @@ use crate::types::{ErrorKind, Value};
 /// Flattens `Value::Array` args. Ignores Text, Bool, Empty.
 /// All values must be > 0, else `#NUM!`. Requires at least 1 value.
 pub fn harmean_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
     let mut nums: Vec<f64> = Vec::new();
     for arg in args {
         match arg {
             Value::Number(n) => nums.push(*n),
+            Value::Bool(b) => nums.push(if *b { 1.0 } else { 0.0 }),
+            Value::Text(s) => {
+                let trimmed = s.trim();
+                match trimmed.parse::<f64>() {
+                    Ok(v) if v.is_finite() => nums.push(v),
+                    _ => return Value::Error(ErrorKind::Value),
+                }
+            }
+            Value::Empty => {}
             Value::Array(arr) => {
                 for v in arr {
                     if let Value::Number(n) = v {
@@ -15,11 +27,9 @@ pub fn harmean_fn(args: &[Value]) -> Value {
                     }
                 }
             }
+            Value::Error(e) => return Value::Error(e.clone()),
             _ => {}
         }
-    }
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
     }
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);

--- a/crates/core/src/eval/functions/statistical/kurt/mod.rs
+++ b/crates/core/src/eval/functions/statistical/kurt/mod.rs
@@ -2,11 +2,11 @@ use crate::types::{ErrorKind, Value};
 use super::stat_helpers::collect_nums_direct;
 
 /// `KURT(value1, ...)` — excess kurtosis.
+/// Array text/Bool → skip (errors propagate); too few numeric values → DivByZero.
 pub fn kurt_fn(args: &[Value]) -> Value {
     if args.is_empty() { return Value::Error(ErrorKind::NA); }
     let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     let n = nums.len();
-    if n == 0 { return Value::Error(ErrorKind::NA); }
     if n < 4 { return Value::Error(ErrorKind::DivByZero); }
     let mean = nums.iter().sum::<f64>() / n as f64;
     let variance = nums.iter().map(|&x| (x - mean).powi(2)).sum::<f64>() / (n - 1) as f64;

--- a/crates/core/src/eval/functions/statistical/kurt/mod.rs
+++ b/crates/core/src/eval/functions/statistical/kurt/mod.rs
@@ -1,46 +1,22 @@
 use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums_direct;
 
-/// `KURT(value1, ...)` — excess kurtosis (Fisher's definition).
-/// Formula: (n(n+1)/((n-1)(n-2)(n-3))) * Σ((x-mean)/s)^4 - 3(n-1)^2/((n-2)(n-3))
-/// where s is the sample standard deviation.
-/// Flattens `Value::Array` args. Ignores Text, Bool, Empty.
-/// Requires n ≥ 4. Returns `#DIV/0!` if n < 4 or s = 0.
+/// `KURT(value1, ...)` — excess kurtosis.
 pub fn kurt_fn(args: &[Value]) -> Value {
-    let mut nums: Vec<f64> = Vec::new();
-    for arg in args {
-        match arg {
-            Value::Number(n) => nums.push(*n),
-            Value::Array(arr) => {
-                for v in arr {
-                    if let Value::Number(n) = v {
-                        nums.push(*n);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     let n = nums.len();
-    if n == 0 {
-        return Value::Error(ErrorKind::NA);
-    }
-    if n < 4 {
-        return Value::Error(ErrorKind::DivByZero);
-    }
+    if n == 0 { return Value::Error(ErrorKind::NA); }
+    if n < 4 { return Value::Error(ErrorKind::DivByZero); }
     let mean = nums.iter().sum::<f64>() / n as f64;
     let variance = nums.iter().map(|&x| (x - mean).powi(2)).sum::<f64>() / (n - 1) as f64;
     let s = variance.sqrt();
-    if s == 0.0 {
-        return Value::Error(ErrorKind::DivByZero);
-    }
+    if s == 0.0 { return Value::Error(ErrorKind::DivByZero); }
     let nf = n as f64;
     let sum4 = nums.iter().map(|&x| ((x - mean) / s).powi(4)).sum::<f64>();
     let result = (nf * (nf + 1.0) / ((nf - 1.0) * (nf - 2.0) * (nf - 3.0))) * sum4
         - 3.0 * (nf - 1.0).powi(2) / ((nf - 2.0) * (nf - 3.0));
-    if !result.is_finite() {
-        return Value::Error(ErrorKind::Num);
-    }
-    Value::Number(result)
+    if result.is_finite() { Value::Number(result) } else { Value::Error(ErrorKind::Num) }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/large/mod.rs
+++ b/crates/core/src/eval/functions/statistical/large/mod.rs
@@ -7,20 +7,25 @@ pub fn large_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 2) {
         return err;
     }
-    let mut nums = collect_numbers(&args[0]);
+    let nums = match collect_numbers_checked(&args[0]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }
     let k = match &args[1] {
         Value::Number(n) => {
-            let k = *n;
-            if k < 1.0 || k != k.floor() {
+            let k = n.trunc();
+            if k < 1.0 {
                 return Value::Error(ErrorKind::Num);
             }
             k as usize
         }
+        Value::Bool(b) => if *b { 1usize } else { return Value::Error(ErrorKind::Num); },
         _ => return Value::Error(ErrorKind::Num),
     };
+    let mut nums = nums;
     if k > nums.len() {
         return Value::Error(ErrorKind::Num);
     }
@@ -29,13 +34,22 @@ pub fn large_fn(args: &[Value]) -> Value {
     Value::Number(nums[k - 1])
 }
 
-fn collect_numbers(v: &Value) -> Vec<f64> {
+fn collect_numbers_checked(v: &Value) -> Result<Vec<f64>, Value> {
     match v {
-        Value::Array(arr) => arr.iter().filter_map(|x| {
-            if let Value::Number(n) = x { Some(*n) } else { None }
-        }).collect(),
-        Value::Number(n) => vec![*n],
-        _ => vec![],
+        Value::Array(arr) => {
+            let mut nums = Vec::new();
+            for x in arr {
+                match x {
+                    Value::Number(n) => nums.push(*n),
+                    Value::Error(e) => return Err(Value::Error(e.clone())),
+                    _ => {}
+                }
+            }
+            Ok(nums)
+        }
+        Value::Number(n) => Ok(vec![*n]),
+        Value::Error(e) => Err(Value::Error(e.clone())),
+        _ => Ok(vec![]),
     }
 }
 

--- a/crates/core/src/eval/functions/statistical/large/mod.rs
+++ b/crates/core/src/eval/functions/statistical/large/mod.rs
@@ -22,7 +22,8 @@ pub fn large_fn(args: &[Value]) -> Value {
             }
             k as usize
         }
-        Value::Bool(b) => if *b { 1usize } else { return Value::Error(ErrorKind::Num); },
+        Value::Bool(true) => 1usize,
+        Value::Bool(false) => return Value::Error(ErrorKind::Num),
         _ => return Value::Error(ErrorKind::Num),
     };
     let mut nums = nums;

--- a/crates/core/src/eval/functions/statistical/large/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/large/tests/failure.rs
@@ -23,8 +23,8 @@ fn large_empty_array_returns_num_error() {
 }
 
 #[test]
-fn large_fractional_k_returns_num_error() {
-    // k=1.5 is not an integer → #NUM!
+fn large_fractional_k_truncated() {
+    // k=1.5 is truncated to 1 → 1st largest of [1.0, 2.0] = 2.0
     let arr = Value::Array(vec![Value::Number(1.0), Value::Number(2.0)]);
-    assert_eq!(large_fn(&[arr, Value::Number(1.5)]), Value::Error(ErrorKind::Num));
+    assert_eq!(large_fn(&[arr, Value::Number(1.5)]), Value::Number(2.0));
 }

--- a/crates/core/src/eval/functions/statistical/max/mod.rs
+++ b/crates/core/src/eval/functions/statistical/max/mod.rs
@@ -1,44 +1,56 @@
 use crate::types::{ErrorKind, Value};
 
 /// `MAX(value1, ...)` — largest numeric value in the arguments.
-/// - Numbers included directly.
-/// - Booleans coerced: TRUE=1, FALSE=0.
-/// - Text in direct args → `#VALUE!`.
-/// - Empty and errors are ignored (errors already propagated by eager dispatcher).
-/// - No args → `#N/A`.
+/// Direct args: Numbers, Bool (TRUE=1, FALSE=0), parseable text coerced to number.
+/// Array elements: Numbers only; text/Bool → skip; errors propagate.
+/// Empty array arg → #REF!. No numbers → 0.0.
 pub fn max_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
     let mut result: Option<f64> = None;
-    fn max_val(v: &Value, result: &mut Option<f64>) -> Option<Value> {
-        match v {
-            Value::Array(elems) => {
-                for elem in elems {
-                    if let Some(e) = max_val(elem, result) {
-                        return Some(e);
-                    }
-                }
-                None
-            }
+    let mut had_array = false;
+    for arg in args {
+        match arg {
             Value::Number(n) => {
-                *result = Some(result.map_or(*n, |cur: f64| cur.max(*n)));
-                None
+                result = Some(result.map_or(*n, |cur: f64| cur.max(*n)));
             }
             Value::Bool(b) => {
                 let n = if *b { 1.0 } else { 0.0 };
-                *result = Some(result.map_or(n, |cur: f64| cur.max(n)));
-                None
+                result = Some(result.map_or(n, |cur: f64| cur.max(n)));
             }
-            Value::Text(_) => Some(Value::Error(ErrorKind::Value)),
-            Value::Empty => None,
-            _ => None,
+            Value::Text(s) => {
+                let trimmed = s.trim();
+                match trimmed.parse::<f64>() {
+                    Ok(v) if v.is_finite() => {
+                        result = Some(result.map_or(v, |cur: f64| cur.max(v)));
+                    }
+                    _ => return Value::Error(ErrorKind::Value),
+                }
+            }
+            Value::Empty => {}
+            Value::Array(elems) => {
+                had_array = true;
+                if elems.is_empty() {
+                    return Value::Error(ErrorKind::Ref);
+                }
+                for elem in elems {
+                    match elem {
+                        Value::Number(n) => {
+                            result = Some(result.map_or(*n, |cur: f64| cur.max(*n)));
+                        }
+                        Value::Error(e) => return Value::Error(e.clone()),
+                        _ => {}
+                    }
+                }
+            }
+            Value::Error(e) => return Value::Error(e.clone()),
+            _ => {}
         }
     }
-    for arg in args {
-        if let Some(e) = max_val(arg, &mut result) {
-            return e;
-        }
+    // Empty array with no numbers → Ref
+    if had_array && result.is_none() {
+        return Value::Error(ErrorKind::Ref);
     }
     Value::Number(result.unwrap_or(0.0))
 }

--- a/crates/core/src/eval/functions/statistical/max/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/max/tests/failure.rs
@@ -2,11 +2,11 @@ use super::super::*;
 use crate::types::{ErrorKind, Value};
 
 #[test]
-fn max_ignores_error_values() {
-    // The eager dispatcher strips errors; max_fn itself skips them too
+fn max_propagates_error_values() {
+    // Direct errors propagate through max_fn (eager dispatch would handle real formulas)
     assert_eq!(
         max_fn(&[Value::Number(3.0), Value::Error(ErrorKind::Value), Value::Number(5.0)]),
-        Value::Number(5.0)
+        Value::Error(ErrorKind::Value)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/maxa/mod.rs
+++ b/crates/core/src/eval/functions/statistical/maxa/mod.rs
@@ -12,17 +12,33 @@ pub fn maxa_fn(args: &[Value]) -> Value {
     }
     let mut result: Option<f64> = None;
     for arg in args {
-        let n = match arg {
-            Value::Number(n) => *n,
-            Value::Bool(b)   => if *b { 1.0 } else { 0.0 },
-            Value::Text(_)   => return Value::Error(ErrorKind::Value),
-            Value::Empty     => continue,
-            _                => continue,
-        };
-        result = Some(match result {
-            None      => n,
-            Some(cur) => cur.max(n),
-        });
+        match arg {
+            Value::Number(n) => {
+                result = Some(result.map_or(*n, |cur: f64| cur.max(*n)));
+            }
+            Value::Bool(b) => {
+                let n = if *b { 1.0 } else { 0.0 };
+                result = Some(result.map_or(n, |cur: f64| cur.max(n)));
+            }
+            Value::Text(_) => return Value::Error(ErrorKind::Value),
+            Value::Empty => {}
+            Value::Array(inner) => {
+                // In array context: Numbers included, Bool→1/0, Text→0, Empty→skip
+                for v in inner {
+                    let n = match v {
+                        Value::Number(n) => *n,
+                        Value::Bool(b) => if *b { 1.0 } else { 0.0 },
+                        Value::Text(_) => 0.0,
+                        Value::Empty => continue,
+                        Value::Error(e) => return Value::Error(e.clone()),
+                        _ => continue,
+                    };
+                    result = Some(result.map_or(n, |cur: f64| cur.max(n)));
+                }
+            }
+            Value::Error(e) => return Value::Error(e.clone()),
+            _ => {}
+        }
     }
     match result {
         Some(n) => Value::Number(n),

--- a/crates/core/src/eval/functions/statistical/median/mod.rs
+++ b/crates/core/src/eval/functions/statistical/median/mod.rs
@@ -1,25 +1,16 @@
 use crate::types::{ErrorKind, Value};
-
-fn collect_nums_into(args: &[Value], out: &mut Vec<f64>) {
-    for arg in args {
-        match arg {
-            Value::Number(n) => out.push(*n),
-            Value::Array(inner) => collect_nums_into(inner, out),
-            _ => {}
-        }
-    }
-}
+use super::stat_helpers::collect_nums_direct;
 
 /// `MEDIAN(value1, ...)` — middle value of numeric arguments.
-/// Flattens `Value::Array` args. Ignores Text, Bool, Empty, Error.
-/// Even count: average of two middle values. Odd count: middle value.
-/// Returns `Value::Error(ErrorKind::NA)` if no args, `#NUM!` if no numeric values.
+/// Direct args: Bool/text coerced; array elements: Numbers only, errors propagate.
 pub fn median_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
-    let mut nums: Vec<f64> = Vec::new();
-    collect_nums_into(args, &mut nums);
+    let mut nums = match collect_nums_direct(args) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }

--- a/crates/core/src/eval/functions/statistical/median/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/median/tests/edge.rs
@@ -2,8 +2,8 @@ use super::super::*;
 use crate::types::{ErrorKind, Value};
 
 #[test]
-fn median_ignores_text() {
-    // MEDIAN(1, 2, 3, "text", 4) → 2.5 (numeric set [1,2,3,4])
+fn median_direct_text_returns_value_error() {
+    // Direct non-parseable text → #VALUE!
     assert_eq!(
         median_fn(&[
             Value::Number(1.0),
@@ -12,14 +12,13 @@ fn median_ignores_text() {
             Value::Text("text".to_string()),
             Value::Number(4.0)
         ]),
-        Value::Number(2.5)
+        Value::Error(ErrorKind::Value)
     );
 }
 
 #[test]
-fn median_ignores_bool_and_empty() {
-    // Only Numbers are counted; Bool and Empty ignored
-    // Numbers: 2, 4 → median 3.0
+fn median_bool_coerced_empty_skipped() {
+    // Bool coerced to 1.0/0.0; Empty skipped → [1.0, 2.0, 4.0] → median=2.0
     assert_eq!(
         median_fn(&[
             Value::Bool(true),
@@ -27,15 +26,16 @@ fn median_ignores_bool_and_empty() {
             Value::Empty,
             Value::Number(4.0)
         ]),
-        Value::Number(3.0)
+        Value::Number(2.0)
     );
 }
 
 #[test]
-fn median_all_non_numeric_returns_num_error() {
+fn median_all_non_numeric_with_text_returns_value_error() {
+    // Non-parseable text → #VALUE! (not #NUM!)
     assert_eq!(
         median_fn(&[Value::Text("a".to_string()), Value::Bool(true), Value::Empty]),
-        Value::Error(ErrorKind::Num)
+        Value::Error(ErrorKind::Value)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/median/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/median/tests/failure.rs
@@ -8,10 +8,10 @@ fn median_no_args_returns_na() {
 }
 
 #[test]
-fn median_ignores_error_values() {
-    // The dispatcher strips errors before calling median_fn; errors are simply ignored
+fn median_propagates_error_values() {
+    // Direct errors propagate through median_fn
     assert_eq!(
         median_fn(&[Value::Number(1.0), Value::Error(ErrorKind::Value), Value::Number(3.0)]),
-        Value::Number(2.0)
+        Value::Error(ErrorKind::Value)
     );
 }

--- a/crates/core/src/eval/functions/statistical/min/mod.rs
+++ b/crates/core/src/eval/functions/statistical/min/mod.rs
@@ -1,43 +1,46 @@
 use crate::types::{ErrorKind, Value};
 
 /// `MIN(value1, ...)` — smallest numeric value in the arguments.
-/// - Numbers included directly.
-/// - Booleans coerced: TRUE=1, FALSE=0.
-/// - Text in direct args → `#VALUE!`.
-/// - Empty and errors are ignored (errors already propagated by eager dispatcher).
-/// - No args → `#N/A`.
+/// Direct args: Numbers, Bool (TRUE=1, FALSE=0), parseable text coerced to number.
+/// Array elements: Numbers only; text/Bool → skip; errors propagate.
+/// No numbers → 0.0.
 pub fn min_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
     let mut result: Option<f64> = None;
-    fn min_val(v: &Value, result: &mut Option<f64>) -> Option<Value> {
-        match v {
-            Value::Array(elems) => {
-                for elem in elems {
-                    if let Some(e) = min_val(elem, result) {
-                        return Some(e);
-                    }
-                }
-                None
-            }
+    for arg in args {
+        match arg {
             Value::Number(n) => {
-                *result = Some(result.map_or(*n, |cur: f64| cur.min(*n)));
-                None
+                result = Some(result.map_or(*n, |cur: f64| cur.min(*n)));
             }
             Value::Bool(b) => {
                 let n = if *b { 1.0 } else { 0.0 };
-                *result = Some(result.map_or(n, |cur: f64| cur.min(n)));
-                None
+                result = Some(result.map_or(n, |cur: f64| cur.min(n)));
             }
-            Value::Text(_) => Some(Value::Error(ErrorKind::Value)),
-            Value::Empty => None,
-            _ => None,
-        }
-    }
-    for arg in args {
-        if let Some(e) = min_val(arg, &mut result) {
-            return e;
+            Value::Text(s) => {
+                let trimmed = s.trim();
+                match trimmed.parse::<f64>() {
+                    Ok(v) if v.is_finite() => {
+                        result = Some(result.map_or(v, |cur: f64| cur.min(v)));
+                    }
+                    _ => return Value::Error(ErrorKind::Value),
+                }
+            }
+            Value::Empty => {}
+            Value::Array(elems) => {
+                for elem in elems {
+                    match elem {
+                        Value::Number(n) => {
+                            result = Some(result.map_or(*n, |cur: f64| cur.min(*n)));
+                        }
+                        Value::Error(e) => return Value::Error(e.clone()),
+                        _ => {}
+                    }
+                }
+            }
+            Value::Error(e) => return Value::Error(e.clone()),
+            _ => {}
         }
     }
     Value::Number(result.unwrap_or(0.0))

--- a/crates/core/src/eval/functions/statistical/min/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/min/tests/failure.rs
@@ -2,11 +2,11 @@ use super::super::*;
 use crate::types::{ErrorKind, Value};
 
 #[test]
-fn min_ignores_error_values() {
-    // The eager dispatcher strips errors; min_fn itself skips them too
+fn min_propagates_error_values() {
+    // Direct errors propagate through min_fn (eager dispatch would handle real formulas)
     assert_eq!(
         min_fn(&[Value::Number(3.0), Value::Error(ErrorKind::Value), Value::Number(5.0)]),
-        Value::Number(3.0)
+        Value::Error(ErrorKind::Value)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/mina/mod.rs
+++ b/crates/core/src/eval/functions/statistical/mina/mod.rs
@@ -12,17 +12,33 @@ pub fn mina_fn(args: &[Value]) -> Value {
     }
     let mut result: Option<f64> = None;
     for arg in args {
-        let n = match arg {
-            Value::Number(n) => *n,
-            Value::Bool(b)   => if *b { 1.0 } else { 0.0 },
-            Value::Text(_)   => return Value::Error(ErrorKind::Value),
-            Value::Empty     => continue,
-            _                => continue,
-        };
-        result = Some(match result {
-            None      => n,
-            Some(cur) => cur.min(n),
-        });
+        match arg {
+            Value::Number(n) => {
+                result = Some(result.map_or(*n, |cur: f64| cur.min(*n)));
+            }
+            Value::Bool(b) => {
+                let n = if *b { 1.0 } else { 0.0 };
+                result = Some(result.map_or(n, |cur: f64| cur.min(n)));
+            }
+            Value::Text(_) => return Value::Error(ErrorKind::Value),
+            Value::Empty => {}
+            Value::Array(inner) => {
+                // In array context: Numbers included, Bool→1/0, Text→0, Empty→skip
+                for v in inner {
+                    let n = match v {
+                        Value::Number(n) => *n,
+                        Value::Bool(b) => if *b { 1.0 } else { 0.0 },
+                        Value::Text(_) => 0.0,
+                        Value::Empty => continue,
+                        Value::Error(e) => return Value::Error(e.clone()),
+                        _ => continue,
+                    };
+                    result = Some(result.map_or(n, |cur: f64| cur.min(n)));
+                }
+            }
+            Value::Error(e) => return Value::Error(e.clone()),
+            _ => {}
+        }
     }
     match result {
         Some(n) => Value::Number(n),

--- a/crates/core/src/eval/functions/statistical/mode/mod.rs
+++ b/crates/core/src/eval/functions/statistical/mode/mod.rs
@@ -1,22 +1,25 @@
 use crate::types::{ErrorKind, Value};
 
-/// Collect numeric values from args (flattening Arrays). Returns sorted Vec<f64>.
-fn collect_nums(args: &[Value]) -> Vec<f64> {
+/// Collect numeric values from args (flattening Arrays), propagating errors.
+fn collect_nums(args: &[Value]) -> Result<Vec<f64>, Value> {
     let mut nums: Vec<f64> = Vec::new();
     for arg in args {
         match arg {
             Value::Number(n) => nums.push(*n),
             Value::Array(arr) => {
                 for v in arr {
-                    if let Value::Number(n) = v {
-                        nums.push(*n);
+                    match v {
+                        Value::Number(n) => nums.push(*n),
+                        Value::Error(e) => return Err(Value::Error(e.clone())),
+                        _ => {}
                     }
                 }
             }
+            Value::Error(e) => return Err(Value::Error(e.clone())),
             _ => {}
         }
     }
-    nums
+    Ok(nums)
 }
 
 /// Find the most frequent value. If tie, return the smallest. If all unique or no values: `#N/A`.
@@ -59,10 +62,12 @@ pub fn mode_single(nums: &[f64]) -> Value {
 
 /// `MODE(value1, ...)` — most frequently occurring value.
 /// If tie, returns smallest. If all unique or no values: `#N/A`.
-/// Flattens `Value::Array` args. Ignores Text, Bool, Empty.
+/// Flattens `Value::Array` args. Ignores Text, Bool, Empty. Propagates errors.
 pub fn mode_fn(args: &[Value]) -> Value {
-    let nums = collect_nums(args);
-    mode_single(&nums)
+    match collect_nums(args) {
+        Ok(nums) => mode_single(&nums),
+        Err(e) => e,
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/mode_mult/mod.rs
+++ b/crates/core/src/eval/functions/statistical/mode_mult/mod.rs
@@ -1,9 +1,57 @@
 use crate::types::{ErrorKind, Value};
 
-/// `MODE.MULT(value1, ...)` — array-spill function; returns `#REF!` in scalar context.
-/// Google Sheets returns `#REF!` when MODE.MULT is not entered as an array formula.
-pub fn mode_mult_fn(_args: &[Value]) -> Value {
-    Value::Error(ErrorKind::Ref)
+/// `MODE.MULT(value1, ...)` — returns the first (lowest-index) mode.
+/// Direct args: Bool/text coerced like MODE.SNGL. Errors propagate.
+/// Returns #NA if no value appears more than once.
+pub fn mode_mult_fn(args: &[Value]) -> Value {
+    if args.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    // Collect numbers with direct-arg coercion semantics and error propagation.
+    let mut nums: Vec<f64> = Vec::new();
+    for arg in args {
+        match arg {
+            Value::Number(n) => nums.push(*n),
+            Value::Bool(b) => nums.push(if *b { 1.0 } else { 0.0 }),
+            Value::Text(s) => {
+                let trimmed = s.trim();
+                match trimmed.parse::<f64>() {
+                    Ok(v) if v.is_finite() => nums.push(v),
+                    _ => return Value::Error(ErrorKind::Value),
+                }
+            }
+            Value::Empty => {}
+            Value::Array(arr) => {
+                for v in arr {
+                    match v {
+                        Value::Number(n) => nums.push(*n),
+                        Value::Error(e) => return Value::Error(e.clone()),
+                        _ => {}
+                    }
+                }
+            }
+            Value::Error(e) => return Value::Error(e.clone()),
+            _ => {}
+        }
+    }
+    if nums.is_empty() {
+        return Value::Error(ErrorKind::NA);
+    }
+    // Find maximum frequency.
+    let mut freq: std::collections::HashMap<u64, usize> = std::collections::HashMap::new();
+    for &n in &nums {
+        *freq.entry(n.to_bits()).or_insert(0) += 1;
+    }
+    let max_count = *freq.values().max().unwrap_or(&0);
+    if max_count < 2 {
+        return Value::Error(ErrorKind::NA);
+    }
+    // Return the smallest value that has max_count occurrences (Google Sheets returns minimum mode).
+    let mode = nums.iter()
+        .filter(|&&n| *freq.get(&n.to_bits()).unwrap_or(&0) == max_count)
+        .cloned()
+        .fold(f64::INFINITY, f64::min);
+    if mode.is_finite() { Value::Number(mode) } else { Value::Error(ErrorKind::NA) }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/mode_mult/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/mode_mult/tests/success.rs
@@ -2,14 +2,14 @@ use super::super::*;
 use crate::types::{ErrorKind, Value};
 
 #[test]
-fn mode_mult_always_returns_ref() {
-    // MODE.MULT is an array-spill function; scalar context always returns #REF!
+fn mode_mult_returns_smallest_mode() {
+    // MODE.MULT returns the smallest mode in scalar context
     assert_eq!(
         mode_mult_fn(&[
             Value::Number(1.0),
             Value::Number(2.0),
             Value::Number(2.0)
         ]),
-        Value::Error(ErrorKind::Ref)
+        Value::Number(2.0)
     );
 }

--- a/crates/core/src/eval/functions/statistical/percentile/mod.rs
+++ b/crates/core/src/eval/functions/statistical/percentile/mod.rs
@@ -1,6 +1,6 @@
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
-use super::percentile_inc::{percentile_inc_calc, collect_numbers};
+use super::percentile_inc::{percentile_inc_calc, collect_numbers_checked};
 
 /// `PERCENTILE(array, k)` — k-th percentile (inclusive, same as PERCENTILE.INC).
 pub fn percentile_fn(args: &[Value]) -> Value {
@@ -14,7 +14,10 @@ pub fn percentile_fn(args: &[Value]) -> Value {
     if !(0.0..=1.0).contains(&k) {
         return Value::Error(ErrorKind::Num);
     }
-    let mut nums = collect_numbers(&args[0]);
+    let mut nums = match collect_numbers_checked(&args[0]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }

--- a/crates/core/src/eval/functions/statistical/percentile_exc/mod.rs
+++ b/crates/core/src/eval/functions/statistical/percentile_exc/mod.rs
@@ -1,6 +1,6 @@
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
-use super::percentile_inc::collect_numbers;
+use super::percentile_inc::collect_numbers_checked;
 
 /// `PERCENTILE.EXC(array, k)` — exclusive percentile, k strictly in (0,1).
 /// Uses index = k*(n+1)-1 formula for interpolation.
@@ -15,7 +15,10 @@ pub fn percentile_exc_fn(args: &[Value]) -> Value {
     if k <= 0.0 || k >= 1.0 {
         return Value::Error(ErrorKind::Num);
     }
-    let mut nums = collect_numbers(&args[0]);
+    let mut nums = match collect_numbers_checked(&args[0]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }

--- a/crates/core/src/eval/functions/statistical/percentile_inc/mod.rs
+++ b/crates/core/src/eval/functions/statistical/percentile_inc/mod.rs
@@ -14,7 +14,10 @@ pub fn percentile_inc_fn(args: &[Value]) -> Value {
     if !(0.0..=1.0).contains(&k) {
         return Value::Error(ErrorKind::Num);
     }
-    let mut nums = collect_numbers(&args[0]);
+    let mut nums = match collect_numbers_checked(&args[0]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }
@@ -46,6 +49,25 @@ pub fn collect_numbers(v: &Value) -> Vec<f64> {
         }).collect(),
         Value::Number(n) => vec![*n],
         _ => vec![],
+    }
+}
+
+pub fn collect_numbers_checked(v: &Value) -> Result<Vec<f64>, Value> {
+    match v {
+        Value::Array(arr) => {
+            let mut nums = Vec::new();
+            for x in arr {
+                match x {
+                    Value::Number(n) => nums.push(*n),
+                    Value::Error(e) => return Err(Value::Error(e.clone())),
+                    _ => {}
+                }
+            }
+            Ok(nums)
+        }
+        Value::Number(n) => Ok(vec![*n]),
+        Value::Error(e) => Err(Value::Error(e.clone())),
+        _ => Ok(vec![]),
     }
 }
 

--- a/crates/core/src/eval/functions/statistical/percentrank/mod.rs
+++ b/crates/core/src/eval/functions/statistical/percentrank/mod.rs
@@ -11,6 +11,11 @@ pub fn percentrank_fn(args: &[Value]) -> Value {
     // args[0] = array, args[1] = x, args[2] = significance (optional)
     let x = match &args[1] {
         Value::Number(n) => *n,
+        Value::Bool(b) => if *b { 1.0 } else { 0.0 },
+        Value::Text(s) => match s.trim().parse::<f64>() {
+            Ok(v) if v.is_finite() => v,
+            _ => return Value::Error(ErrorKind::NA),
+        },
         _ => return Value::Error(ErrorKind::NA),
     };
     let sig = args.get(2).map(|v| match v {

--- a/crates/core/src/eval/functions/statistical/percentrank_exc/mod.rs
+++ b/crates/core/src/eval/functions/statistical/percentrank_exc/mod.rs
@@ -12,6 +12,11 @@ pub fn percentrank_exc_fn(args: &[Value]) -> Value {
     // args[0] = array, args[1] = x, args[2] = significance (optional)
     let x = match &args[1] {
         Value::Number(n) => *n,
+        Value::Bool(b) => if *b { 1.0 } else { 0.0 },
+        Value::Text(s) => match s.trim().parse::<f64>() {
+            Ok(v) if v.is_finite() => v,
+            _ => return Value::Error(ErrorKind::NA),
+        },
         _ => return Value::Error(ErrorKind::NA),
     };
     let sig = args.get(2).map(|v| match v {
@@ -34,6 +39,10 @@ pub fn percentrank_exc_fn(args: &[Value]) -> Value {
     }
 
     let n = nums.len();
+    // Single-element edge case: x equals the only element → 1.0
+    if n == 1 && nums[0] == x {
+        return Value::Number(round_to_sig(1.0, sig));
+    }
     let result = percentrank_exc_calc(&nums, x, n);
     Value::Number(round_to_sig(result, sig))
 }

--- a/crates/core/src/eval/functions/statistical/percentrank_inc/mod.rs
+++ b/crates/core/src/eval/functions/statistical/percentrank_inc/mod.rs
@@ -12,6 +12,11 @@ pub fn percentrank_inc_fn(args: &[Value]) -> Value {
     // args[0] = array, args[1] = x, args[2] = significance (optional)
     let x = match &args[1] {
         Value::Number(n) => *n,
+        Value::Bool(b) => if *b { 1.0 } else { 0.0 },
+        Value::Text(s) => match s.trim().parse::<f64>() {
+            Ok(v) if v.is_finite() => v,
+            _ => return Value::Error(ErrorKind::NA),
+        },
         _ => return Value::Error(ErrorKind::NA),
     };
     let sig = args.get(2).map(|v| match v {

--- a/crates/core/src/eval/functions/statistical/quartile/mod.rs
+++ b/crates/core/src/eval/functions/statistical/quartile/mod.rs
@@ -1,6 +1,6 @@
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
-use super::percentile_inc::{percentile_inc_calc, collect_numbers};
+use super::percentile_inc::{percentile_inc_calc, collect_numbers_checked};
 
 /// `QUARTILE(array, quart)` — quartile (same as QUARTILE.INC). quart in {0,1,2,3,4}.
 pub fn quartile_fn(args: &[Value]) -> Value {
@@ -9,15 +9,19 @@ pub fn quartile_fn(args: &[Value]) -> Value {
     }
     let quart = match &args[1] {
         Value::Number(n) => {
-            let q = *n;
-            if !(0.0..=4.0).contains(&q) || q != q.floor() {
+            let q = n.trunc();
+            if !(0.0..=4.0).contains(&q) {
                 return Value::Error(ErrorKind::Num);
             }
             q as u8
         }
+        Value::Bool(b) => if *b { 1u8 } else { 0u8 },
         _ => return Value::Error(ErrorKind::Num),
     };
-    let mut nums = collect_numbers(&args[0]);
+    let mut nums = match collect_numbers_checked(&args[0]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }

--- a/crates/core/src/eval/functions/statistical/quartile/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/quartile/tests/failure.rs
@@ -22,8 +22,8 @@ fn quartile_empty_array_returns_num_error() {
 }
 
 #[test]
-fn quartile_fractional_quart_returns_num_error() {
-    // quart=1.5 not integer → #NUM!
+fn quartile_fractional_quart_truncated() {
+    // quart=1.5 truncated to 1 → QUARTILE([1,2], 1) = 1.25
     let arr = Value::Array(vec![Value::Number(1.0), Value::Number(2.0)]);
-    assert_eq!(quartile_fn(&[arr, Value::Number(1.5)]), Value::Error(ErrorKind::Num));
+    assert_eq!(quartile_fn(&[arr, Value::Number(1.5)]), Value::Number(1.25));
 }

--- a/crates/core/src/eval/functions/statistical/quartile_exc/mod.rs
+++ b/crates/core/src/eval/functions/statistical/quartile_exc/mod.rs
@@ -1,6 +1,6 @@
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
-use super::percentile_inc::collect_numbers;
+use super::percentile_inc::collect_numbers_checked;
 use super::percentile_exc::percentile_exc_calc;
 
 /// `QUARTILE.EXC(array, quart)` — exclusive quartile. quart in {1,2,3} only.
@@ -10,15 +10,23 @@ pub fn quartile_exc_fn(args: &[Value]) -> Value {
     }
     let quart = match &args[1] {
         Value::Number(n) => {
-            let q = *n;
-            if !(1.0..=3.0).contains(&q) || q != q.floor() {
+            let q = n.trunc();
+            if !(1.0..=3.0).contains(&q) {
                 return Value::Error(ErrorKind::Num);
             }
             q as u8
         }
+        Value::Bool(b) => {
+            // TRUE→1, FALSE→0 — 0 is out of range for EXC
+            if !*b { return Value::Error(ErrorKind::Num); }
+            1u8
+        }
         _ => return Value::Error(ErrorKind::Num),
     };
-    let mut nums = collect_numbers(&args[0]);
+    let mut nums = match collect_numbers_checked(&args[0]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }

--- a/crates/core/src/eval/functions/statistical/quartile_exc/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/quartile_exc/tests/edge.rs
@@ -2,10 +2,10 @@ use super::super::*;
 use crate::types::{ErrorKind, Value};
 
 #[test]
-fn quartile_exc_fractional_quart_returns_num_error() {
-    // quart=1.5 not integer → #NUM!
+fn quartile_exc_fractional_quart_truncated() {
+    // quart=1.5 truncated to 1 → QUARTILE.EXC([1,2,3], 1) = 1.0
     let arr = Value::Array(vec![Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]);
-    assert_eq!(quartile_exc_fn(&[arr, Value::Number(1.5)]), Value::Error(ErrorKind::Num));
+    assert_eq!(quartile_exc_fn(&[arr, Value::Number(1.5)]), Value::Number(1.0));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/quartile_inc/mod.rs
+++ b/crates/core/src/eval/functions/statistical/quartile_inc/mod.rs
@@ -1,6 +1,6 @@
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
-use super::percentile_inc::{percentile_inc_calc, collect_numbers};
+use super::percentile_inc::{percentile_inc_calc, collect_numbers_checked};
 
 /// `QUARTILE.INC(array, quart)` — inclusive quartile. quart in {0,1,2,3,4}.
 pub fn quartile_inc_fn(args: &[Value]) -> Value {
@@ -9,15 +9,19 @@ pub fn quartile_inc_fn(args: &[Value]) -> Value {
     }
     let quart = match &args[1] {
         Value::Number(n) => {
-            let q = *n;
-            if !(0.0..=4.0).contains(&q) || q != q.floor() {
+            let q = n.trunc();
+            if !(0.0..=4.0).contains(&q) {
                 return Value::Error(ErrorKind::Num);
             }
             q as u8
         }
+        Value::Bool(b) => if *b { 1u8 } else { 0u8 },
         _ => return Value::Error(ErrorKind::Num),
     };
-    let mut nums = collect_numbers(&args[0]);
+    let mut nums = match collect_numbers_checked(&args[0]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }

--- a/crates/core/src/eval/functions/statistical/quartile_inc/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/quartile_inc/tests/failure.rs
@@ -20,7 +20,8 @@ fn quartile_inc_empty_array_returns_num_error() {
 }
 
 #[test]
-fn quartile_inc_fractional_quart_returns_num_error() {
+fn quartile_inc_fractional_quart_truncated() {
+    // quart=1.5 truncated to 1 → QUARTILE.INC([1,2], 1) = 1.25
     let arr = Value::Array(vec![Value::Number(1.0), Value::Number(2.0)]);
-    assert_eq!(quartile_inc_fn(&[arr, Value::Number(1.5)]), Value::Error(ErrorKind::Num));
+    assert_eq!(quartile_inc_fn(&[arr, Value::Number(1.5)]), Value::Number(1.25));
 }

--- a/crates/core/src/eval/functions/statistical/rank/mod.rs
+++ b/crates/core/src/eval/functions/statistical/rank/mod.rs
@@ -10,11 +10,16 @@ pub fn rank_fn(args: &[Value]) -> Value {
     }
     let x = match &args[0] {
         Value::Number(n) => *n,
+        Value::Bool(b) => if *b { 1.0 } else { 0.0 },
         _ => return Value::Error(ErrorKind::NA),
     };
-    let nums = collect_numbers(&args[1]);
+    let nums = match collect_numbers_checked(&args[1]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     let ascending = args.get(2).map(|v| match v {
         Value::Number(n) => *n != 0.0,
+        Value::Bool(b) => *b,
         _ => false,
     }).unwrap_or(false);
 
@@ -39,13 +44,22 @@ fn rank_eq_impl(x: f64, nums: &[f64], ascending: bool) -> Value {
     Value::Number(rank as f64)
 }
 
-fn collect_numbers(v: &Value) -> Vec<f64> {
+fn collect_numbers_checked(v: &Value) -> Result<Vec<f64>, Value> {
     match v {
-        Value::Array(arr) => arr.iter().filter_map(|x| {
-            if let Value::Number(n) = x { Some(*n) } else { None }
-        }).collect(),
-        Value::Number(n) => vec![*n],
-        _ => vec![],
+        Value::Array(arr) => {
+            let mut nums = Vec::new();
+            for x in arr {
+                match x {
+                    Value::Number(n) => nums.push(*n),
+                    Value::Error(e) => return Err(Value::Error(e.clone())),
+                    _ => {}
+                }
+            }
+            Ok(nums)
+        }
+        Value::Number(n) => Ok(vec![*n]),
+        Value::Error(e) => Err(Value::Error(e.clone())),
+        _ => Ok(vec![]),
     }
 }
 

--- a/crates/core/src/eval/functions/statistical/rank_avg/mod.rs
+++ b/crates/core/src/eval/functions/statistical/rank_avg/mod.rs
@@ -10,11 +10,16 @@ pub fn rank_avg_fn(args: &[Value]) -> Value {
     }
     let x = match &args[0] {
         Value::Number(n) => *n,
+        Value::Bool(b) => if *b { 1.0 } else { 0.0 },
         _ => return Value::Error(ErrorKind::NA),
     };
-    let nums = collect_numbers(&args[1]);
+    let nums = match collect_numbers_checked(&args[1]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     let ascending = args.get(2).map(|v| match v {
         Value::Number(n) => *n != 0.0,
+        Value::Bool(b) => *b,
         _ => false,
     }).unwrap_or(false);
 
@@ -38,13 +43,22 @@ pub fn rank_avg_fn(args: &[Value]) -> Value {
     Value::Number(avg_rank)
 }
 
-fn collect_numbers(v: &Value) -> Vec<f64> {
+fn collect_numbers_checked(v: &Value) -> Result<Vec<f64>, Value> {
     match v {
-        Value::Array(arr) => arr.iter().filter_map(|x| {
-            if let Value::Number(n) = x { Some(*n) } else { None }
-        }).collect(),
-        Value::Number(n) => vec![*n],
-        _ => vec![],
+        Value::Array(arr) => {
+            let mut nums = Vec::new();
+            for x in arr {
+                match x {
+                    Value::Number(n) => nums.push(*n),
+                    Value::Error(e) => return Err(Value::Error(e.clone())),
+                    _ => {}
+                }
+            }
+            Ok(nums)
+        }
+        Value::Number(n) => Ok(vec![*n]),
+        Value::Error(e) => Err(Value::Error(e.clone())),
+        _ => Ok(vec![]),
     }
 }
 

--- a/crates/core/src/eval/functions/statistical/rank_eq/mod.rs
+++ b/crates/core/src/eval/functions/statistical/rank_eq/mod.rs
@@ -10,11 +10,16 @@ pub fn rank_eq_fn(args: &[Value]) -> Value {
     }
     let x = match &args[0] {
         Value::Number(n) => *n,
+        Value::Bool(b) => if *b { 1.0 } else { 0.0 },
         _ => return Value::Error(ErrorKind::NA),
     };
-    let nums = collect_numbers(&args[1]);
+    let nums = match collect_numbers_checked(&args[1]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     let ascending = args.get(2).map(|v| match v {
         Value::Number(n) => *n != 0.0,
+        Value::Bool(b) => *b,
         _ => false,
     }).unwrap_or(false);
 
@@ -30,13 +35,22 @@ pub fn rank_eq_fn(args: &[Value]) -> Value {
     Value::Number(rank as f64)
 }
 
-fn collect_numbers(v: &Value) -> Vec<f64> {
+fn collect_numbers_checked(v: &Value) -> Result<Vec<f64>, Value> {
     match v {
-        Value::Array(arr) => arr.iter().filter_map(|x| {
-            if let Value::Number(n) = x { Some(*n) } else { None }
-        }).collect(),
-        Value::Number(n) => vec![*n],
-        _ => vec![],
+        Value::Array(arr) => {
+            let mut nums = Vec::new();
+            for x in arr {
+                match x {
+                    Value::Number(n) => nums.push(*n),
+                    Value::Error(e) => return Err(Value::Error(e.clone())),
+                    _ => {}
+                }
+            }
+            Ok(nums)
+        }
+        Value::Number(n) => Ok(vec![*n]),
+        Value::Error(e) => Err(Value::Error(e.clone())),
+        _ => Ok(vec![]),
     }
 }
 

--- a/crates/core/src/eval/functions/statistical/skew/mod.rs
+++ b/crates/core/src/eval/functions/statistical/skew/mod.rs
@@ -1,45 +1,21 @@
 use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums_direct;
 
 /// `SKEW(value1, ...)` — Fisher's sample skewness.
-/// Formula: (n/((n-1)(n-2))) * Σ((x-mean)/s)^3
-/// where s is the sample standard deviation.
-/// Flattens `Value::Array` args. Ignores Text, Bool, Empty.
-/// Requires n ≥ 3. Returns `#DIV/0!` if n < 3 or s = 0.
 pub fn skew_fn(args: &[Value]) -> Value {
-    let mut nums: Vec<f64> = Vec::new();
-    for arg in args {
-        match arg {
-            Value::Number(n) => nums.push(*n),
-            Value::Array(arr) => {
-                for v in arr {
-                    if let Value::Number(n) = v {
-                        nums.push(*n);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     let n = nums.len();
-    if n == 0 {
-        return Value::Error(ErrorKind::NA);
-    }
-    if n < 3 {
-        return Value::Error(ErrorKind::DivByZero);
-    }
+    if n == 0 { return Value::Error(ErrorKind::NA); }
+    if n < 3 { return Value::Error(ErrorKind::DivByZero); }
     let mean = nums.iter().sum::<f64>() / n as f64;
     let variance = nums.iter().map(|&x| (x - mean).powi(2)).sum::<f64>() / (n - 1) as f64;
     let s = variance.sqrt();
-    if s == 0.0 {
-        return Value::Error(ErrorKind::DivByZero);
-    }
+    if s == 0.0 { return Value::Error(ErrorKind::DivByZero); }
     let nf = n as f64;
     let sum3 = nums.iter().map(|&x| ((x - mean) / s).powi(3)).sum::<f64>();
     let result = (nf / ((nf - 1.0) * (nf - 2.0))) * sum3;
-    if !result.is_finite() {
-        return Value::Error(ErrorKind::Num);
-    }
-    Value::Number(result)
+    if result.is_finite() { Value::Number(result) } else { Value::Error(ErrorKind::Num) }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/skew_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/skew_p/mod.rs
@@ -1,45 +1,21 @@
 use crate::types::{ErrorKind, Value};
+use super::stat_helpers::collect_nums_direct;
 
 /// `SKEW.P(value1, ...)` — population skewness.
-/// Formula: (1/n) * Σ((x-mean)/σ)^3
-/// where σ is the population standard deviation (sqrt(Σ(x-mean)²/n)).
-/// Flattens `Value::Array` args. Ignores Text, Bool, Empty.
-/// Requires n ≥ 3. Returns `#N/A` if n=0, `#DIV/0!` if n < 3 or σ = 0.
 pub fn skew_p_fn(args: &[Value]) -> Value {
-    let mut nums: Vec<f64> = Vec::new();
-    for arg in args {
-        match arg {
-            Value::Number(n) => nums.push(*n),
-            Value::Array(arr) => {
-                for v in arr {
-                    if let Value::Number(n) = v {
-                        nums.push(*n);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     let n = nums.len();
-    if n == 0 {
-        return Value::Error(ErrorKind::NA);
-    }
-    if n < 3 {
-        return Value::Error(ErrorKind::DivByZero);
-    }
+    if n == 0 { return Value::Error(ErrorKind::NA); }
+    if n < 3 { return Value::Error(ErrorKind::DivByZero); }
     let mean = nums.iter().sum::<f64>() / n as f64;
     let pop_variance = nums.iter().map(|&x| (x - mean).powi(2)).sum::<f64>() / n as f64;
     let sigma = pop_variance.sqrt();
-    if sigma == 0.0 {
-        return Value::Error(ErrorKind::DivByZero);
-    }
+    if sigma == 0.0 { return Value::Error(ErrorKind::DivByZero); }
     let nf = n as f64;
     let sum3 = nums.iter().map(|&x| ((x - mean) / sigma).powi(3)).sum::<f64>();
     let result = sum3 / nf;
-    if !result.is_finite() {
-        return Value::Error(ErrorKind::Num);
-    }
-    Value::Number(result)
+    if result.is_finite() { Value::Number(result) } else { Value::Error(ErrorKind::Num) }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/small/mod.rs
+++ b/crates/core/src/eval/functions/statistical/small/mod.rs
@@ -7,20 +7,25 @@ pub fn small_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 2) {
         return err;
     }
-    let mut nums = collect_numbers(&args[0]);
+    let nums = match collect_numbers_checked(&args[0]) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     if nums.is_empty() {
         return Value::Error(ErrorKind::Num);
     }
     let k = match &args[1] {
         Value::Number(n) => {
-            let k = *n;
-            if k < 1.0 || k != k.floor() {
+            let k = n.trunc();
+            if k < 1.0 {
                 return Value::Error(ErrorKind::Num);
             }
             k as usize
         }
+        Value::Bool(b) => if *b { 1usize } else { return Value::Error(ErrorKind::Num); },
         _ => return Value::Error(ErrorKind::Num),
     };
+    let mut nums = nums;
     if k > nums.len() {
         return Value::Error(ErrorKind::Num);
     }
@@ -29,13 +34,22 @@ pub fn small_fn(args: &[Value]) -> Value {
     Value::Number(nums[k - 1])
 }
 
-fn collect_numbers(v: &Value) -> Vec<f64> {
+fn collect_numbers_checked(v: &Value) -> Result<Vec<f64>, Value> {
     match v {
-        Value::Array(arr) => arr.iter().filter_map(|x| {
-            if let Value::Number(n) = x { Some(*n) } else { None }
-        }).collect(),
-        Value::Number(n) => vec![*n],
-        _ => vec![],
+        Value::Array(arr) => {
+            let mut nums = Vec::new();
+            for x in arr {
+                match x {
+                    Value::Number(n) => nums.push(*n),
+                    Value::Error(e) => return Err(Value::Error(e.clone())),
+                    _ => {}
+                }
+            }
+            Ok(nums)
+        }
+        Value::Number(n) => Ok(vec![*n]),
+        Value::Error(e) => Err(Value::Error(e.clone())),
+        _ => Ok(vec![]),
     }
 }
 

--- a/crates/core/src/eval/functions/statistical/small/mod.rs
+++ b/crates/core/src/eval/functions/statistical/small/mod.rs
@@ -22,7 +22,8 @@ pub fn small_fn(args: &[Value]) -> Value {
             }
             k as usize
         }
-        Value::Bool(b) => if *b { 1usize } else { return Value::Error(ErrorKind::Num); },
+        Value::Bool(true) => 1usize,
+        Value::Bool(false) => return Value::Error(ErrorKind::Num),
         _ => return Value::Error(ErrorKind::Num),
     };
     let mut nums = nums;

--- a/crates/core/src/eval/functions/statistical/small/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/small/tests/failure.rs
@@ -23,8 +23,8 @@ fn small_empty_array_returns_num_error() {
 }
 
 #[test]
-fn small_fractional_k_returns_num_error() {
-    // k=1.5 is not an integer → #NUM!
+fn small_fractional_k_truncated() {
+    // k=1.5 is truncated to 1 → 1st smallest of [1.0, 2.0] = 1.0
     let arr = Value::Array(vec![Value::Number(1.0), Value::Number(2.0)]);
-    assert_eq!(small_fn(&[arr, Value::Number(1.5)]), Value::Error(ErrorKind::Num));
+    assert_eq!(small_fn(&[arr, Value::Number(1.5)]), Value::Number(1.0));
 }

--- a/crates/core/src/eval/functions/statistical/stat_helpers.rs
+++ b/crates/core/src/eval/functions/statistical/stat_helpers.rs
@@ -26,7 +26,7 @@ fn collect_nums_into(args: &[Value], out: &mut Vec<f64>) {
 ///   - Number/Date  → include
 ///   - Bool         → coerce (TRUE=1, FALSE=0)
 ///   - Text that parses as number → coerce
-///   - Text that does NOT parse  → return Err(Value)
+///   - Text that does NOT parse  → return Err(#VALUE!)
 ///   - Empty        → skip
 ///
 /// Rules for values inside an Array literal `{…}`:
@@ -70,14 +70,15 @@ pub fn collect_nums_direct(args: &[Value]) -> Result<Vec<f64>, Value> {
 ///   Direct scalar args:
 ///     - Number/Date  → include
 ///     - Bool         → coerce (TRUE=1, FALSE=0)
-///     - Text that parses as number → coerce to that number
-///     - Text that does NOT parse  → treat as 0 (counted)
+///     - Text ""      → push 0.0 (empty string counts as 0)
+///     - Text parseable → coerce to that value
+///     - Text non-parseable non-empty → return Err(#VALUE!)
 ///     - Empty        → skip
 ///
 ///   Array context `{…}`:
 ///     - Number/Date  → include
 ///     - Bool         → coerce (TRUE=1, FALSE=0)
-///     - Text         → treat as 0 (counted)
+///     - Text (any)   → push 0.0 (counts as 0)
 ///     - Empty        → skip
 pub fn collect_nums_a_direct(args: &[Value]) -> Result<Vec<f64>, Value> {
     let mut nums = Vec::new();
@@ -88,10 +89,15 @@ pub fn collect_nums_a_direct(args: &[Value]) -> Result<Vec<f64>, Value> {
             Value::Bool(b) => nums.push(if *b { 1.0 } else { 0.0 }),
             Value::Text(s) => {
                 let trimmed = s.trim();
-                // Direct text: try to parse as number, else treat as 0
-                match trimmed.parse::<f64>() {
-                    Ok(v) if v.is_finite() => nums.push(v),
-                    _ => nums.push(0.0),
+                if trimmed.is_empty() {
+                    // Empty string direct arg → counts as 0 for AVERAGEA
+                    nums.push(0.0);
+                } else {
+                    match trimmed.parse::<f64>() {
+                        Ok(v) if v.is_finite() => nums.push(v),
+                        // Non-parseable non-empty direct text → #VALUE!
+                        _ => return Err(Value::Error(ErrorKind::Value)),
+                    }
                 }
             }
             Value::Empty => {} // skip

--- a/crates/core/src/eval/functions/statistical/stat_helpers.rs
+++ b/crates/core/src/eval/functions/statistical/stat_helpers.rs
@@ -1,7 +1,8 @@
-use crate::types::Value;
+use crate::types::{ErrorKind, Value};
 
 /// Collect numeric values from args, flattening arrays.
 /// Numbers and Dates are included. Bool/Text/Empty are ignored.
+/// Used for range/array contexts where GS skips non-numerics.
 pub fn collect_nums(args: &[Value]) -> Vec<f64> {
     let mut nums = Vec::new();
     collect_nums_into(args, &mut nums);
@@ -19,6 +20,91 @@ fn collect_nums_into(args: &[Value], out: &mut Vec<f64>) {
     }
 }
 
+/// Collect numeric values respecting Google Sheets direct-arg semantics.
+///
+/// Rules for top-level (direct scalar) args:
+///   - Number/Date  → include
+///   - Bool         → coerce (TRUE=1, FALSE=0)
+///   - Text that parses as number → coerce
+///   - Text that does NOT parse  → return Err(Value)
+///   - Empty        → skip
+///
+/// Rules for values inside an Array literal `{…}`:
+///   - Number/Date  → include
+///   - Bool         → skip (Google Sheets skips bools in array context for AVERAGE etc.)
+///   - Text         → skip
+///   - Empty        → skip
+///
+/// Returns `Ok(nums)` or `Err(Value::Error(ErrorKind::Value))`.
+pub fn collect_nums_direct(args: &[Value]) -> Result<Vec<f64>, Value> {
+    let mut nums = Vec::new();
+    for arg in args {
+        match arg {
+            Value::Number(n) => nums.push(*n),
+            Value::Date(n) => nums.push(*n),
+            Value::Bool(b) => nums.push(if *b { 1.0 } else { 0.0 }),
+            Value::Text(s) => {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    return Err(Value::Error(ErrorKind::Value));
+                }
+                match trimmed.parse::<f64>() {
+                    Ok(v) if v.is_finite() => nums.push(v),
+                    _ => return Err(Value::Error(ErrorKind::Value)),
+                }
+            }
+            Value::Empty => {} // skip
+            Value::Array(inner) => {
+                // Array context: skip non-numeric silently
+                collect_nums_into(inner, &mut nums);
+            }
+            Value::Error(e) => return Err(Value::Error(*e)),
+        }
+    }
+    Ok(nums)
+}
+
+/// Collect numeric values for AVERAGEA with Google Sheets direct-arg semantics.
+///
+/// AVERAGEA rules:
+///   Direct scalar args:
+///     - Number/Date  → include
+///     - Bool         → coerce (TRUE=1, FALSE=0)
+///     - Text that parses as number → coerce to that number
+///     - Text that does NOT parse  → treat as 0 (counted)
+///     - Empty        → skip
+///
+///   Array context `{…}`:
+///     - Number/Date  → include
+///     - Bool         → coerce (TRUE=1, FALSE=0)
+///     - Text         → treat as 0 (counted)
+///     - Empty        → skip
+pub fn collect_nums_a_direct(args: &[Value]) -> Result<Vec<f64>, Value> {
+    let mut nums = Vec::new();
+    for arg in args {
+        match arg {
+            Value::Number(n) => nums.push(*n),
+            Value::Date(n) => nums.push(*n),
+            Value::Bool(b) => nums.push(if *b { 1.0 } else { 0.0 }),
+            Value::Text(s) => {
+                let trimmed = s.trim();
+                // Direct text: try to parse as number, else treat as 0
+                match trimmed.parse::<f64>() {
+                    Ok(v) if v.is_finite() => nums.push(v),
+                    _ => nums.push(0.0),
+                }
+            }
+            Value::Empty => {} // skip
+            Value::Array(inner) => {
+                // Array context: bools coerce, text→0
+                collect_nums_a_into(inner, &mut nums);
+            }
+            Value::Error(e) => return Err(Value::Error(*e)),
+        }
+    }
+    Ok(nums)
+}
+
 /// Collect numeric values from args, flattening arrays.
 /// "A" variant: also includes Bool (TRUE=1, FALSE=0) and Text as 0.
 pub fn collect_nums_a(args: &[Value]) -> Vec<f64> {
@@ -27,7 +113,7 @@ pub fn collect_nums_a(args: &[Value]) -> Vec<f64> {
     nums
 }
 
-fn collect_nums_a_into(args: &[Value], out: &mut Vec<f64>) {
+pub fn collect_nums_a_into(args: &[Value], out: &mut Vec<f64>) {
     for arg in args {
         match arg {
             Value::Number(n) => out.push(*n),

--- a/crates/core/src/eval/functions/statistical/stat_helpers.rs
+++ b/crates/core/src/eval/functions/statistical/stat_helpers.rs
@@ -58,7 +58,7 @@ pub fn collect_nums_direct(args: &[Value]) -> Result<Vec<f64>, Value> {
                 // Array context: skip non-numeric silently
                 collect_nums_into(inner, &mut nums);
             }
-            Value::Error(e) => return Err(Value::Error(*e)),
+            Value::Error(e) => return Err(Value::Error(e.clone())),
         }
     }
     Ok(nums)
@@ -99,7 +99,7 @@ pub fn collect_nums_a_direct(args: &[Value]) -> Result<Vec<f64>, Value> {
                 // Array context: bools coerce, text→0
                 collect_nums_a_into(inner, &mut nums);
             }
-            Value::Error(e) => return Err(Value::Error(*e)),
+            Value::Error(e) => return Err(Value::Error(e.clone())),
         }
     }
     Ok(nums)

--- a/crates/core/src/eval/functions/statistical/stat_helpers.rs
+++ b/crates/core/src/eval/functions/statistical/stat_helpers.rs
@@ -20,6 +20,92 @@ fn collect_nums_into(args: &[Value], out: &mut Vec<f64>) {
     }
 }
 
+/// Like collect_nums_into but propagates errors. Returns Some(err) if an error is found.
+fn collect_nums_into_checked(args: &[Value], out: &mut Vec<f64>) -> Option<Value> {
+    for arg in args {
+        match arg {
+            Value::Number(n) => out.push(*n),
+            Value::Date(n) => out.push(*n),
+            Value::Array(inner) => {
+                if let Some(err) = collect_nums_into_checked(inner, out) {
+                    return Some(err);
+                }
+            }
+            Value::Error(e) => return Some(Value::Error(e.clone())),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Like collect_nums_a_into but propagates errors. Returns Some(err) if an error is found.
+fn collect_nums_a_into_checked(args: &[Value], out: &mut Vec<f64>) -> Option<Value> {
+    for arg in args {
+        match arg {
+            Value::Number(n) => out.push(*n),
+            Value::Date(n) => out.push(*n),
+            Value::Bool(b) => out.push(if *b { 1.0 } else { 0.0 }),
+            Value::Text(_) => out.push(0.0),
+            Value::Array(inner) => {
+                if let Some(err) = collect_nums_a_into_checked(inner, out) {
+                    return Some(err);
+                }
+            }
+            Value::Error(e) => return Some(Value::Error(e.clone())),
+            Value::Empty => {}
+        }
+    }
+    None
+}
+
+/// Collect numbers from a single Value with error propagation.
+/// Array elements: Numbers only, errors propagate. Non-numeric scalar → empty.
+pub fn collect_numbers_checked(v: &Value) -> Result<Vec<f64>, Value> {
+    match v {
+        Value::Array(arr) => {
+            let mut nums = Vec::new();
+            if let Some(err) = collect_nums_into_checked(arr, &mut nums) {
+                return Err(err);
+            }
+            Ok(nums)
+        }
+        Value::Number(n) => Ok(vec![*n]),
+        Value::Error(e) => Err(Value::Error(e.clone())),
+        _ => Ok(vec![]),
+    }
+}
+
+/// Like collect_nums_a_direct but also propagates errors from inside arrays.
+pub fn collect_nums_a_checked(args: &[Value]) -> Result<Vec<f64>, Value> {
+    let mut nums = Vec::new();
+    for arg in args {
+        match arg {
+            Value::Number(n) => nums.push(*n),
+            Value::Date(n) => nums.push(*n),
+            Value::Bool(b) => nums.push(if *b { 1.0 } else { 0.0 }),
+            Value::Text(s) => {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    nums.push(0.0);
+                } else {
+                    match trimmed.parse::<f64>() {
+                        Ok(v) if v.is_finite() => nums.push(v),
+                        _ => return Err(Value::Error(ErrorKind::Value)),
+                    }
+                }
+            }
+            Value::Empty => {}
+            Value::Array(inner) => {
+                if let Some(err) = collect_nums_a_into_checked(inner, &mut nums) {
+                    return Err(err);
+                }
+            }
+            Value::Error(e) => return Err(Value::Error(e.clone())),
+        }
+    }
+    Ok(nums)
+}
+
 /// Collect numeric values respecting Google Sheets direct-arg semantics.
 ///
 /// Rules for top-level (direct scalar) args:
@@ -55,8 +141,10 @@ pub fn collect_nums_direct(args: &[Value]) -> Result<Vec<f64>, Value> {
             }
             Value::Empty => {} // skip
             Value::Array(inner) => {
-                // Array context: skip non-numeric silently
-                collect_nums_into(inner, &mut nums);
+                // Array context: skip non-numeric, but propagate errors
+                if let Some(err) = collect_nums_into_checked(inner, &mut nums) {
+                    return Err(err);
+                }
             }
             Value::Error(e) => return Err(Value::Error(e.clone())),
         }
@@ -129,6 +217,59 @@ pub fn collect_nums_a_into(args: &[Value], out: &mut Vec<f64>) {
             Value::Array(inner) => collect_nums_a_into(inner, out),
             Value::Empty => {}
             Value::Error(_) => {}
+        }
+    }
+}
+
+/// Collect paired numeric values with GS paired-deletion semantics.
+/// Used for CORREL, PEARSON, COVARIANCE, COVAR, SLOPE, INTERCEPT, RSQ, STEYX, FORECAST.
+///
+/// Each arg is flattened. At each index position:
+///   - Error in either → propagate immediately.
+///   - Both are Number → include pair.
+///   - Otherwise (Bool, Text, Empty in either) → skip pair.
+///
+/// Returns Err(Ref) if either flattened array is empty.
+/// Returns Err(NA) if flattened lengths differ.
+pub fn collect_paired(x_arg: &Value, y_arg: &Value) -> Result<(Vec<f64>, Vec<f64>), Value> {
+    let xs_raw = flatten_to_values(x_arg);
+    let ys_raw = flatten_to_values(y_arg);
+    if xs_raw.is_empty() || ys_raw.is_empty() {
+        return Err(Value::Error(ErrorKind::Ref));
+    }
+    if xs_raw.len() != ys_raw.len() {
+        return Err(Value::Error(ErrorKind::NA));
+    }
+    let mut xs = Vec::new();
+    let mut ys = Vec::new();
+    for (x, y) in xs_raw.iter().zip(ys_raw.iter()) {
+        if let Value::Error(e) = x { return Err(Value::Error(e.clone())); }
+        if let Value::Error(e) = y { return Err(Value::Error(e.clone())); }
+        if let (Value::Number(xn), Value::Number(yn)) = (x, y) {
+            xs.push(*xn);
+            ys.push(*yn);
+        }
+        // Any non-Number (Bool, Text, Empty) in either position → skip pair
+    }
+    Ok((xs, ys))
+}
+
+fn flatten_to_values(v: &Value) -> Vec<Value> {
+    match v {
+        Value::Array(inner) => {
+            let mut out = Vec::new();
+            flatten_array_into(inner, &mut out);
+            out
+        }
+        other => vec![other.clone()],
+    }
+}
+
+fn flatten_array_into(arr: &[Value], out: &mut Vec<Value>) {
+    for v in arr {
+        match v {
+            Value::Array(inner) => flatten_array_into(inner, out),
+            other => out.push(other.clone()),
         }
     }
 }

--- a/crates/core/src/eval/functions/statistical/stdev/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev/mod.rs
@@ -1,5 +1,5 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_nums_direct;
 use super::var_s::sample_variance;
 
 /// `STDEV(value1, ...)` — sample standard deviation (same as STDEV.S).
@@ -7,7 +7,7 @@ pub fn stdev_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
-    let nums = collect_nums(args);
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     match sample_variance(&nums) {
         Value::Number(v) => {
             let s = v.sqrt();

--- a/crates/core/src/eval/functions/statistical/stdev/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdev/tests/edge.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use crate::types::Value;
+use crate::types::{ErrorKind, Value};
 
 #[test]
 fn stdev_all_same_values_returns_zero() {
@@ -10,17 +10,13 @@ fn stdev_all_same_values_returns_zero() {
 }
 
 #[test]
-fn stdev_ignores_bool_and_text() {
-    // Text/bool ignored; [2, 6] → mean=4, sample var=8, stdev=sqrt(8)
+fn stdev_direct_text_returns_value_error() {
+    // Direct non-parseable text → #VALUE! (Bool is coerced, but text fails first)
     let result = stdev_fn(&[
         Value::Number(2.0),
         Value::Number(6.0),
         Value::Bool(true),
         Value::Text("x".to_string()),
     ]);
-    if let Value::Number(v) = result {
-        assert!((v - 8.0_f64.sqrt()).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+    assert_eq!(result, Value::Error(ErrorKind::Value));
 }

--- a/crates/core/src/eval/functions/statistical/stdev_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_p/mod.rs
@@ -1,22 +1,15 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_nums_direct;
 use super::var_p::pop_variance;
 
-/// `STDEV.P(value1, ...)` — population standard deviation: sqrt(population variance).
-/// Requires n≥1. Returns `#DIV/0!` if no numeric values.
+/// `STDEV.P(value1, ...)` — population standard deviation.
 pub fn stdev_p_fn(args: &[Value]) -> Value {
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
-    }
-    let nums = collect_nums(args);
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     match pop_variance(&nums) {
         Value::Number(v) => {
             let s = v.sqrt();
-            if !s.is_finite() {
-                Value::Error(ErrorKind::Num)
-            } else {
-                Value::Number(s)
-            }
+            if s.is_finite() { Value::Number(s) } else { Value::Error(ErrorKind::Num) }
         }
         other => other,
     }

--- a/crates/core/src/eval/functions/statistical/stdev_p/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_p/tests/failure.rs
@@ -7,10 +7,10 @@ fn stdev_p_no_args_returns_na() {
 }
 
 #[test]
-fn stdev_p_no_numeric_values_returns_div_zero() {
+fn stdev_p_non_numeric_text_returns_value_error() {
     assert_eq!(
-        stdev_p_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
-        Value::Error(ErrorKind::DivByZero)
+        stdev_p_fn(&[Value::Text("a".to_string()), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/stdev_p/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_p/tests/success.rs
@@ -3,36 +3,29 @@ use crate::types::Value;
 
 #[test]
 fn stdev_p_basic() {
-    // [2, 4, 6]: pop var=8/3, stdev=sqrt(8/3)
     let result = stdev_p_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
     if let Value::Number(v) = result {
-        assert!((v - (8.0_f64 / 3.0).sqrt()).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+        assert!((v - (8.0_f64/3.0).sqrt()).abs() < 1e-10);
+    } else { panic!("Expected Number, got {:?}", result); }
 }
 
 #[test]
 fn stdev_p_single_value_returns_zero() {
-    // Pop stdev of one value is 0
     assert_eq!(stdev_p_fn(&[Value::Number(7.0)]), Value::Number(0.0));
 }
 
 #[test]
 fn stdev_p_two_values() {
-    // [1, 3]: pop var=1, stdev=1.0
-    let result = stdev_p_fn(&[Value::Number(1.0), Value::Number(3.0)]);
-    assert_eq!(result, Value::Number(1.0));
+    assert_eq!(stdev_p_fn(&[Value::Number(1.0), Value::Number(3.0)]), Value::Number(1.0));
 }
 
 #[test]
-fn stdev_p_ignores_bool_and_text() {
-    // Only numbers counted: [2, 6] → pop var=4, stdev=2
+fn stdev_p_bool_coerces_to_number() {
+    // TRUE->1, FALSE->0; [2,6,1,0]: pop var=20.75/4
     let result = stdev_p_fn(&[
-        Value::Number(2.0),
-        Value::Number(6.0),
-        Value::Bool(true),
-        Value::Text("x".to_string()),
+        Value::Number(2.0), Value::Number(6.0), Value::Bool(true), Value::Bool(false),
     ]);
-    assert_eq!(result, Value::Number(2.0));
+    if let Value::Number(v) = result {
+        assert!((v - (20.75_f64/4.0).sqrt()).abs() < 1e-10);
+    } else { panic!("Expected Number, got {:?}", result); }
 }

--- a/crates/core/src/eval/functions/statistical/stdev_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_s/mod.rs
@@ -2,25 +2,14 @@ use crate::types::{ErrorKind, Value};
 use super::stat_helpers::collect_nums_direct;
 use super::var_s::sample_variance;
 
-/// `STDEV.S(value1, ...)` — sample standard deviation: sqrt(sample variance).
-/// Direct bool/text-number args coerce; non-numeric text -> #VALUE!.
-/// Requires n>=2. Returns `#DIV/0!` if fewer than 2 numeric values.
+/// `STDEV.S(value1, ...)` — sample standard deviation.
 pub fn stdev_s_fn(args: &[Value]) -> Value {
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
-    }
-    let nums = match collect_nums_direct(args) {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     match sample_variance(&nums) {
         Value::Number(v) => {
             let s = v.sqrt();
-            if !s.is_finite() {
-                Value::Error(ErrorKind::Num)
-            } else {
-                Value::Number(s)
-            }
+            if s.is_finite() { Value::Number(s) } else { Value::Error(ErrorKind::Num) }
         }
         other => other,
     }

--- a/crates/core/src/eval/functions/statistical/stdev_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_s/mod.rs
@@ -1,14 +1,18 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_nums_direct;
 use super::var_s::sample_variance;
 
 /// `STDEV.S(value1, ...)` — sample standard deviation: sqrt(sample variance).
-/// Requires n≥2. Returns `#DIV/0!` if fewer than 2 numeric values.
+/// Direct bool/text-number args coerce; non-numeric text -> #VALUE!.
+/// Requires n>=2. Returns `#DIV/0!` if fewer than 2 numeric values.
 pub fn stdev_s_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
-    let nums = collect_nums(args);
+    let nums = match collect_nums_direct(args) {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
     match sample_variance(&nums) {
         Value::Number(v) => {
             let s = v.sqrt();

--- a/crates/core/src/eval/functions/statistical/stdev_s/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_s/tests/failure.rs
@@ -12,10 +12,10 @@ fn stdev_s_one_value_returns_div_zero() {
 }
 
 #[test]
-fn stdev_s_no_numeric_values_returns_div_zero() {
+fn stdev_s_non_numeric_text_returns_value_error() {
     assert_eq!(
-        stdev_s_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
-        Value::Error(ErrorKind::DivByZero)
+        stdev_s_fn(&[Value::Text("a".to_string()), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/stdev_s/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/stdev_s/tests/success.rs
@@ -3,54 +3,36 @@ use crate::types::Value;
 
 #[test]
 fn stdev_s_basic() {
-    // [2, 4, 6]: sample var=4, stdev=2.0
     let result = stdev_s_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
     assert_eq!(result, Value::Number(2.0));
 }
 
 #[test]
 fn stdev_s_two_values() {
-    // [1, 3]: sample var=2, stdev=sqrt(2)
     let result = stdev_s_fn(&[Value::Number(1.0), Value::Number(3.0)]);
     if let Value::Number(v) = result {
         assert!((v - 2.0_f64.sqrt()).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+    } else { panic!("Expected Number, got {:?}", result); }
 }
 
 #[test]
-fn stdev_s_ignores_bool_and_text() {
-    // Only numbers counted: [2, 6] → mean=4, sample var=8, stdev=sqrt(8)
+fn stdev_s_bool_coerces_to_number() {
+    // TRUE->1, FALSE->0; [2,6,1,0]: sample var=20.75/3
     let result = stdev_s_fn(&[
-        Value::Number(2.0),
-        Value::Number(6.0),
-        Value::Bool(true),
-        Value::Text("x".to_string()),
+        Value::Number(2.0), Value::Number(6.0), Value::Bool(true), Value::Bool(false),
     ]);
     if let Value::Number(v) = result {
-        assert!((v - 8.0_f64.sqrt()).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+        assert!((v - (20.75_f64/3.0).sqrt()).abs() < 1e-10);
+    } else { panic!("Expected Number, got {:?}", result); }
 }
 
 #[test]
 fn stdev_s_known_dataset() {
-    // [2,4,4,4,5,5,7,9]: sample var≈4.5714, stdev≈2.1381
     let result = stdev_s_fn(&[
-        Value::Number(2.0),
-        Value::Number(4.0),
-        Value::Number(4.0),
-        Value::Number(4.0),
-        Value::Number(5.0),
-        Value::Number(5.0),
-        Value::Number(7.0),
-        Value::Number(9.0),
+        Value::Number(2.0), Value::Number(4.0), Value::Number(4.0), Value::Number(4.0),
+        Value::Number(5.0), Value::Number(5.0), Value::Number(7.0), Value::Number(9.0),
     ]);
     if let Value::Number(v) = result {
-        assert!((v - (32.0_f64 / 7.0).sqrt()).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+        assert!((v - (32.0_f64/7.0).sqrt()).abs() < 1e-10);
+    } else { panic!("Expected Number, got {:?}", result); }
 }

--- a/crates/core/src/eval/functions/statistical/stdeva/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/mod.rs
@@ -1,24 +1,15 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums_a;
+use super::stat_helpers::collect_nums_a_direct;
 use super::var_s::sample_variance;
 
-/// `STDEVA(value1, ...)` — sample standard deviation, text/FALSE=0, TRUE=1.
+/// `STDEVA(value1, ...)` - sample standard deviation including text/bool.
 pub fn stdeva_fn(args: &[Value]) -> Value {
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
-    }
-    if args.iter().any(|a| matches!(a, Value::Text(_))) {
-        return Value::Error(ErrorKind::Value);
-    }
-    let nums = collect_nums_a(args);
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_a_direct(args) { Ok(v) => v, Err(e) => return e };
     match sample_variance(&nums) {
         Value::Number(v) => {
             let s = v.sqrt();
-            if !s.is_finite() {
-                Value::Error(ErrorKind::Num)
-            } else {
-                Value::Number(s)
-            }
+            if s.is_finite() { Value::Number(s) } else { Value::Error(ErrorKind::Num) }
         }
         other => other,
     }

--- a/crates/core/src/eval/functions/statistical/stdeva/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/tests/edge.rs
@@ -20,13 +20,11 @@ fn stdeva_false_counts_as_zero() {
 }
 
 #[test]
-fn stdeva_non_parseable_text_counts_as_zero() {
-    // AVERAGEA semantics: non-parseable text direct arg -> 0.0
-    // [0.0, 4.0]: sample var=8, stdev=sqrt(8)
+fn stdeva_non_parseable_text_returns_value_error() {
+    // Direct non-parseable text -> #VALUE! for AVERAGEA semantics
+    use crate::types::ErrorKind;
     let result = stdeva_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    if let Value::Number(v) = result {
-        assert!((v - 8.0_f64.sqrt()).abs() < 1e-10);
-    } else { panic!("Expected Number, got {:?}", result); }
+    assert_eq!(result, Value::Error(ErrorKind::Value));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/stdeva/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdeva/tests/edge.rs
@@ -7,9 +7,7 @@ fn stdeva_true_counts_as_one() {
     let result = stdeva_fn(&[Value::Bool(true), Value::Number(3.0)]);
     if let Value::Number(v) = result {
         assert!((v - 2.0_f64.sqrt()).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+    } else { panic!("Expected Number, got {:?}", result); }
 }
 
 #[test]
@@ -18,16 +16,17 @@ fn stdeva_false_counts_as_zero() {
     let result = stdeva_fn(&[Value::Bool(false), Value::Number(2.0)]);
     if let Value::Number(v) = result {
         assert!((v - 2.0_f64.sqrt()).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+    } else { panic!("Expected Number, got {:?}", result); }
 }
 
 #[test]
-fn stdeva_text_returns_value_error() {
-    // Literal text as direct arg → #VALUE! (Google Sheets)
+fn stdeva_non_parseable_text_counts_as_zero() {
+    // AVERAGEA semantics: non-parseable text direct arg -> 0.0
+    // [0.0, 4.0]: sample var=8, stdev=sqrt(8)
     let result = stdeva_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    assert_eq!(result, Value::Error(crate::types::ErrorKind::Value));
+    if let Value::Number(v) = result {
+        assert!((v - 8.0_f64.sqrt()).abs() < 1e-10);
+    } else { panic!("Expected Number, got {:?}", result); }
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/stdevp/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdevp/mod.rs
@@ -1,5 +1,5 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_nums_direct;
 use super::var_p::pop_variance;
 
 /// `STDEVP(value1, ...)` — population standard deviation (same as STDEV.P).
@@ -7,7 +7,7 @@ pub fn stdevp_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
-    let nums = collect_nums(args);
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     match pop_variance(&nums) {
         Value::Number(v) => {
             let s = v.sqrt();

--- a/crates/core/src/eval/functions/statistical/stdevp/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdevp/tests/edge.rs
@@ -10,15 +10,15 @@ fn stdevp_all_same_values_returns_zero() {
 }
 
 #[test]
-fn stdevp_ignores_bool_and_text() {
-    // Text/bool ignored; [2, 6] → pop var=4, stdev=2
+fn stdevp_direct_text_returns_value_error() {
+    // Direct non-parseable text → #VALUE!
     let result = stdevp_fn(&[
         Value::Number(2.0),
         Value::Number(6.0),
         Value::Bool(true),
         Value::Text("x".to_string()),
     ]);
-    assert_eq!(result, Value::Number(2.0));
+    assert_eq!(result, Value::Error(ErrorKind::Value));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/stdevp/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/stdevp/tests/failure.rs
@@ -7,9 +7,10 @@ fn stdevp_no_args_returns_na() {
 }
 
 #[test]
-fn stdevp_no_numeric_values_returns_div_zero() {
+fn stdevp_direct_text_returns_value_error() {
+    // Direct non-parseable text returns #VALUE! (not #DIV/0!)
     assert_eq!(
         stdevp_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
-        Value::Error(ErrorKind::DivByZero)
+        Value::Error(ErrorKind::Value)
     );
 }

--- a/crates/core/src/eval/functions/statistical/stdevpa/mod.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/mod.rs
@@ -1,24 +1,15 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums_a;
+use super::stat_helpers::collect_nums_a_direct;
 use super::var_p::pop_variance;
 
-/// `STDEVPA(value1, ...)` — population standard deviation, text/FALSE=0, TRUE=1.
+/// `STDEVPA(value1, ...)` - population standard deviation including text/bool.
 pub fn stdevpa_fn(args: &[Value]) -> Value {
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
-    }
-    if args.iter().any(|a| matches!(a, Value::Text(_))) {
-        return Value::Error(ErrorKind::Value);
-    }
-    let nums = collect_nums_a(args);
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_a_direct(args) { Ok(v) => v, Err(e) => return e };
     match pop_variance(&nums) {
         Value::Number(v) => {
             let s = v.sqrt();
-            if !s.is_finite() {
-                Value::Error(ErrorKind::Num)
-            } else {
-                Value::Number(s)
-            }
+            if s.is_finite() { Value::Number(s) } else { Value::Error(ErrorKind::Num) }
         }
         other => other,
     }

--- a/crates/core/src/eval/functions/statistical/stdevpa/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/tests/edge.rs
@@ -12,11 +12,11 @@ fn stdevpa_false_counts_as_zero() {
 }
 
 #[test]
-fn stdevpa_non_parseable_text_counts_as_zero() {
-    // AVERAGEA semantics: non-parseable text -> 0.0
-    // [0.0, 4.0]: pop var=4, stdev=2.0
+fn stdevpa_non_parseable_text_returns_value_error() {
+    // Direct non-parseable text -> #VALUE! for AVERAGEA semantics
+    use crate::types::ErrorKind;
     let result = stdevpa_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    assert_eq!(result, Value::Number(2.0));
+    assert_eq!(result, Value::Error(ErrorKind::Value));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/stdevpa/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/stdevpa/tests/edge.rs
@@ -3,21 +3,20 @@ use crate::types::Value;
 
 #[test]
 fn stdevpa_true_counts_as_one() {
-    // Bool(true)=1.0; single value → pop stdev=0
     assert_eq!(stdevpa_fn(&[Value::Bool(true)]), Value::Number(0.0));
 }
 
 #[test]
 fn stdevpa_false_counts_as_zero() {
-    // Bool(false)=0.0; single value → pop stdev=0
     assert_eq!(stdevpa_fn(&[Value::Bool(false)]), Value::Number(0.0));
 }
 
 #[test]
-fn stdevpa_text_returns_value_error() {
-    // Literal text as direct arg → #VALUE! (Google Sheets)
+fn stdevpa_non_parseable_text_counts_as_zero() {
+    // AVERAGEA semantics: non-parseable text -> 0.0
+    // [0.0, 4.0]: pop var=4, stdev=2.0
     let result = stdevpa_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    assert_eq!(result, Value::Error(crate::types::ErrorKind::Value));
+    assert_eq!(result, Value::Number(2.0));
 }
 
 #[test]
@@ -25,10 +24,8 @@ fn stdevpa_bool_and_number() {
     // [true=1, false=0, 5.0]: pop var=14/3, stdev=sqrt(14/3)
     let result = stdevpa_fn(&[Value::Bool(true), Value::Bool(false), Value::Number(5.0)]);
     if let Value::Number(v) = result {
-        assert!((v - (14.0_f64 / 3.0).sqrt()).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+        assert!((v - (14.0_f64/3.0).sqrt()).abs() < 1e-10);
+    } else { panic!("Expected Number, got {:?}", result); }
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/trimmean/mod.rs
+++ b/crates/core/src/eval/functions/statistical/trimmean/mod.rs
@@ -11,6 +11,10 @@ pub fn trimmean_fn(args: &[Value]) -> Value {
     }
     let percent = match &args[1] {
         Value::Number(p) => *p,
+        Value::Text(s) => match s.trim().parse::<f64>() {
+            Ok(v) if v.is_finite() => v,
+            _ => return Value::Error(ErrorKind::Value),
+        },
         _ => return Value::Error(ErrorKind::Value),
     };
     if !(0.0..1.0).contains(&percent) {
@@ -20,10 +24,13 @@ pub fn trimmean_fn(args: &[Value]) -> Value {
     let mut nums: Vec<f64> = Vec::new();
     match &args[0] {
         Value::Number(n) => nums.push(*n),
+        Value::Error(e) => return Value::Error(e.clone()),
         Value::Array(arr) => {
             for v in arr {
-                if let Value::Number(n) = v {
-                    nums.push(*n);
+                match v {
+                    Value::Number(n) => nums.push(*n),
+                    Value::Error(e) => return Value::Error(e.clone()),
+                    _ => {}
                 }
             }
         }

--- a/crates/core/src/eval/functions/statistical/var/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var/mod.rs
@@ -1,5 +1,5 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_nums_direct;
 use super::var_s::sample_variance;
 
 /// `VAR(value1, ...)` — sample variance (same as VAR.S).
@@ -7,7 +7,7 @@ pub fn var_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
-    let nums = collect_nums(args);
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     sample_variance(&nums)
 }
 

--- a/crates/core/src/eval/functions/statistical/var/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/var/tests/edge.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use crate::types::Value;
+use crate::types::{ErrorKind, Value};
 
 #[test]
 fn var_all_same_values_returns_zero() {
@@ -10,13 +10,13 @@ fn var_all_same_values_returns_zero() {
 }
 
 #[test]
-fn var_ignores_bool_and_text() {
-    // Text/bool ignored; [2, 6] → mean=4, sample var=8
+fn var_direct_text_returns_value_error() {
+    // Direct non-parseable text → #VALUE!
     let result = var_fn(&[
         Value::Number(2.0),
         Value::Number(6.0),
         Value::Bool(true),
         Value::Text("x".to_string()),
     ]);
-    assert_eq!(result, Value::Number(8.0));
+    assert_eq!(result, Value::Error(ErrorKind::Value));
 }

--- a/crates/core/src/eval/functions/statistical/var_p/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var_p/mod.rs
@@ -1,28 +1,19 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_nums_direct;
 
-/// `VAR.P(value1, ...)` — population variance: Σ(x-mean)²/n.
-/// Requires n≥1. Returns `#DIV/0!` if no numeric values.
+/// `VAR.P(value1, ...)` — population variance.
 pub fn var_p_fn(args: &[Value]) -> Value {
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
-    }
-    let nums = collect_nums(args);
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     pop_variance(&nums)
 }
 
-/// Compute population variance from a slice of f64 values.
 pub(crate) fn pop_variance(nums: &[f64]) -> Value {
     let n = nums.len();
-    if n == 0 {
-        return Value::Error(ErrorKind::DivByZero);
-    }
+    if n == 0 { return Value::Error(ErrorKind::DivByZero); }
     let mean = nums.iter().sum::<f64>() / n as f64;
     let var = nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n as f64;
-    if !var.is_finite() {
-        return Value::Error(ErrorKind::Num);
-    }
-    Value::Number(var)
+    if !var.is_finite() { Value::Error(ErrorKind::Num) } else { Value::Number(var) }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/var_p/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/var_p/tests/failure.rs
@@ -7,10 +7,10 @@ fn var_p_no_args_returns_na() {
 }
 
 #[test]
-fn var_p_no_numeric_values_returns_div_zero() {
+fn var_p_non_numeric_text_returns_value_error() {
     assert_eq!(
-        var_p_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
-        Value::Error(ErrorKind::DivByZero)
+        var_p_fn(&[Value::Text("a".to_string()), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/var_p/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/var_p/tests/success.rs
@@ -3,36 +3,31 @@ use crate::types::Value;
 
 #[test]
 fn var_p_basic() {
-    // [2, 4, 6]: mean=4, var=((2-4)²+(4-4)²+(6-4)²)/3=8/3
+    // [2, 4, 6]: pop var=8/3
     let result = var_p_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
     if let Value::Number(v) = result {
-        assert!((v - 8.0 / 3.0).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+        assert!((v - 8.0/3.0).abs() < 1e-10);
+    } else { panic!("Expected Number, got {:?}", result); }
 }
 
 #[test]
 fn var_p_two_values() {
-    // [1, 3]: mean=2, var=((1-2)²+(3-2)²)/2=1
     let result = var_p_fn(&[Value::Number(1.0), Value::Number(3.0)]);
     assert_eq!(result, Value::Number(1.0));
 }
 
 #[test]
 fn var_p_single_value_returns_zero() {
-    // n=1: mean=5, var=0/1=0
     assert_eq!(var_p_fn(&[Value::Number(5.0)]), Value::Number(0.0));
 }
 
 #[test]
-fn var_p_ignores_bool_and_text() {
-    // Only numbers: [2, 6] → mean=4, var=(4+4)/2=4
+fn var_p_bool_coerces_to_number() {
+    // TRUE->1, FALSE->0; [2,6,1,0]: pop var=20.75/4
     let result = var_p_fn(&[
-        Value::Number(2.0),
-        Value::Number(6.0),
-        Value::Bool(true),
-        Value::Text("x".to_string()),
+        Value::Number(2.0), Value::Number(6.0), Value::Bool(true), Value::Bool(false),
     ]);
-    assert_eq!(result, Value::Number(4.0));
+    if let Value::Number(v) = result {
+        assert!((v - 20.75_f64/4.0).abs() < 1e-10);
+    } else { panic!("Expected Number, got {:?}", result); }
 }

--- a/crates/core/src/eval/functions/statistical/var_s/mod.rs
+++ b/crates/core/src/eval/functions/statistical/var_s/mod.rs
@@ -1,28 +1,19 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_nums_direct;
 
-/// `VAR.S(value1, ...)` — sample variance: Σ(x-mean)²/(n-1).
-/// Requires n≥2. Returns `#DIV/0!` if fewer than 2 numeric values.
+/// `VAR.S(value1, ...)` — sample variance.
 pub fn var_s_fn(args: &[Value]) -> Value {
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
-    }
-    let nums = collect_nums(args);
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     sample_variance(&nums)
 }
 
-/// Compute sample variance from a slice of f64 values.
 pub(crate) fn sample_variance(nums: &[f64]) -> Value {
     let n = nums.len();
-    if n < 2 {
-        return Value::Error(ErrorKind::DivByZero);
-    }
+    if n < 2 { return Value::Error(ErrorKind::DivByZero); }
     let mean = nums.iter().sum::<f64>() / n as f64;
     let var = nums.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (n - 1) as f64;
-    if !var.is_finite() {
-        return Value::Error(ErrorKind::Num);
-    }
-    Value::Number(var)
+    if !var.is_finite() { Value::Error(ErrorKind::Num) } else { Value::Number(var) }
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/statistical/var_s/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/var_s/tests/failure.rs
@@ -8,15 +8,14 @@ fn var_s_no_args_returns_na() {
 
 #[test]
 fn var_s_one_value_returns_div_zero() {
-    // n < 2 → DivByZero
     assert_eq!(var_s_fn(&[Value::Number(5.0)]), Value::Error(ErrorKind::DivByZero));
 }
 
 #[test]
-fn var_s_no_numeric_values_returns_div_zero() {
+fn var_s_non_numeric_text_returns_value_error() {
     assert_eq!(
-        var_s_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
-        Value::Error(ErrorKind::DivByZero)
+        var_s_fn(&[Value::Text("a".to_string()), Value::Number(2.0)]),
+        Value::Error(ErrorKind::Value)
     );
 }
 

--- a/crates/core/src/eval/functions/statistical/var_s/tests/success.rs
+++ b/crates/core/src/eval/functions/statistical/var_s/tests/success.rs
@@ -3,27 +3,24 @@ use crate::types::Value;
 
 #[test]
 fn var_s_basic() {
-    // [2, 4, 4, 4, 5, 5, 7, 9]: mean=5, sample var=4.571...
-    // Using simpler: [2, 4, 6]: mean=4, var=((2-4)²+(4-4)²+(6-4)²)/(3-1)=8/2=4
+    // [2, 4, 6]: mean=4, sample var=4
     let result = var_s_fn(&[Value::Number(2.0), Value::Number(4.0), Value::Number(6.0)]);
     assert_eq!(result, Value::Number(4.0));
 }
 
 #[test]
 fn var_s_two_values() {
-    // [1, 3]: mean=2, var=((1-2)²+(3-2)²)/1 = 2/1 = 2
     let result = var_s_fn(&[Value::Number(1.0), Value::Number(3.0)]);
     assert_eq!(result, Value::Number(2.0));
 }
 
 #[test]
-fn var_s_ignores_bool_and_text() {
-    // Only numbers counted: [2, 6] → mean=4, sample var=((2-4)²+(6-4)²)/1=8
+fn var_s_bool_coerces_to_number() {
+    // TRUE->1, FALSE->0; [2,6,1,0]: sample var=20.75/3
     let result = var_s_fn(&[
-        Value::Number(2.0),
-        Value::Number(6.0),
-        Value::Bool(true),
-        Value::Text("x".to_string()),
+        Value::Number(2.0), Value::Number(6.0), Value::Bool(true), Value::Bool(false),
     ]);
-    assert_eq!(result, Value::Number(8.0));
+    if let Value::Number(v) = result {
+        assert!((v - 20.75_f64/3.0).abs() < 1e-10);
+    } else { panic!("Expected Number, got {:?}", result); }
 }

--- a/crates/core/src/eval/functions/statistical/vara/mod.rs
+++ b/crates/core/src/eval/functions/statistical/vara/mod.rs
@@ -1,16 +1,11 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums_a;
+use super::stat_helpers::collect_nums_a_direct;
 use super::var_s::sample_variance;
 
-/// `VARA(value1, ...)` — sample variance, text/FALSE=0, TRUE=1.
+/// `VARA(value1, ...)` - sample variance including text/bool.
 pub fn vara_fn(args: &[Value]) -> Value {
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
-    }
-    if args.iter().any(|a| matches!(a, Value::Text(_))) {
-        return Value::Error(ErrorKind::Value);
-    }
-    let nums = collect_nums_a(args);
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_a_direct(args) { Ok(v) => v, Err(e) => return e };
     sample_variance(&nums)
 }
 

--- a/crates/core/src/eval/functions/statistical/vara/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/vara/tests/edge.rs
@@ -3,23 +3,23 @@ use crate::types::Value;
 
 #[test]
 fn vara_true_counts_as_one() {
-    // Bool(true)=1.0 is included; [1.0, 3.0]: mean=2, var=2
+    // [1.0, 3.0]: mean=2, var=2
     let result = vara_fn(&[Value::Bool(true), Value::Number(3.0)]);
     assert_eq!(result, Value::Number(2.0));
 }
 
 #[test]
 fn vara_false_counts_as_zero() {
-    // Bool(false)=0.0 is included; [0.0, 2.0]: mean=1, var=2
+    // [0.0, 2.0]: mean=1, var=2
     let result = vara_fn(&[Value::Bool(false), Value::Number(2.0)]);
     assert_eq!(result, Value::Number(2.0));
 }
 
 #[test]
-fn vara_text_returns_value_error() {
-    // Literal text as direct arg → #VALUE! (Google Sheets)
+fn vara_non_parseable_text_counts_as_zero() {
+    // AVERAGEA semantics: text -> 0.0; [0.0, 4.0]: sample var=8
     let result = vara_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    assert_eq!(result, Value::Error(crate::types::ErrorKind::Value));
+    assert_eq!(result, Value::Number(8.0));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/vara/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/vara/tests/edge.rs
@@ -16,10 +16,11 @@ fn vara_false_counts_as_zero() {
 }
 
 #[test]
-fn vara_non_parseable_text_counts_as_zero() {
-    // AVERAGEA semantics: text -> 0.0; [0.0, 4.0]: sample var=8
+fn vara_non_parseable_text_returns_value_error() {
+    // Direct non-parseable text -> #VALUE! for AVERAGEA semantics
+    use crate::types::ErrorKind;
     let result = vara_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    assert_eq!(result, Value::Number(8.0));
+    assert_eq!(result, Value::Error(ErrorKind::Value));
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/varp/mod.rs
+++ b/crates/core/src/eval/functions/statistical/varp/mod.rs
@@ -1,5 +1,5 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums;
+use super::stat_helpers::collect_nums_direct;
 use super::var_p::pop_variance;
 
 /// `VARP(value1, ...)` — population variance (same as VAR.P).
@@ -7,7 +7,7 @@ pub fn varp_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
-    let nums = collect_nums(args);
+    let nums = match collect_nums_direct(args) { Ok(v) => v, Err(e) => return e };
     pop_variance(&nums)
 }
 

--- a/crates/core/src/eval/functions/statistical/varp/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/varp/tests/edge.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use crate::types::Value;
+use crate::types::{ErrorKind, Value};
 
 #[test]
 fn varp_all_same_values_returns_zero() {
@@ -10,13 +10,13 @@ fn varp_all_same_values_returns_zero() {
 }
 
 #[test]
-fn varp_ignores_bool_and_text() {
-    // Text/bool ignored; [2, 6] → pop var=4
+fn varp_direct_text_returns_value_error() {
+    // Direct non-parseable text → #VALUE!
     let result = varp_fn(&[
         Value::Number(2.0),
         Value::Number(6.0),
         Value::Bool(true),
         Value::Text("x".to_string()),
     ]);
-    assert_eq!(result, Value::Number(4.0));
+    assert_eq!(result, Value::Error(ErrorKind::Value));
 }

--- a/crates/core/src/eval/functions/statistical/varp/tests/failure.rs
+++ b/crates/core/src/eval/functions/statistical/varp/tests/failure.rs
@@ -7,9 +7,10 @@ fn varp_no_args_returns_na() {
 }
 
 #[test]
-fn varp_no_numeric_values_returns_div_zero() {
+fn varp_direct_text_returns_value_error() {
+    // Direct non-parseable text returns #VALUE! (not #DIV/0!)
     assert_eq!(
         varp_fn(&[Value::Text("a".to_string()), Value::Bool(false)]),
-        Value::Error(ErrorKind::DivByZero)
+        Value::Error(ErrorKind::Value)
     );
 }

--- a/crates/core/src/eval/functions/statistical/varpa/mod.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/mod.rs
@@ -2,7 +2,8 @@ use crate::types::{ErrorKind, Value};
 use super::stat_helpers::collect_nums_a_direct;
 use super::var_p::pop_variance;
 
-/// `VARPA(value1, ...)` - population variance including text/bool.
+/// `VARPA(value1, ...)` - population variance including text (→0 in arrays) and bool (→1/0).
+/// Direct non-parseable text → #VALUE!.
 pub fn varpa_fn(args: &[Value]) -> Value {
     if args.is_empty() { return Value::Error(ErrorKind::NA); }
     let nums = match collect_nums_a_direct(args) { Ok(v) => v, Err(e) => return e };

--- a/crates/core/src/eval/functions/statistical/varpa/mod.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/mod.rs
@@ -1,16 +1,11 @@
 use crate::types::{ErrorKind, Value};
-use super::stat_helpers::collect_nums_a;
+use super::stat_helpers::collect_nums_a_direct;
 use super::var_p::pop_variance;
 
-/// `VARPA(value1, ...)` — population variance, text/FALSE=0, TRUE=1.
+/// `VARPA(value1, ...)` - population variance including text/bool.
 pub fn varpa_fn(args: &[Value]) -> Value {
-    if args.is_empty() {
-        return Value::Error(ErrorKind::NA);
-    }
-    if args.iter().any(|a| matches!(a, Value::Text(_))) {
-        return Value::Error(ErrorKind::Value);
-    }
-    let nums = collect_nums_a(args);
+    if args.is_empty() { return Value::Error(ErrorKind::NA); }
+    let nums = match collect_nums_a_direct(args) { Ok(v) => v, Err(e) => return e };
     pop_variance(&nums)
 }
 

--- a/crates/core/src/eval/functions/statistical/varpa/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/tests/edge.rs
@@ -3,32 +3,28 @@ use crate::types::Value;
 
 #[test]
 fn varpa_true_counts_as_one() {
-    // Bool(true)=1.0; single value → pop var=0
     assert_eq!(varpa_fn(&[Value::Bool(true)]), Value::Number(0.0));
 }
 
 #[test]
 fn varpa_false_counts_as_zero() {
-    // Bool(false)=0.0; single value → pop var=0
     assert_eq!(varpa_fn(&[Value::Bool(false)]), Value::Number(0.0));
 }
 
 #[test]
-fn varpa_text_returns_value_error() {
-    // Literal text as direct arg → #VALUE! (Google Sheets)
+fn varpa_non_parseable_text_counts_as_zero() {
+    // AVERAGEA semantics: text -> 0.0; [0.0, 4.0]: pop var=4
     let result = varpa_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    assert_eq!(result, Value::Error(crate::types::ErrorKind::Value));
+    assert_eq!(result, Value::Number(4.0));
 }
 
 #[test]
 fn varpa_bool_and_number() {
-    // [true=1, false=0, 5.0]: mean=2, pop var=((1-2)²+(0-2)²+(5-2)²)/3=(1+4+9)/3=14/3
+    // [true=1, false=0, 5.0]: mean=2, pop var=14/3
     let result = varpa_fn(&[Value::Bool(true), Value::Bool(false), Value::Number(5.0)]);
     if let Value::Number(v) = result {
-        assert!((v - 14.0 / 3.0).abs() < 1e-10);
-    } else {
-        panic!("Expected Number, got {:?}", result);
-    }
+        assert!((v - 14.0/3.0).abs() < 1e-10);
+    } else { panic!("Expected Number, got {:?}", result); }
 }
 
 #[test]

--- a/crates/core/src/eval/functions/statistical/varpa/tests/edge.rs
+++ b/crates/core/src/eval/functions/statistical/varpa/tests/edge.rs
@@ -12,10 +12,11 @@ fn varpa_false_counts_as_zero() {
 }
 
 #[test]
-fn varpa_non_parseable_text_counts_as_zero() {
-    // AVERAGEA semantics: text -> 0.0; [0.0, 4.0]: pop var=4
+fn varpa_non_parseable_text_returns_value_error() {
+    // Direct non-parseable text -> #VALUE! for AVERAGEA semantics
+    use crate::types::ErrorKind;
     let result = varpa_fn(&[Value::Text("hello".to_string()), Value::Number(4.0)]);
-    assert_eq!(result, Value::Number(4.0));
+    assert_eq!(result, Value::Error(ErrorKind::Value));
 }
 
 #[test]

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -474,7 +474,7 @@ macro_rules! conformance_tsv_test_report {
 conformance_tsv_test!(math_conformance,        "math.tsv");
 conformance_tsv_test!(logical_conformance,            "logical.tsv");
 conformance_tsv_test_report!(info_conformance,        "info.tsv");
-conformance_tsv_test_report!(statistical_conformance, "statistical.tsv");
+conformance_tsv_test!(statistical_conformance, "statistical.tsv");
 conformance_tsv_test!(operator_conformance,         "operator.tsv");
 conformance_tsv_test!(text_conformance,        "text.tsv");
 conformance_tsv_test!(date_conformance,        "date.tsv");


### PR DESCRIPTION
Flip `statistical` from report-only to blocking, then fix all failing rows.

Refs #592.