### PR TITLE
fix(eval): financial conformance — align with 2026-06-08 fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
         run: |
           gh run download \
             --repo "$GITHUB_REPOSITORY" \
+            --branch main \
             --name conformance-report \
             --dir baseline/ \
             2>/dev/null || echo "No baseline found (first run or main has no artifact)"

--- a/crates/core/src/eval/functions/financial/bonds/mod.rs
+++ b/crates/core/src/eval/functions/financial/bonds/mod.rs
@@ -159,7 +159,7 @@ pub fn coupon_period_days(pcd: NaiveDate, ncd: NaiveDate, frequency: u32, basis:
     }
 }
 
-fn last_day_of_month(year: i32, month: u32) -> NaiveDate {
+pub fn last_day_of_month(year: i32, month: u32) -> NaiveDate {
     let next_month_start = if month == 12 {
         NaiveDate::from_ymd_opt(year + 1, 1, 1).unwrap()
     } else {
@@ -210,15 +210,34 @@ pub fn months_per_period(frequency: u32) -> i32 {
     12 / frequency as i32
 }
 
+/// Add months to a date using bond EOM convention.
+///
+/// If `eom` is true (maturity was end-of-month), the result is always the
+/// last day of the target month.  Otherwise, use `day` clamped to the target
+/// month's last day.
+pub fn add_months_coupon(date: NaiveDate, months: i32, eom: bool, day: u32) -> NaiveDate {
+    let total_months = date.year() * 12 + date.month() as i32 - 1 + months;
+    let year = total_months / 12;
+    let month = (total_months % 12 + 1) as u32;
+    if eom {
+        last_day_of_month(year, month)
+    } else {
+        NaiveDate::from_ymd_opt(year, month, day)
+            .unwrap_or_else(|| last_day_of_month(year, month))
+    }
+}
+
 /// Previous coupon date on or before settlement.
 ///
 /// Steps backwards from maturity by `months_per_period` until the candidate
-/// is ≤ settlement.
+/// is ≤ settlement.  Uses EOM convention if maturity is end-of-month.
 pub fn prev_coupon_date(settlement: NaiveDate, maturity: NaiveDate, frequency: u32) -> NaiveDate {
     let mpp = months_per_period(frequency);
+    let eom = maturity == last_day_of_month(maturity.year(), maturity.month());
+    let day = maturity.day();
     let mut candidate = maturity;
     while candidate > settlement {
-        candidate = add_months(candidate, -mpp);
+        candidate = add_months_coupon(candidate, -mpp, eom, day);
     }
     candidate
 }
@@ -227,7 +246,9 @@ pub fn prev_coupon_date(settlement: NaiveDate, maturity: NaiveDate, frequency: u
 pub fn next_coupon_date(settlement: NaiveDate, maturity: NaiveDate, frequency: u32) -> NaiveDate {
     let pcd = prev_coupon_date(settlement, maturity, frequency);
     let mpp = months_per_period(frequency);
-    add_months(pcd, mpp)
+    let eom = maturity == last_day_of_month(maturity.year(), maturity.month());
+    let day = maturity.day();
+    add_months_coupon(pcd, mpp, eom, day)
 }
 
 // ---------------------------------------------------------------------------
@@ -313,8 +334,12 @@ pub fn accrint_fn(args: &[Value]) -> Value {
     // for the numerator A, which matches `days_30_360_eu`.
     let mpp = months_per_period(frequency);
     let mut result = 0.0;
+    // Use EOM-aware date stepping: if the issue date is end-of-month,
+    // all coupon dates should also be end-of-month.
+    let loop_eom = issue == last_day_of_month(issue.year(), issue.month());
+    let loop_day = issue.day();
     let mut pcd = issue;
-    let mut ncd = add_months(pcd, mpp);
+    let mut ncd = add_months_coupon(pcd, mpp, loop_eom, loop_day);
 
     loop {
         let period_start = if pcd < issue { issue } else { pcd };
@@ -325,7 +350,7 @@ pub fn accrint_fn(args: &[Value]) -> Value {
                 break;
             }
             pcd = ncd;
-            ncd = add_months(pcd, mpp);
+            ncd = add_months_coupon(pcd, mpp, loop_eom, loop_day);
             continue;
         }
 
@@ -359,7 +384,7 @@ pub fn accrint_fn(args: &[Value]) -> Value {
             break;
         }
         pcd = ncd;
-        ncd = add_months(pcd, mpp);
+        ncd = add_months_coupon(pcd, mpp, loop_eom, loop_day);
     }
 
     if !result.is_finite() {
@@ -390,10 +415,6 @@ pub fn accrintm_fn(args: &[Value]) -> Value {
         Ok(n) => n,
         Err(e) => return e,
     };
-    // Text par value must return #VALUE!
-    if matches!(args[3], Value::Text(_)) {
-        return Value::Error(ErrorKind::Value);
-    }
     let par = match to_number(args[3].clone()) {
         Ok(n) => n,
         Err(e) => return e,
@@ -540,13 +561,15 @@ pub fn coupnum_fn(args: &[Value]) -> Value {
         Err(e) => return e,
     };
     let mpp = months_per_period(frequency);
-    // Count from NCD to maturity
+    // Count from NCD to maturity using EOM-aware stepping keyed on maturity
     let ncd = next_coupon_date(settlement, maturity, frequency);
+    let mat_eom = maturity == last_day_of_month(maturity.year(), maturity.month());
+    let mat_day = maturity.day();
     // Number of coupon periods from ncd to maturity
     let mut count = 1u32;
     let mut cur = ncd;
     while cur < maturity {
-        let next = add_months(cur, mpp);
+        let next = add_months_coupon(cur, mpp, mat_eom, mat_day);
         if next > maturity {
             break;
         }
@@ -820,9 +843,11 @@ pub fn price_calc(
     let n = {
         let mut count = 1i32;
         let mpp = months_per_period(frequency);
+        let mat_eom = maturity == last_day_of_month(maturity.year(), maturity.month());
+        let mat_day = maturity.day();
         let mut cur = ncd;
         while cur < maturity {
-            let next = add_months(cur, mpp);
+            let next = add_months_coupon(cur, mpp, mat_eom, mat_day);
             if next > maturity {
                 break;
             }

--- a/crates/core/src/eval/functions/financial/bonds/mod.rs
+++ b/crates/core/src/eval/functions/financial/bonds/mod.rs
@@ -168,8 +168,24 @@ fn last_day_of_month(year: i32, month: u32) -> NaiveDate {
     next_month_start - Duration::days(1)
 }
 
-fn is_last_day_of_month(date: NaiveDate) -> bool {
-    date == last_day_of_month(date.year(), date.month())
+/// Count Feb 29 occurrences in [start, end) (exclusive end).
+/// Used for basis=3 (Actual/365) where Google Sheets excludes leap days.
+fn count_feb29(start: NaiveDate, end: NaiveDate) -> i64 {
+    if start >= end {
+        return 0;
+    }
+    let mut count = 0i64;
+    let mut year = start.year();
+    let end_year = end.year();
+    while year <= end_year {
+        if let Some(feb29) = NaiveDate::from_ymd_opt(year, 2, 29) {
+            if feb29 >= start && feb29 < end {
+                count += 1;
+            }
+        }
+        year += 1;
+    }
+    count
 }
 
 /// Add months to a date, snapping to end-of-month if necessary.
@@ -183,11 +199,6 @@ pub fn add_months(date: NaiveDate, months: i32) -> NaiveDate {
     let total_months = date.year() * 12 + date.month() as i32 - 1 + months;
     let year = total_months / 12;
     let month = (total_months % 12 + 1) as u32;
-
-    if is_last_day_of_month(date) {
-        // Preserve EOM: return last day of target month
-        return last_day_of_month(year, month);
-    }
 
     let day = date.day();
     NaiveDate::from_ymd_opt(year, month, day)
@@ -246,6 +257,10 @@ pub fn accrint_fn(args: &[Value]) -> Value {
         Ok(n) => n,
         Err(e) => return e,
     };
+    // Text par value must return #VALUE! (text coercion not allowed for par)
+    if matches!(args[4], Value::Text(_)) {
+        return Value::Error(ErrorKind::Value);
+    }
     let par = match to_number(args[4].clone()) {
         Ok(n) => n,
         Err(e) => return e,
@@ -281,8 +296,11 @@ pub fn accrint_fn(args: &[Value]) -> Value {
         None => return Value::Error(ErrorKind::Value),
     };
 
-    if settlement <= issue {
+    if settlement < issue {
         return Value::Error(ErrorKind::Num);
+    }
+    if settlement == issue {
+        return Value::Number(0.0);
     }
 
     // ACCRINT sums over coupon periods from issue to settlement.
@@ -323,6 +341,15 @@ pub fn accrint_fn(args: &[Value]) -> Value {
             days_between(period_start, period_end, basis) as f64
         };
         let e = coupon_period_days(pcd, ncd, frequency, basis);
+        // basis=2 (Actual/360): cap a at e so A/E never exceeds 1 for a full coupon period.
+        let a = if basis == 2 { a.min(e) } else { a };
+        // basis=3 (Actual/365): Google Sheets excludes Feb 29 from the numerator
+        // (every year is treated as exactly 365 days). Subtract leap days in [period_start, period_end).
+        let a = if basis == 3 && !(is_last && period_end == ncd) {
+            a - count_feb29(period_start, period_end) as f64
+        } else {
+            a
+        };
 
         if e > 0.0 {
             result += par * (rate / frequency as f64) * (a / e);
@@ -363,6 +390,10 @@ pub fn accrintm_fn(args: &[Value]) -> Value {
         Ok(n) => n,
         Err(e) => return e,
     };
+    // Text par value must return #VALUE!
+    if matches!(args[3], Value::Text(_)) {
+        return Value::Error(ErrorKind::Value);
+    }
     let par = match to_number(args[3].clone()) {
         Ok(n) => n,
         Err(e) => return e,
@@ -390,8 +421,11 @@ pub fn accrintm_fn(args: &[Value]) -> Value {
         None => return Value::Error(ErrorKind::Value),
     };
 
-    if settlement <= issue {
+    if settlement < issue {
         return Value::Error(ErrorKind::Num);
+    }
+    if settlement == issue {
+        return Value::Number(0.0);
     }
 
     let yf = yearfrac(issue, settlement, basis);
@@ -488,7 +522,7 @@ pub fn coupncd_fn(args: &[Value]) -> Value {
         Err(e) => return e,
     };
     let ncd = next_coupon_date(settlement, maturity, frequency);
-    Value::Number(date_to_serial(ncd))
+    Value::Date(date_to_serial(ncd))
 }
 
 // ---------------------------------------------------------------------------
@@ -537,7 +571,7 @@ pub fn couppcd_fn(args: &[Value]) -> Value {
         Err(e) => return e,
     };
     let pcd = prev_coupon_date(settlement, maturity, frequency);
-    Value::Number(date_to_serial(pcd))
+    Value::Date(date_to_serial(pcd))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/core/src/eval/functions/financial/misc/mod.rs
+++ b/crates/core/src/eval/functions/financial/misc/mod.rs
@@ -145,11 +145,24 @@ pub fn ppmt_fn(args: &[Value]) -> Value {
 /// `CUMIPMT(rate, nper, pv, start_period, end_period, type)`
 ///
 /// Cumulative interest paid between start and end period (inclusive).
+/// Parse a number value, also accepting a percent string like "10%" → 0.1.
+fn coerce_percent_or_number(v: Value) -> Result<f64, Value> {
+    if let Value::Text(ref s) = v {
+        let trimmed = s.trim();
+        if let Some(without_pct) = trimmed.strip_suffix('%') {
+            return without_pct.trim().parse::<f64>()
+                .map(|n| n / 100.0)
+                .map_err(|_| Value::Error(ErrorKind::Value));
+        }
+    }
+    to_number(v)
+}
+
 pub fn cumipmt_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 6, 6) {
         return err;
     }
-    let rate   = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    let rate   = match coerce_percent_or_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
     let nper   = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
     let pv     = match to_number(args[2].clone()) { Ok(n) => n, Err(e) => return e };
     let start  = match to_number(args[3].clone()) { Ok(n) => n, Err(e) => return e };
@@ -301,7 +314,12 @@ pub fn syd_fn(args: &[Value]) -> Value {
         return err;
     }
     let cost    = match to_number(args[0].clone()) { Ok(n) => n, Err(e) => return e };
+    // GS: if salvage is a text string whose numeric value is negative, return #NUM!
+    let salvage_is_text = matches!(args[1], Value::Text(_));
     let salvage = match to_number(args[1].clone()) { Ok(n) => n, Err(e) => return e };
+    if salvage_is_text && salvage < 0.0 {
+        return Value::Error(ErrorKind::Num);
+    }
     let life    = match to_number(args[2].clone()) { Ok(n) => n, Err(e) => return e };
     let per     = match to_number(args[3].clone()) { Ok(n) => n, Err(e) => return e };
 
@@ -895,6 +913,10 @@ fn flatten_array(v: Value) -> Result<Vec<f64>, Value> {
                         for sub in flatten_array(Value::Array(inner))? {
                             out.push(sub);
                         }
+                    }
+                    // Empty string in an array literal is an error (GS: #VALUE!)
+                    Value::Text(ref s) if s.is_empty() => {
+                        return Err(Value::Error(ErrorKind::Value));
                     }
                     other => out.push(to_number(other)?),
                 }

--- a/crates/core/src/eval/functions/financial/misc/mod.rs
+++ b/crates/core/src/eval/functions/financial/misc/mod.rs
@@ -827,7 +827,7 @@ fn duration_calc(args: &[Value], _modified: bool) -> Result<f64, Value> {
     use crate::eval::functions::date::serial::serial_to_date;
     use crate::eval::functions::financial::bonds::{
         coupon_period_days, days_between, months_per_period, next_coupon_date,
-        prev_coupon_date, add_months, validate_basis, validate_frequency,
+        prev_coupon_date, add_months_coupon, last_day_of_month, validate_basis, validate_frequency,
     };
 
     let settlement_s = to_number(args[0].clone())?;
@@ -860,8 +860,10 @@ fn duration_calc(args: &[Value], _modified: bool) -> Result<f64, Value> {
     let days_to_ncd = days_between(settlement, ncd, basis) as f64;
     let dsc_e = days_to_ncd / period_days;
 
-    // Count coupons
+    // Count coupons using EOM-aware stepping keyed on maturity
     let mpp = months_per_period(frequency);
+    let mat_eom = maturity == last_day_of_month(maturity.year(), maturity.month());
+    let mat_day = maturity.day();
     let mut coupon_dates: Vec<f64> = Vec::new();
     let mut t = dsc_e; // fractional periods from settlement to first coupon
     let mut cur = ncd;
@@ -870,7 +872,7 @@ fn duration_calc(args: &[Value], _modified: bool) -> Result<f64, Value> {
         if cur >= maturity {
             break;
         }
-        cur = add_months(cur, mpp);
+        cur = add_months_coupon(cur, mpp, mat_eom, mat_day);
         t += 1.0;
         if t > 1000.0 { break; } // safety
     }

--- a/crates/core/src/eval/functions/financial/misc/mod.rs
+++ b/crates/core/src/eval/functions/financial/misc/mod.rs
@@ -824,6 +824,7 @@ pub fn mduration_fn(args: &[Value]) -> Value {
 }
 
 fn duration_calc(args: &[Value], _modified: bool) -> Result<f64, Value> {
+    use chrono::Datelike;
     use crate::eval::functions::date::serial::serial_to_date;
     use crate::eval::functions::financial::bonds::{
         coupon_period_days, days_between, months_per_period, next_coupon_date,

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -474,7 +474,7 @@ conformance_tsv_test!(database_conformance,    "database.tsv");
 conformance_tsv_test_report!(array_conformance,       "array.tsv");
 conformance_tsv_test!(filter_conformance,             "filter.tsv");
 conformance_tsv_test!(web_conformance,         "web.tsv");
-conformance_tsv_test_report!(financial_conformance,   "financial.tsv");
+conformance_tsv_test!(financial_conformance,         "financial.tsv");
 
 /// P1.5 workbook fixtures — cross-sheet refs, named ranges, date-typed scalars
 /// (pipeline-generated, core issue #527; registered via PR #562).

--- a/crates/core/tests/conformance_reporter.rs
+++ b/crates/core/tests/conformance_reporter.rs
@@ -22,6 +22,7 @@ fn parse_expected(value: &str, expected_type: &str) -> Option<Value> {
             _       => None,
         },
         "error" => parse_error_string(value).map(Value::Error),
+        "date" => value.parse::<f64>().ok().map(Value::Number),
         "string" | "array" => Some(Value::Text(value.to_string())),
         _ => Some(Value::Text(value.to_string())),
     }


### PR DESCRIPTION
Fixes the `financial` conformance category against the refreshed 2026-06-08 Google Sheets fixtures and flips it from report-only to blocking.

Refs #592