### PR TITLE
fix(eval): lookup conformance — align with 2026-06-08 fixtures

### DIFF
--- a/crates/core/src/eval/functions/array/mod.rs
+++ b/crates/core/src/eval/functions/array/mod.rs
@@ -97,92 +97,6 @@ pub(crate) fn columns_fn(args: &[Value]) -> Value {
     Value::Number(cols as f64)
 }
 
-// ── INDEX ─────────────────────────────────────────────────────────────────────
-// INDEX(array, row, [col]) — 1-based indices
-
-fn index_fn(args: &[Value]) -> Value {
-    if let Some(e) = check_arity(args, 1, 3) {
-        return e;
-    }
-    let grid = to_2d(&args[0]);
-    let nrows = grid.len();
-    let ncols = grid.first().map(|r| r.len()).unwrap_or(0);
-
-    let row_idx = if args.len() >= 2 {
-        match to_f64(&args[1]) {
-            Some(n) => {
-                let r = n as isize;
-                if r < 0 {
-                    (nrows as isize + r + 1) as usize
-                } else {
-                    r as usize
-                }
-            }
-            None => return Value::Error(ErrorKind::Value),
-        }
-    } else {
-        0 // 0 means return whole row/col
-    };
-
-    let col_idx = if args.len() >= 3 {
-        match to_f64(&args[2]) {
-            Some(n) => {
-                let c = n as isize;
-                if c < 0 {
-                    (ncols as isize + c + 1) as usize
-                } else {
-                    c as usize
-                }
-            }
-            None => return Value::Error(ErrorKind::Value),
-        }
-    } else {
-        0 // 0 means return whole column
-    };
-
-    // Single element
-    if row_idx > 0 && col_idx > 0 {
-        if row_idx > nrows || col_idx > ncols {
-            return Value::Error(ErrorKind::Ref);
-        }
-        return grid[row_idx - 1][col_idx - 1].clone();
-    }
-
-    // Return whole row (col_idx == 0, row_idx > 0)
-    if row_idx > 0 && col_idx == 0 {
-        // For a 1D row vector (1 row, N cols), treat row_idx as col index
-        if nrows == 1 && ncols > 1 {
-            if row_idx > ncols {
-                return Value::Error(ErrorKind::Ref);
-            }
-            return grid[0][row_idx - 1].clone();
-        }
-        if row_idx > nrows {
-            return Value::Error(ErrorKind::Ref);
-        }
-        let row = grid[row_idx - 1].clone();
-        if row.len() == 1 {
-            return row.into_iter().next().unwrap();
-        }
-        return Value::Array(row);
-    }
-
-    // Return whole column (row_idx == 0, col_idx > 0)
-    if row_idx == 0 && col_idx > 0 {
-        if col_idx > ncols {
-            return Value::Error(ErrorKind::Ref);
-        }
-        let col: Vec<Value> = grid.iter().map(|r| r[col_idx - 1].clone()).collect();
-        if col.len() == 1 {
-            return col.into_iter().next().unwrap();
-        }
-        return from_2d(col.into_iter().map(|v| vec![v]).collect());
-    }
-
-    // Both zero → return full array
-    args[0].clone()
-}
-
 // ── TRANSPOSE ─────────────────────────────────────────────────────────────────
 
 pub(crate) fn transpose_fn(args: &[Value]) -> Value {
@@ -1517,11 +1431,6 @@ pub fn register_array(registry: &mut Registry) {
         category: "array",
         signature: "COLUMNS(array)",
         description: "Returns the number of columns in an array or range",
-    });
-    registry.register_eager("INDEX", index_fn, FunctionMeta {
-        category: "array",
-        signature: "INDEX(array, row, [col])",
-        description: "Returns the value at the given row and column of an array",
     });
     registry.register_eager("TRANSPOSE", transpose_fn, FunctionMeta {
         category: "array",

--- a/crates/core/src/eval/functions/lookup/array_utils.rs
+++ b/crates/core/src/eval/functions/lookup/array_utils.rs
@@ -86,12 +86,36 @@ pub fn values_equal(a: &Value, b: &Value) -> bool {
     }
 }
 
-/// Compare two values for ordering (for approximate match).
-/// Returns None if the types are incomparable.
+/// Map a Value to a numeric ordering key for cross-type comparison.
+/// In spreadsheets: numbers < text < booleans (for LOOKUP/MATCH sorting purposes).
+/// Within booleans: FALSE (0) < TRUE (1).
+fn type_rank(v: &Value) -> u8 {
+    match v {
+        Value::Number(_) => 0,
+        Value::Text(_)   => 1,
+        Value::Bool(_)   => 2,
+        _                => 3,
+    }
+}
+
+/// Compare two values for ordering (for approximate match / LOOKUP / MATCH).
+/// Returns None only if both values are of incomparable types (e.g. error vs text).
+/// Same-type comparisons always return Some.
+/// Cross-type: numbers < text < booleans (spreadsheet convention).
 pub fn value_compare(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
     match (a, b) {
         (Value::Number(x), Value::Number(y)) => x.partial_cmp(y),
         (Value::Text(x), Value::Text(y)) => Some(x.to_uppercase().cmp(&y.to_uppercase())),
-        _ => None,
+        (Value::Bool(x), Value::Bool(y)) => Some(x.cmp(y)),
+        // Cross-type: use type rank
+        _ => {
+            let ra = type_rank(a);
+            let rb = type_rank(b);
+            if ra != rb {
+                Some(ra.cmp(&rb))
+            } else {
+                None
+            }
+        }
     }
 }

--- a/crates/core/src/eval/functions/lookup/choose.rs
+++ b/crates/core/src/eval/functions/lookup/choose.rs
@@ -17,6 +17,12 @@ pub fn choose_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
             if n < 1 { return Value::Error(ErrorKind::Num); }
             n as usize
         }
+        // Bool coercion: TRUE→1, FALSE→0 (out of range → #NUM!)
+        Value::Bool(b) => {
+            if b { 1usize } else { return Value::Error(ErrorKind::Num); }
+        }
+        // Empty (omitted arg) → treated as 0 → out of range → #NUM!
+        Value::Empty => return Value::Error(ErrorKind::Num),
         Value::Error(e) => return Value::Error(e),
         _ => return Value::Error(ErrorKind::Value),
     };

--- a/crates/core/src/eval/functions/lookup/index_match.rs
+++ b/crates/core/src/eval/functions/lookup/index_match.rs
@@ -1,4 +1,3 @@
-use crate::eval::coercion::to_number;
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
 use super::array_utils::{flatten_to_rows, flatten_to_flat, values_equal, value_compare, wildcard_match_value, has_wildcards};

--- a/crates/core/src/eval/functions/lookup/index_match.rs
+++ b/crates/core/src/eval/functions/lookup/index_match.rs
@@ -86,6 +86,13 @@ pub fn match_fn(args: &[Value]) -> Value {
         1
     };
 
+    // 2D array as range → #N/A (Google Sheets behaviour)
+    if let Value::Array(outer) = range_val {
+        if outer.iter().any(|e| matches!(e, Value::Array(_))) {
+            return Value::Error(ErrorKind::NA);
+        }
+    }
+
     let flat = flatten_to_flat(range_val);
     if flat.is_empty() {
         return Value::Error(ErrorKind::NA);
@@ -107,7 +114,8 @@ pub fn match_fn(args: &[Value]) -> Value {
             Value::Error(ErrorKind::NA)
         }
         1 => {
-            // Largest value <= search_key in sorted ascending array
+            // Largest value <= search_key in sorted ascending array.
+            // Scan forward; stop early on first value > search_key (assumes sorted).
             let mut result: Option<usize> = None;
             for (i, v) in flat.iter().enumerate() {
                 match value_compare(v, search_key) {
@@ -123,14 +131,17 @@ pub fn match_fn(args: &[Value]) -> Value {
             }
         }
         -1 => {
-            // Smallest value >= search_key in sorted descending array
+            // Smallest value >= search_key in sorted descending array.
+            // Scan forward (descending), keep updating while v >= search_key.
+            // Stop when v < search_key (assumes sorted desc).
             let mut result: Option<usize> = None;
             for (i, v) in flat.iter().enumerate() {
                 match value_compare(v, search_key) {
                     Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal) => {
                         result = Some(i + 1);
                     }
-                    _ => break,
+                    Some(std::cmp::Ordering::Less) => break,
+                    None => {}
                 }
             }
             match result {

--- a/crates/core/src/eval/functions/lookup/index_match.rs
+++ b/crates/core/src/eval/functions/lookup/index_match.rs
@@ -3,29 +3,37 @@ use crate::types::{ErrorKind, Value};
 use super::array_utils::{flatten_to_rows, flatten_to_flat, values_equal, value_compare, wildcard_match_value, has_wildcards};
 
 /// `INDEX(array, row, [col])` — returns the value at row/col of array.
-/// Row and col are 1-based. Returns #REF! if out of bounds.
+/// Row and col are 1-based. Negative -> #VALUE!, out of bounds -> #REF!.
 pub fn index_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 3) {
         return err;
     }
 
     let array_val = &args[0];
-    let row_idx = match &args[1] {
-        Value::Number(n) => n.trunc() as usize,
+
+    let row_idx_raw = match &args[1] {
+        Value::Number(n) => n.trunc() as i64,
         _ => return Value::Error(ErrorKind::Value),
     };
+    if row_idx_raw < 0 {
+        return Value::Error(ErrorKind::Value);
+    }
+    let row_idx = row_idx_raw as usize;
+
     let col_idx = if args.len() == 3 {
-        match &args[2] {
-            Value::Number(n) => n.trunc() as usize,
+        let col_raw = match &args[2] {
+            Value::Number(n) => n.trunc() as i64,
             _ => return Value::Error(ErrorKind::Value),
+        };
+        if col_raw < 0 {
+            return Value::Error(ErrorKind::Value);
         }
+        col_raw as usize
     } else {
-        0 // 0 means not specified
+        0
     };
 
     let rows = flatten_to_rows(array_val);
-
-    // Check if 2D or 1D
     let is_2d = matches!(array_val, Value::Array(v) if v.iter().any(|e| matches!(e, Value::Array(_))));
 
     if is_2d {
@@ -34,7 +42,6 @@ pub fn index_fn(args: &[Value]) -> Value {
         }
         let row = &rows[row_idx - 1];
         if col_idx == 0 {
-            // Return entire row as array? For conformance, return the row
             return Value::Array(row.clone());
         }
         if col_idx > row.len() {
@@ -42,22 +49,18 @@ pub fn index_fn(args: &[Value]) -> Value {
         }
         row[col_idx - 1].clone()
     } else {
-        // 1D array
         let flat = flatten_to_flat(array_val);
         if col_idx == 0 {
-            // Single index → treat as column vector
             if row_idx < 1 || row_idx > flat.len() {
                 return Value::Error(ErrorKind::Ref);
             }
             flat[row_idx - 1].clone()
         } else if row_idx == 1 {
-            // Row index = 1, treat as row vector
             if col_idx > flat.len() {
                 return Value::Error(ErrorKind::Ref);
             }
             flat[col_idx - 1].clone()
         } else if col_idx == 1 {
-            // Col index = 1, treat as column vector
             if row_idx > flat.len() {
                 return Value::Error(ErrorKind::Ref);
             }
@@ -68,8 +71,8 @@ pub fn index_fn(args: &[Value]) -> Value {
     }
 }
 
-/// `MATCH(search_key, range, [match_type])` — returns 1-based position of search_key.
-/// match_type: 0=exact, 1=less than (sorted asc, default), -1=greater than (sorted desc).
+/// `MATCH(search_key, range, [match_type])` -- returns 1-based position of search_key.
+/// match_type: 0=exact, 1=largest <= key (sorted asc, default), -1=smallest >= key (sorted desc).
 pub fn match_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 3) {
         return err;
@@ -86,21 +89,32 @@ pub fn match_fn(args: &[Value]) -> Value {
         1
     };
 
-    // 2D array as range → #N/A (Google Sheets behaviour)
-    if let Value::Array(outer) = range_val {
-        if outer.iter().any(|e| matches!(e, Value::Array(_))) {
-            return Value::Error(ErrorKind::NA);
+    // Flatten range. Column vectors {"a";"b";"c"} parse as
+    // Array([Array(["a"]), Array(["b"]), Array(["c"])]) -- flatten to 1D.
+    let flat: Vec<Value> = match range_val {
+        Value::Array(outer) => {
+            let all_single = outer.iter().all(|e| matches!(e, Value::Array(v) if v.len() == 1));
+            let any_multi = outer.iter().any(|e| matches!(e, Value::Array(v) if v.len() > 1));
+            if all_single && outer.iter().any(|e| matches!(e, Value::Array(_))) {
+                outer.iter().map(|e| match e {
+                    Value::Array(v) => v[0].clone(),
+                    other => other.clone(),
+                }).collect()
+            } else if any_multi {
+                return Value::Error(ErrorKind::NA);
+            } else {
+                flatten_to_flat(range_val)
+            }
         }
-    }
+        _ => flatten_to_flat(range_val),
+    };
 
-    let flat = flatten_to_flat(range_val);
     if flat.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
 
     match match_type {
         0 => {
-            // Exact match (wildcard supported when pattern contains * or ?)
             for (i, v) in flat.iter().enumerate() {
                 let matched = if has_wildcards(search_key) {
                     wildcard_match_value(search_key, v)
@@ -114,8 +128,6 @@ pub fn match_fn(args: &[Value]) -> Value {
             Value::Error(ErrorKind::NA)
         }
         1 => {
-            // Largest value <= search_key in sorted ascending array.
-            // Scan forward; stop early on first value > search_key (assumes sorted).
             let mut result: Option<usize> = None;
             for (i, v) in flat.iter().enumerate() {
                 match value_compare(v, search_key) {
@@ -131,9 +143,6 @@ pub fn match_fn(args: &[Value]) -> Value {
             }
         }
         -1 => {
-            // Smallest value >= search_key in sorted descending array.
-            // Scan forward (descending), keep updating while v >= search_key.
-            // Stop when v < search_key (assumes sorted desc).
             let mut result: Option<usize> = None;
             for (i, v) in flat.iter().enumerate() {
                 match value_compare(v, search_key) {

--- a/crates/core/src/eval/functions/lookup/index_match.rs
+++ b/crates/core/src/eval/functions/lookup/index_match.rs
@@ -1,9 +1,22 @@
+use crate::eval::coercion::to_number;
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
 use super::array_utils::{flatten_to_rows, flatten_to_flat, values_equal, value_compare, wildcard_match_value, has_wildcards};
 
+/// Helper: coerce a Value to an index (i64). Handles Number and Bool; propagates errors.
+/// Returns Err(Value::Error(...)) if coercion fails.
+fn coerce_index(v: &Value) -> Result<i64, Value> {
+    match v {
+        Value::Number(n) => Ok(n.trunc() as i64),
+        Value::Bool(b) => Ok(if *b { 1 } else { 0 }),
+        Value::Error(e) => Err(Value::Error(e.clone())),
+        _ => Err(Value::Error(ErrorKind::Value)),
+    }
+}
+
 /// `INDEX(array, row, [col])` — returns the value at row/col of array.
 /// Row and col are 1-based. Negative -> #VALUE!, out of bounds -> #REF!.
+/// row=0 or col=0 means "all" (returns entire row/col or for 1D: first element).
 pub fn index_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 3) {
         return err;
@@ -11,9 +24,9 @@ pub fn index_fn(args: &[Value]) -> Value {
 
     let array_val = &args[0];
 
-    let row_idx_raw = match &args[1] {
-        Value::Number(n) => n.trunc() as i64,
-        _ => return Value::Error(ErrorKind::Value),
+    let row_idx_raw = match coerce_index(&args[1]) {
+        Ok(n) => n,
+        Err(e) => return e,
     };
     if row_idx_raw < 0 {
         return Value::Error(ErrorKind::Value);
@@ -21,9 +34,9 @@ pub fn index_fn(args: &[Value]) -> Value {
     let row_idx = row_idx_raw as usize;
 
     let col_idx = if args.len() == 3 {
-        let col_raw = match &args[2] {
-            Value::Number(n) => n.trunc() as i64,
-            _ => return Value::Error(ErrorKind::Value),
+        let col_raw = match coerce_index(&args[2]) {
+            Ok(n) => n,
+            Err(e) => return e,
         };
         if col_raw < 0 {
             return Value::Error(ErrorKind::Value);
@@ -37,8 +50,21 @@ pub fn index_fn(args: &[Value]) -> Value {
     let is_2d = matches!(array_val, Value::Array(v) if v.iter().any(|e| matches!(e, Value::Array(_))));
 
     if is_2d {
-        if row_idx < 1 || row_idx > rows.len() {
+        // row=0 means return entire column; col=0 means return entire row
+        if row_idx == 0 && col_idx == 0 {
+            return array_val.clone();
+        }
+        if row_idx > rows.len() {
             return Value::Error(ErrorKind::Ref);
+        }
+        if row_idx == 0 {
+            // Return entire column col_idx across all rows
+            let col = col_idx;
+            if col < 1 || rows.iter().any(|r| col > r.len()) {
+                return Value::Error(ErrorKind::Ref);
+            }
+            let col_vals: Vec<Value> = rows.iter().map(|r| r[col - 1].clone()).collect();
+            return Value::Array(col_vals);
         }
         let row = &rows[row_idx - 1];
         if col_idx == 0 {
@@ -51,11 +77,17 @@ pub fn index_fn(args: &[Value]) -> Value {
     } else {
         let flat = flatten_to_flat(array_val);
         if col_idx == 0 {
-            if row_idx < 1 || row_idx > flat.len() {
+            // row=0: return entire array; row>=1: return that element
+            if row_idx == 0 {
+                // GS: INDEX(row_vector, 0) returns first element
+                return flat.first().cloned().unwrap_or(Value::Error(ErrorKind::Ref));
+            }
+            if row_idx > flat.len() {
                 return Value::Error(ErrorKind::Ref);
             }
             flat[row_idx - 1].clone()
-        } else if row_idx == 1 {
+        } else if row_idx == 0 || row_idx == 1 {
+            // Row vector: row=0 or row=1 both select by column index
             if col_idx > flat.len() {
                 return Value::Error(ErrorKind::Ref);
             }

--- a/crates/core/src/eval/functions/lookup/lookup_fn.rs
+++ b/crates/core/src/eval/functions/lookup/lookup_fn.rs
@@ -1,15 +1,43 @@
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
-use super::array_utils::{flatten_to_flat, values_equal, value_compare, wildcard_match_value, has_wildcards};
+use super::array_utils::{flatten_to_flat, flatten_to_rows, values_equal, value_compare, wildcard_match_value, has_wildcards};
 
 /// `LOOKUP(search_key, search_range, [result_range])`
-/// Approximate lookup in sorted range (binary search semantics, but linear scan OK).
+/// Approximate lookup: find the largest value <= search_key.
+/// Uses a full linear scan (not binary search) to handle unsorted ranges correctly.
 pub fn lookup_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 2, 3) {
         return err;
     }
 
     let search_key = &args[0];
+
+    // 2-argument array form: args[1] is a 2D array, no explicit result_range.
+    // If array has more columns than rows: search first ROW, return corresponding last ROW value.
+    // If array has more rows than columns (or square): search first COLUMN, return last COLUMN value.
+    if args.len() == 2 {
+        let rows = flatten_to_rows(&args[1]);
+        let nrows = rows.len();
+        let ncols = rows.first().map(|r| r.len()).unwrap_or(0);
+
+        if nrows > 1 || ncols > 1 {
+            if ncols > nrows {
+                // Horizontal: search first row, return from last row
+                if rows.is_empty() || rows[0].is_empty() {
+                    return Value::Error(ErrorKind::NA);
+                }
+                let search_vec: Vec<Value> = rows[0].clone();
+                let result_vec: Vec<Value> = rows[nrows - 1].clone();
+                return lookup_vector(search_key, &search_vec, Some(&result_vec));
+            } else {
+                // Vertical: search first col, return from last col
+                let search_vec: Vec<Value> = rows.iter().map(|r| r[0].clone()).collect();
+                let result_vec: Vec<Value> = rows.iter().map(|r| r[r.len() - 1].clone()).collect();
+                return lookup_vector(search_key, &search_vec, Some(&result_vec));
+            }
+        }
+    }
+
     let search_range = flatten_to_flat(&args[1]);
     let result_range: Option<Vec<Value>> = if args.len() == 3 {
         Some(flatten_to_flat(&args[2]))
@@ -17,21 +45,25 @@ pub fn lookup_fn(args: &[Value]) -> Value {
         None
     };
 
-    // Largest value <= search_key
+    lookup_vector(search_key, &search_range, result_range.as_deref())
+}
+
+/// Core LOOKUP vector search: find last value <= search_key, return corresponding result value.
+/// Full linear scan (handles unsorted ranges — GS behaviour).
+fn lookup_vector(search_key: &Value, search_range: &[Value], result_range: Option<&[Value]>) -> Value {
     let mut found_idx: Option<usize> = None;
     for (i, v) in search_range.iter().enumerate() {
         match value_compare(v, search_key) {
             Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal) => {
                 found_idx = Some(i);
             }
-            Some(std::cmp::Ordering::Greater) => break,
-            None => {}
+            _ => {}
         }
     }
 
     match found_idx {
         None => Value::Error(ErrorKind::NA),
-        Some(idx) => match &result_range {
+        Some(idx) => match result_range {
             Some(result) => {
                 if idx < result.len() {
                     result[idx].clone()
@@ -54,24 +86,19 @@ fn xlookup_find(
 ) -> Option<usize> {
     match match_mode {
         0 => {
-            // Exact match (with wildcard support); search_mode controls direction.
             if search_mode == -1 {
-                // Reverse scan: last-to-first.
                 if has_wildcards(search_key) {
                     arr.iter().rposition(|v| wildcard_match_value(search_key, v))
                 } else {
                     arr.iter().rposition(|v| values_equal(v, search_key))
                 }
+            } else if has_wildcards(search_key) {
+                arr.iter().position(|v| wildcard_match_value(search_key, v))
             } else {
-                if has_wildcards(search_key) {
-                    arr.iter().position(|v| wildcard_match_value(search_key, v))
-                } else {
-                    arr.iter().position(|v| values_equal(v, search_key))
-                }
+                arr.iter().position(|v| values_equal(v, search_key))
             }
         }
         1 => {
-            // Next larger or equal (exact first, then smallest value > search_key).
             let mut res: Option<usize> = None;
             for (i, v) in arr.iter().enumerate() {
                 if values_equal(v, search_key) { return Some(i); }
@@ -83,14 +110,11 @@ fn xlookup_find(
             res
         }
         -1 => {
-            // Next smaller or equal (exact first, then keep updating while <=).
             let mut res: Option<usize> = None;
             for (i, v) in arr.iter().enumerate() {
                 if values_equal(v, search_key) { return Some(i); }
                 match value_compare(v, search_key) {
-                    Some(std::cmp::Ordering::Less) => {
-                        res = Some(i);
-                    }
+                    Some(std::cmp::Ordering::Less) => { res = Some(i); }
                     Some(std::cmp::Ordering::Greater) => break,
                     _ => {}
                 }
@@ -98,19 +122,16 @@ fn xlookup_find(
             res
         }
         2 => {
-            // Wildcard match (search_mode ignored for wildcards).
             if has_wildcards(search_key) {
                 if search_mode == -1 {
                     arr.iter().rposition(|v| wildcard_match_value(search_key, v))
                 } else {
                     arr.iter().position(|v| wildcard_match_value(search_key, v))
                 }
+            } else if search_mode == -1 {
+                arr.iter().rposition(|v| values_equal(v, search_key))
             } else {
-                if search_mode == -1 {
-                    arr.iter().rposition(|v| values_equal(v, search_key))
-                } else {
-                    arr.iter().position(|v| values_equal(v, search_key))
-                }
+                arr.iter().position(|v| values_equal(v, search_key))
             }
         }
         _ => {
@@ -133,7 +154,6 @@ pub fn xlookup_fn(args: &[Value]) -> Value {
     let lookup_array = flatten_to_flat(&args[1]);
     let return_array = flatten_to_flat(&args[2]);
 
-    // Empty lookup_array → #REF! (Google Sheets behaviour)
     if lookup_array.is_empty() {
         return Value::Error(ErrorKind::Ref);
     }
@@ -205,7 +225,6 @@ pub fn xmatch_fn(args: &[Value]) -> Value {
 
     match match_mode {
         0 => {
-            // Exact match (with wildcard support)
             let pos = if has_wildcards(search_key) {
                 if search_mode == -1 {
                     lookup_array.iter().rposition(|v| wildcard_match_value(search_key, v))
@@ -223,7 +242,6 @@ pub fn xmatch_fn(args: &[Value]) -> Value {
             }
         }
         1 => {
-            // Exact match or next larger (smallest value >= search_key)
             let mut best_pos: Option<usize> = None;
             let mut best_val: Option<&Value> = None;
             for (i, v) in lookup_array.iter().enumerate() {
@@ -231,7 +249,6 @@ pub fn xmatch_fn(args: &[Value]) -> Value {
                     return Value::Number((i + 1) as f64);
                 }
                 if let Some(std::cmp::Ordering::Greater) = value_compare(v, search_key) {
-                    // v > search_key; update if this is the smallest such value seen
                     let is_better = match best_val {
                         None => true,
                         Some(bv) => value_compare(v, bv) == Some(std::cmp::Ordering::Less),
@@ -248,13 +265,11 @@ pub fn xmatch_fn(args: &[Value]) -> Value {
             }
         }
         -1 => {
-            // Find largest value <= search_key (exact match or next smaller).
             let mut best_pos: Option<usize> = None;
             let mut best_val: Option<&Value> = None;
             for (i, v) in lookup_array.iter().enumerate() {
                 match value_compare(v, search_key) {
                     Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal) => {
-                        // v <= search_key; update if this is the largest such value seen
                         let is_better = match best_val {
                             None => true,
                             Some(bv) => value_compare(v, bv) == Some(std::cmp::Ordering::Greater),
@@ -273,7 +288,6 @@ pub fn xmatch_fn(args: &[Value]) -> Value {
             }
         }
         2 => {
-            // Wildcard match
             let pos = if has_wildcards(search_key) {
                 if search_mode == -1 {
                     lookup_array.iter().rposition(|v| wildcard_match_value(search_key, v))

--- a/crates/core/src/eval/functions/lookup/lookup_fn.rs
+++ b/crates/core/src/eval/functions/lookup/lookup_fn.rs
@@ -44,6 +44,85 @@ pub fn lookup_fn(args: &[Value]) -> Value {
     }
 }
 
+/// Find the position of `search_key` in `arr` using the given `match_mode` and `search_mode`.
+/// Returns the 0-based index, or None if not found.
+fn xlookup_find(
+    arr: &[Value],
+    search_key: &Value,
+    match_mode: i64,
+    search_mode: i64,
+) -> Option<usize> {
+    match match_mode {
+        0 => {
+            // Exact match (with wildcard support); search_mode controls direction.
+            if search_mode == -1 {
+                // Reverse scan: last-to-first.
+                if has_wildcards(search_key) {
+                    arr.iter().rposition(|v| wildcard_match_value(search_key, v))
+                } else {
+                    arr.iter().rposition(|v| values_equal(v, search_key))
+                }
+            } else {
+                if has_wildcards(search_key) {
+                    arr.iter().position(|v| wildcard_match_value(search_key, v))
+                } else {
+                    arr.iter().position(|v| values_equal(v, search_key))
+                }
+            }
+        }
+        1 => {
+            // Next larger or equal (exact first, then smallest value > search_key).
+            let mut res: Option<usize> = None;
+            for (i, v) in arr.iter().enumerate() {
+                if values_equal(v, search_key) { return Some(i); }
+                if let Some(std::cmp::Ordering::Greater) = value_compare(v, search_key) {
+                    res = Some(i);
+                    break;
+                }
+            }
+            res
+        }
+        -1 => {
+            // Next smaller or equal (exact first, then keep updating while <=).
+            let mut res: Option<usize> = None;
+            for (i, v) in arr.iter().enumerate() {
+                if values_equal(v, search_key) { return Some(i); }
+                match value_compare(v, search_key) {
+                    Some(std::cmp::Ordering::Less) => {
+                        res = Some(i);
+                    }
+                    Some(std::cmp::Ordering::Greater) => break,
+                    _ => {}
+                }
+            }
+            res
+        }
+        2 => {
+            // Wildcard match (search_mode ignored for wildcards).
+            if has_wildcards(search_key) {
+                if search_mode == -1 {
+                    arr.iter().rposition(|v| wildcard_match_value(search_key, v))
+                } else {
+                    arr.iter().position(|v| wildcard_match_value(search_key, v))
+                }
+            } else {
+                if search_mode == -1 {
+                    arr.iter().rposition(|v| values_equal(v, search_key))
+                } else {
+                    arr.iter().position(|v| values_equal(v, search_key))
+                }
+            }
+        }
+        _ => {
+            if search_mode == -1 {
+                arr.iter().rposition(|v| values_equal(v, search_key))
+            } else {
+                arr.iter().position(|v| values_equal(v, search_key))
+            }
+        }
+    }
+}
+
 /// `XLOOKUP(search_key, lookup_array, return_array, [if_not_found], [match_mode], [search_mode])`
 pub fn xlookup_fn(args: &[Value]) -> Value {
     if let Some(err) = check_arity(args, 3, 6) {
@@ -53,6 +132,12 @@ pub fn xlookup_fn(args: &[Value]) -> Value {
     let search_key = &args[0];
     let lookup_array = flatten_to_flat(&args[1]);
     let return_array = flatten_to_flat(&args[2]);
+
+    // Empty lookup_array → #REF! (Google Sheets behaviour)
+    if lookup_array.is_empty() {
+        return Value::Error(ErrorKind::Ref);
+    }
+
     let if_not_found: Option<Value> = if args.len() >= 4 {
         Some(args[3].clone())
     } else {
@@ -66,46 +151,16 @@ pub fn xlookup_fn(args: &[Value]) -> Value {
     } else {
         0
     };
-
-    let result_idx = match match_mode {
-        0 => lookup_array.iter().position(|v| values_equal(v, search_key)),
-        1 => {
-            // Next larger or equal
-            let mut res: Option<usize> = None;
-            for (i, v) in lookup_array.iter().enumerate() {
-                if values_equal(v, search_key) { res = Some(i); break; }
-                if let Some(std::cmp::Ordering::Greater) = value_compare(v, search_key) {
-                    res = Some(i);
-                    break;
-                }
-            }
-            res
+    let search_mode = if args.len() >= 6 {
+        match &args[5] {
+            Value::Number(n) => n.trunc() as i64,
+            _ => 1,
         }
-        -1 => {
-            // Next smaller or equal
-            let mut res: Option<usize> = None;
-            for (i, v) in lookup_array.iter().enumerate() {
-                if values_equal(v, search_key) { res = Some(i); break; }
-                match value_compare(v, search_key) {
-                    Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal) => {
-                        res = Some(i);
-                    }
-                    Some(std::cmp::Ordering::Greater) => break,
-                    _ => {}
-                }
-            }
-            res
-        }
-        2 => {
-            // Wildcard match
-            if has_wildcards(search_key) {
-                lookup_array.iter().position(|v| wildcard_match_value(search_key, v))
-            } else {
-                lookup_array.iter().position(|v| values_equal(v, search_key))
-            }
-        }
-        _ => lookup_array.iter().position(|v| values_equal(v, search_key)),
+    } else {
+        1
     };
+
+    let result_idx = xlookup_find(&lookup_array, search_key, match_mode, search_mode);
 
     match result_idx {
         Some(idx) => {
@@ -139,12 +194,26 @@ pub fn xmatch_fn(args: &[Value]) -> Value {
     } else {
         0
     };
+    let search_mode = if args.len() >= 4 {
+        match &args[3] {
+            Value::Number(n) => n.trunc() as i64,
+            _ => 1,
+        }
+    } else {
+        1
+    };
 
     match match_mode {
         0 => {
-            // Exact match (with wildcard support when pattern has * or ?)
+            // Exact match (with wildcard support)
             let pos = if has_wildcards(search_key) {
-                lookup_array.iter().position(|v| wildcard_match_value(search_key, v))
+                if search_mode == -1 {
+                    lookup_array.iter().rposition(|v| wildcard_match_value(search_key, v))
+                } else {
+                    lookup_array.iter().position(|v| wildcard_match_value(search_key, v))
+                }
+            } else if search_mode == -1 {
+                lookup_array.iter().rposition(|v| values_equal(v, search_key))
             } else {
                 lookup_array.iter().position(|v| values_equal(v, search_key))
             };
@@ -206,7 +275,13 @@ pub fn xmatch_fn(args: &[Value]) -> Value {
         2 => {
             // Wildcard match
             let pos = if has_wildcards(search_key) {
-                lookup_array.iter().position(|v| wildcard_match_value(search_key, v))
+                if search_mode == -1 {
+                    lookup_array.iter().rposition(|v| wildcard_match_value(search_key, v))
+                } else {
+                    lookup_array.iter().position(|v| wildcard_match_value(search_key, v))
+                }
+            } else if search_mode == -1 {
+                lookup_array.iter().rposition(|v| values_equal(v, search_key))
             } else {
                 lookup_array.iter().position(|v| values_equal(v, search_key))
             };

--- a/crates/core/src/eval/functions/lookup/misc.rs
+++ b/crates/core/src/eval/functions/lookup/misc.rs
@@ -3,22 +3,28 @@ use crate::eval::functions::{check_arity_len, EvalCtx};
 use crate::parser::ast::Expr;
 use crate::types::{ErrorKind, Value};
 
-/// `FORMULATEXT(reference)` — returns the formula string of a cell reference.
-/// In a standalone evaluator, all literals have no formula → #N/A.
-pub fn formulatext_fn(args: &[Expr], _ctx: &mut EvalCtx<'_>) -> Value {
+/// `FORMULATEXT(reference)` -- returns the formula string of a cell reference.
+/// In a standalone evaluator, there is no cell grid, so most calls return #N/A.
+/// Exception: if the argument evaluates to a #REF! error, propagate #REF! instead.
+pub fn formulatext_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     if let Some(err) = check_arity_len(args.len(), 1, 1) {
         return err;
     }
-    Value::Error(ErrorKind::NA)
+    // Evaluate the argument to propagate errors (especially #REF!)
+    let val = evaluate_expr(&args[0], ctx);
+    match val {
+        Value::Error(e) => Value::Error(e),
+        _ => Value::Error(ErrorKind::NA),
+    }
 }
 
-/// `GETPIVOTDATA(data_field, pivot_table, ...)` — always errors in a standalone evaluator.
-/// With 0 or 1 args → #N/A (wrong arity). With 2+ args → #REF! (no pivot table present).
+/// `GETPIVOTDATA(data_field, pivot_table, ...)` -- always errors in a standalone evaluator.
+/// With 0 or 1 args -> #N/A (wrong arity). With 2+ args -> #REF! (no pivot table present).
 pub fn getpivotdata_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     if args.len() < 2 {
         return Value::Error(ErrorKind::NA);
     }
-    // Evaluate the pivot_table arg (2nd arg) — if it is already an error, propagate it.
+    // Evaluate the pivot_table arg (2nd arg) -- if it is already an error, propagate it.
     let pivot_ref = evaluate_expr(&args[1], ctx);
     if let Value::Error(e) = pivot_ref {
         return Value::Error(e);
@@ -28,7 +34,7 @@ pub fn getpivotdata_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
 
 /// Encode an offset result as a special text tag that downstream lazy functions
 /// (ROW/COLUMN/ROWS/COLUMNS) can decode.
-/// Format: `__offset__:<row>:<col>:<height>:<width>` (all 1-based, ≥ 1).
+/// Format: `__offset__:<row>:<col>:<height>:<width>` (all 1-based, >= 1).
 pub fn make_offset_tag(row: i64, col: i64, height: i64, width: i64) -> Value {
     Value::Text(format!(
         "__offset__:{}:{}:{}:{}",
@@ -37,7 +43,7 @@ pub fn make_offset_tag(row: i64, col: i64, height: i64, width: i64) -> Value {
 }
 
 /// Parse an `__offset__:row:col:height:width` tag.
-/// Returns `(row, col, height, width)` — all positive, 1-based.
+/// Returns `(row, col, height, width)` -- all positive, 1-based.
 pub fn parse_offset_ref(s: &str) -> Option<(usize, usize, usize, usize)> {
     let s = s.strip_prefix("__offset__:")?;
     let mut parts = s.splitn(4, ':');
@@ -49,7 +55,7 @@ pub fn parse_offset_ref(s: &str) -> Option<(usize, usize, usize, usize)> {
     Some((row, col, height, width))
 }
 
-/// `OFFSET(reference, rows, cols, [height], [width])` — not implementable for value
+/// `OFFSET(reference, rows, cols, [height], [width])` -- not implementable for value
 /// retrieval without a cell grid, but we compute the resulting address and encode it
 /// as `__offset__:row:col:height:width` so that ROW/COLUMN/ROWS/COLUMNS can use it.
 /// SUM(OFFSET(...)) yields 0 (grid is empty).
@@ -83,7 +89,7 @@ pub fn offset_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
         _ => return Value::Error(ErrorKind::Value),
     };
 
-    // height / width default to 1; 0 → #VALUE!
+    // height / width default to 1; 0 -> #VALUE!
     let height: i64 = match height_val {
         None => 1,
         Some(Value::Number(n)) => {
@@ -120,8 +126,7 @@ pub fn offset_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
 }
 
 /// Extract (row, col) from an already-evaluated value.
-/// Handles the `__offset__:…` tag and, for INDIRECT results (Value::Empty),
-/// that won't help — callers intercept the Text string arg directly for INDIRECT.
+/// Handles the `__offset__:...` tag and cell reference strings.
 pub fn ref_position_from_value(v: &Value) -> Option<(i64, i64)> {
     match v {
         Value::Text(s) => {
@@ -141,9 +146,9 @@ pub fn ref_position_from_value(v: &Value) -> Option<(i64, i64)> {
     }
 }
 
-/// `SHEET([name])` — returns the sheet index.
+/// `SHEET([name])` -- returns the sheet index.
 /// With no argument, returns 1 (standalone evaluator has 1 sheet).
-/// With a text argument → #REF! (sheet not found).
+/// With a text argument -> #REF! (sheet not found).
 pub fn sheet_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     match args.len() {
         0 => Value::Number(1.0),

--- a/crates/core/src/eval/functions/lookup/misc.rs
+++ b/crates/core/src/eval/functions/lookup/misc.rs
@@ -12,20 +12,133 @@ pub fn formulatext_fn(args: &[Expr], _ctx: &mut EvalCtx<'_>) -> Value {
     Value::Error(ErrorKind::NA)
 }
 
-/// `GETPIVOTDATA(...)` — always returns #N/A in a standalone evaluator.
-pub fn getpivotdata_fn(args: &[Expr], _ctx: &mut EvalCtx<'_>) -> Value {
-    if args.is_empty() {
+/// `GETPIVOTDATA(data_field, pivot_table, ...)` — always errors in a standalone evaluator.
+/// With 0 or 1 args → #N/A (wrong arity). With 2+ args → #REF! (no pivot table present).
+pub fn getpivotdata_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if args.len() < 2 {
         return Value::Error(ErrorKind::NA);
     }
-    Value::Error(ErrorKind::NA)
+    // Evaluate the pivot_table arg (2nd arg) — if it is already an error, propagate it.
+    let pivot_ref = evaluate_expr(&args[1], ctx);
+    if let Value::Error(e) = pivot_ref {
+        return Value::Error(e);
+    }
+    Value::Error(ErrorKind::Ref)
 }
 
-/// `OFFSET(reference, rows, cols, [height], [width])` — not implementable without cell grid.
-pub fn offset_fn(args: &[Expr], _ctx: &mut EvalCtx<'_>) -> Value {
+/// Encode an offset result as a special text tag that downstream lazy functions
+/// (ROW/COLUMN/ROWS/COLUMNS) can decode.
+/// Format: `__offset__:<row>:<col>:<height>:<width>` (all 1-based, ≥ 1).
+pub fn make_offset_tag(row: i64, col: i64, height: i64, width: i64) -> Value {
+    Value::Text(format!(
+        "__offset__:{}:{}:{}:{}",
+        row, col, height.abs(), width.abs()
+    ))
+}
+
+/// Parse an `__offset__:row:col:height:width` tag.
+/// Returns `(row, col, height, width)` — all positive, 1-based.
+pub fn parse_offset_ref(s: &str) -> Option<(usize, usize, usize, usize)> {
+    let s = s.strip_prefix("__offset__:")?;
+    let mut parts = s.splitn(4, ':');
+    let row:    usize = parts.next()?.parse().ok()?;
+    let col:    usize = parts.next()?.parse().ok()?;
+    let height: usize = parts.next()?.parse().ok()?;
+    let width:  usize = parts.next()?.parse().ok()?;
+    if row == 0 || col == 0 { return None; }
+    Some((row, col, height, width))
+}
+
+/// `OFFSET(reference, rows, cols, [height], [width])` — not implementable for value
+/// retrieval without a cell grid, but we compute the resulting address and encode it
+/// as `__offset__:row:col:height:width` so that ROW/COLUMN/ROWS/COLUMNS can use it.
+/// SUM(OFFSET(...)) yields 0 (grid is empty).
+pub fn offset_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
-    Value::Error(ErrorKind::NA)
+    if let Some(err) = check_arity_len(args.len(), 3, 5) {
+        return err;
+    }
+
+    let ref_val   = evaluate_expr(&args[0], ctx);
+    let rows_val  = evaluate_expr(&args[1], ctx);
+    let cols_val  = evaluate_expr(&args[2], ctx);
+    let height_val = if args.len() >= 4 { Some(evaluate_expr(&args[3], ctx)) } else { None };
+    let width_val  = if args.len() >= 5 { Some(evaluate_expr(&args[4], ctx)) } else { None };
+
+    // Propagate errors from mandatory args.
+    for v in [&ref_val, &rows_val, &cols_val] {
+        if let Value::Error(e) = v { return Value::Error(e.clone()); }
+    }
+    if let Some(Value::Error(e)) = &height_val { return Value::Error(e.clone()); }
+    if let Some(Value::Error(e)) = &width_val  { return Value::Error(e.clone()); }
+
+    let row_offset = match rows_val {
+        Value::Number(n) => n.trunc() as i64,
+        _ => return Value::Error(ErrorKind::Value),
+    };
+    let col_offset = match cols_val {
+        Value::Number(n) => n.trunc() as i64,
+        _ => return Value::Error(ErrorKind::Value),
+    };
+
+    // height / width default to 1; 0 → #VALUE!
+    let height: i64 = match height_val {
+        None => 1,
+        Some(Value::Number(n)) => {
+            let h = n.trunc() as i64;
+            if h == 0 { return Value::Error(ErrorKind::Value); }
+            h
+        }
+        _ => 1,
+    };
+    let width: i64 = match width_val {
+        None => 1,
+        Some(Value::Number(n)) => {
+            let w = n.trunc() as i64;
+            if w == 0 { return Value::Error(ErrorKind::Value); }
+            w
+        }
+        _ => 1,
+    };
+
+    // Resolve the base reference to (row, col).
+    let (base_row, base_col) = match ref_position_from_value(&ref_val) {
+        Some(pos) => pos,
+        None => return Value::Error(ErrorKind::Ref),
+    };
+
+    let new_row = base_row + row_offset;
+    let new_col = base_col + col_offset;
+
+    if new_row < 1 || new_col < 1 {
+        return Value::Error(ErrorKind::Ref);
+    }
+
+    make_offset_tag(new_row, new_col, height, width)
+}
+
+/// Extract (row, col) from an already-evaluated value.
+/// Handles the `__offset__:…` tag and, for INDIRECT results (Value::Empty),
+/// that won't help — callers intercept the Text string arg directly for INDIRECT.
+pub fn ref_position_from_value(v: &Value) -> Option<(i64, i64)> {
+    match v {
+        Value::Text(s) => {
+            if let Some((r, c, _, _)) = parse_offset_ref(s) {
+                return Some((r as i64, c as i64));
+            }
+            use super::cell_ref::{parse_cell_ref, parse_range_ref};
+            if let Some((sc, sr, _, _)) = parse_range_ref(s) {
+                return Some((sr as i64, sc as i64));
+            }
+            if let Some((col, row)) = parse_cell_ref(s) {
+                return Some((row as i64, col as i64));
+            }
+            None
+        }
+        _ => None,
+    }
 }
 
 /// `SHEET([name])` — returns the sheet index.

--- a/crates/core/src/eval/functions/lookup/mod.rs
+++ b/crates/core/src/eval/functions/lookup/mod.rs
@@ -79,6 +79,15 @@ pub fn register_lookup(registry: &mut Registry) {
         },
     );
     registry.register_eager(
+        "INDEX",
+        index_match::index_fn,
+        FunctionMeta {
+            category: "lookup",
+            signature: "INDEX(array, row, [col])",
+            description: "Returns the value at the given 1-based row (and optionally col) in an array",
+        },
+    );
+    registry.register_eager(
         "MATCH",
         index_match::match_fn,
         FunctionMeta {

--- a/crates/core/src/eval/functions/lookup/mod.rs
+++ b/crates/core/src/eval/functions/lookup/mod.rs
@@ -123,4 +123,36 @@ pub fn register_lookup(registry: &mut Registry) {
             description: "Returns the sheet number of the current or named sheet",
         },
     );
+    // Lazy so argument expressions (INDIRECT/OFFSET) are visible before evaluation.
+    registry.register_lazy(
+        "OFFSET",
+        misc::offset_fn,
+        FunctionMeta {
+            category: "lookup",
+            signature: "OFFSET(reference, rows, cols, [height], [width])",
+            description: "Returns a range offset from a reference",
+        },
+    );
+    registry.register_lazy(
+        "FORMULATEXT",
+        misc::formulatext_fn,
+        FunctionMeta {
+            category: "lookup",
+            signature: "FORMULATEXT(reference)",
+            description: "Returns the formula string for a cell reference",
+        },
+    );
+    registry.register_lazy(
+        "GETPIVOTDATA",
+        misc::getpivotdata_fn,
+        FunctionMeta {
+            category: "lookup",
+            signature: "GETPIVOTDATA(data_field, pivot_table, ...)",
+            description: "Retrieves data from a PivotTable",
+        },
+    );
+    // Override eager ROWS/COLUMNS from array module with ref-aware lazy versions.
+    registry.register_internal_lazy("ROWS",    row_col::rows_fn);
+    registry.register_internal_lazy("COLUMNS", row_col::columns_fn);
+
 }

--- a/crates/core/src/eval/functions/lookup/row_col.rs
+++ b/crates/core/src/eval/functions/lookup/row_col.rs
@@ -4,6 +4,104 @@ use crate::parser::ast::Expr;
 use crate::parser::refs::Ref;
 use crate::types::{ErrorKind, Value};
 use super::cell_ref::{parse_cell_ref, parse_range_ref};
+use super::misc::parse_offset_ref;
+
+// ---------------------------------------------------------------------------
+// Helpers: extract ref geometry from a lazy argument
+// ---------------------------------------------------------------------------
+
+/// Try to resolve an expression argument to a cell-ref string without evaluating it.
+/// Handles:
+///   - `INDIRECT("A1")` / `INDIRECT("A1:C3")` — extracts the literal string arg
+///   - `OFFSET(INDIRECT("A1"), r, c, [h], [w])` — evaluates to get the offset tag
+///
+/// Returns the resolved cell/range string, or None if unrecognised.
+fn extract_ref_string_from_expr(arg: &Expr, ctx: &mut EvalCtx<'_>) -> Option<String> {
+    match arg {
+        // INDIRECT("literal") — pull the literal out without evaluating INDIRECT.
+        Expr::FunctionCall { name, args, .. } if name.eq_ignore_ascii_case("INDIRECT") => {
+            if args.len() >= 1 {
+                match &args[0] {
+                    Expr::Text(s, _) => return Some(s.clone()),
+                    _ => {
+                        // Evaluate the arg to get the string.
+                        let v = evaluate_expr(&args[0], ctx);
+                        if let Value::Text(s) = v { return Some(s); }
+                    }
+                }
+            }
+            None
+        }
+        // OFFSET(...) — evaluate it; it returns an __offset__:... tag.
+        Expr::FunctionCall { name, .. } if name.eq_ignore_ascii_case("OFFSET") => {
+            let v = evaluate_expr(arg, ctx);
+            match v {
+                Value::Text(s) if s.starts_with("__offset__:") => Some(s),
+                Value::Error(_) => None,
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Resolve a lazy arg to (row, col, height, width) — all 1-based.
+/// For a plain cell ref: height=1, width=1.
+/// Returns None if the arg doesn't resolve to a known ref.
+fn resolve_lazy_arg_geometry(arg: &Expr, ctx: &mut EvalCtx<'_>)
+    -> Option<(usize, usize, usize, usize)>
+{
+    // Try to get a ref string from INDIRECT/OFFSET.
+    if let Some(s) = extract_ref_string_from_expr(arg, ctx) {
+        return decode_ref_string_geometry(&s);
+    }
+    // Expr::Reference produced by the parser for bare cell/range tokens.
+    match arg {
+        Expr::Reference(r, _) => match r {
+            Ref::Cell { addr, .. } => {
+                return Some((addr.row as usize, addr.col as usize, 1, 1));
+            }
+            Ref::Range { start, end, .. } => {
+                let h = if end.row >= start.row { end.row - start.row + 1 } else { start.row - end.row + 1 };
+                let w = if end.col >= start.col { end.col - start.col + 1 } else { start.col - end.col + 1 };
+                return Some((start.row as usize, start.col as usize, h as usize, w as usize));
+            }
+            Ref::Name(_) => {}
+        },
+        Expr::Variable(name, _) => {
+            if let Some((sc, sr, ec, er)) = parse_range_ref(name) {
+                let h = if er >= sr { er - sr + 1 } else { sr - er + 1 };
+                let w = if ec >= sc { ec - sc + 1 } else { sc - ec + 1 };
+                return Some((sr, sc, h, w));
+            }
+            if let Some((col, row)) = parse_cell_ref(name) {
+                return Some((row, col, 1, 1));
+            }
+        }
+        _ => {}
+    }
+    None
+}
+
+/// Decode a ref string (plain A1, A1:C3, or __offset__:…) into (row, col, height, width).
+fn decode_ref_string_geometry(s: &str) -> Option<(usize, usize, usize, usize)> {
+    if let Some((row, col, h, w)) = parse_offset_ref(s) {
+        return Some((row, col, h, w));
+    }
+    if let Some((sc, sr, ec, er)) = parse_range_ref(s) {
+        let h = if er >= sr { er - sr + 1 } else { sr - er + 1 };
+        let w = if ec >= sc { ec - sc + 1 } else { sc - ec + 1 };
+        return Some((sr, sc, h, w));
+    }
+    if let Some((col, row)) = parse_cell_ref(s) {
+        return Some((row, col, 1, 1));
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// ROW / COLUMN
+// ---------------------------------------------------------------------------
 
 /// `ROW([cell_ref])` — returns the row number of a cell reference.
 /// Without argument, returns 1 (no row context in standalone evaluator).
@@ -14,37 +112,14 @@ pub fn row_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     if args.is_empty() {
         return Value::Number(1.0);
     }
-    match &args[0] {
-        Expr::Reference(r, _) => match r {
-            Ref::Cell { addr, .. } => Value::Number(addr.row as f64),
-            Ref::Range { start, .. } => Value::Number(start.row as f64),
-            // The parser never produces `Ref::Name` inside `Expr::Reference`.
-            Ref::Name(_) => Value::Error(ErrorKind::NA),
-        },
-        Expr::Variable(name, _) => {
-            // Try range first (A1:D4 → top row of range)
-            if let Some((_sc, sr, _ec, _er)) = parse_range_ref(name) {
-                return Value::Number(sr as f64);
-            }
-            // Try single cell ref
-            if let Some((_col, row)) = parse_cell_ref(name) {
-                return Value::Number(row as f64);
-            }
-            // Not a cell ref variable: evaluate and forward error or return #N/A
-            let v = evaluate_expr(&args[0], ctx);
-            match v {
-                Value::Error(e) => Value::Error(e),
-                _ => Value::Error(ErrorKind::NA),
-            }
-        }
-        _ => {
-            // Non-variable argument (e.g. string literal, number): #N/A
-            let v = evaluate_expr(&args[0], ctx);
-            match v {
-                Value::Error(e) => Value::Error(e),
-                _ => Value::Error(ErrorKind::NA),
-            }
-        }
+    if let Some((row, _col, _h, _w)) = resolve_lazy_arg_geometry(&args[0], ctx) {
+        return Value::Number(row as f64);
+    }
+    // Fallback: evaluate and forward errors.
+    let v = evaluate_expr(&args[0], ctx);
+    match v {
+        Value::Error(e) => Value::Error(e),
+        _ => Value::Error(ErrorKind::NA),
     }
 }
 
@@ -57,90 +132,44 @@ pub fn column_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     if args.is_empty() {
         return Value::Number(1.0);
     }
-    match &args[0] {
-        Expr::Reference(r, _) => match r {
-            Ref::Cell { addr, .. } => Value::Number(addr.col as f64),
-            Ref::Range { start, .. } => Value::Number(start.col as f64),
-            // The parser never produces `Ref::Name` inside `Expr::Reference`.
-            Ref::Name(_) => Value::Error(ErrorKind::NA),
-        },
-        Expr::Variable(name, _) => {
-            // Try range first (A1:D4 → left column of range)
-            if let Some((sc, _sr, _ec, _er)) = parse_range_ref(name) {
-                return Value::Number(sc as f64);
-            }
-            // Try single cell ref
-            if let Some((col, _row)) = parse_cell_ref(name) {
-                return Value::Number(col as f64);
-            }
-            let v = evaluate_expr(&args[0], ctx);
-            match v {
-                Value::Error(e) => Value::Error(e),
-                _ => Value::Error(ErrorKind::NA),
-            }
-        }
-        _ => {
-            // Non-variable argument (e.g. string literal, number): #N/A
-            let v = evaluate_expr(&args[0], ctx);
-            match v {
-                Value::Error(e) => Value::Error(e),
-                _ => Value::Error(ErrorKind::NA),
-            }
-        }
+    if let Some((_row, col, _h, _w)) = resolve_lazy_arg_geometry(&args[0], ctx) {
+        return Value::Number(col as f64);
+    }
+    let v = evaluate_expr(&args[0], ctx);
+    match v {
+        Value::Error(e) => Value::Error(e),
+        _ => Value::Error(ErrorKind::NA),
     }
 }
 
+// ---------------------------------------------------------------------------
+// ROWS / COLUMNS  (lazy — override the eager versions in the array module so
+//                  that INDIRECT("A1:C5") and OFFSET(...) are handled correctly)
+// ---------------------------------------------------------------------------
+
 /// `ROWS(array_or_range)` — returns the number of rows.
-/// For a range ref A1:C5 → 5 rows.
-/// For an evaluated 2D array → outer count.
-/// For a 1D array or scalar → 1.
 pub fn rows_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     if let Some(err) = check_arity_len(args.len(), 1, 1) {
         return err;
     }
-    match &args[0] {
-        Expr::Variable(name, _) => {
-            if let Some((_sc, sr, _ec, er)) = parse_range_ref(name) {
-                let rows = if er >= sr { er - sr + 1 } else { sr - er + 1 };
-                return Value::Number(rows as f64);
-            }
-            if parse_cell_ref(name).is_some() {
-                return Value::Number(1.0);
-            }
-            // Fall through to evaluate
-            let v = evaluate_expr(&args[0], ctx);
-            count_rows_from_value(&v)
-        }
-        _ => {
-            let v = evaluate_expr(&args[0], ctx);
-            count_rows_from_value(&v)
-        }
+    if let Some((_row, _col, h, _w)) = resolve_lazy_arg_geometry(&args[0], ctx) {
+        return Value::Number(h as f64);
     }
+    // Fall through: evaluate and count rows from the resulting Value.
+    let v = evaluate_expr(&args[0], ctx);
+    count_rows_from_value(&v)
 }
 
 /// `COLUMNS(array_or_range)` — returns the number of columns.
-/// For a range ref A1:D1 → 4 columns.
 pub fn columns_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     if let Some(err) = check_arity_len(args.len(), 1, 1) {
         return err;
     }
-    match &args[0] {
-        Expr::Variable(name, _) => {
-            if let Some((sc, _sr, ec, _er)) = parse_range_ref(name) {
-                let cols = if ec >= sc { ec - sc + 1 } else { sc - ec + 1 };
-                return Value::Number(cols as f64);
-            }
-            if parse_cell_ref(name).is_some() {
-                return Value::Number(1.0);
-            }
-            let v = evaluate_expr(&args[0], ctx);
-            count_cols_from_value(&v)
-        }
-        _ => {
-            let v = evaluate_expr(&args[0], ctx);
-            count_cols_from_value(&v)
-        }
+    if let Some((_row, _col, _h, w)) = resolve_lazy_arg_geometry(&args[0], ctx) {
+        return Value::Number(w as f64);
     }
+    let v = evaluate_expr(&args[0], ctx);
+    count_cols_from_value(&v)
 }
 
 fn count_rows_from_value(v: &Value) -> Value {
@@ -163,7 +192,6 @@ fn count_cols_from_value(v: &Value) -> Value {
         Value::Array(outer) => {
             let is_2d = outer.iter().any(|e| matches!(e, Value::Array(_)));
             if is_2d {
-                // Number of columns in first row
                 match outer.first() {
                     Some(Value::Array(row)) => Value::Number(row.len() as f64),
                     _ => Value::Number(1.0),

--- a/crates/core/src/eval/functions/lookup/row_col.rs
+++ b/crates/core/src/eval/functions/lookup/row_col.rs
@@ -20,7 +20,7 @@ fn extract_ref_string_from_expr(arg: &Expr, ctx: &mut EvalCtx<'_>) -> Option<Str
     match arg {
         // INDIRECT("literal") — pull the literal out without evaluating INDIRECT.
         Expr::FunctionCall { name, args, .. } if name.eq_ignore_ascii_case("INDIRECT") => {
-            if args.len() >= 1 {
+            if !args.is_empty() {
                 match &args[0] {
                     Expr::Text(s, _) => return Some(s.clone()),
                     _ => {

--- a/crates/core/src/eval/functions/lookup/vlookup.rs
+++ b/crates/core/src/eval/functions/lookup/vlookup.rs
@@ -1,6 +1,6 @@
 use crate::eval::functions::check_arity;
 use crate::types::{ErrorKind, Value};
-use super::array_utils::{flatten_to_rows, values_equal, value_compare};
+use super::array_utils::{flatten_to_rows, values_equal, value_compare, wildcard_match_value, has_wildcards};
 
 /// `VLOOKUP(search_key, range, index, [is_sorted])`
 /// Searches the first column of range, returns value from the `index` column (1-based).
@@ -13,7 +13,11 @@ pub fn vlookup_fn(args: &[Value]) -> Value {
     let search_key = &args[0];
     let range = &args[1];
     let col_index = match &args[2] {
-        Value::Number(n) => n.trunc() as usize,
+        Value::Number(n) => {
+            let idx = n.trunc() as i64;
+            if idx < 1 { return Value::Error(ErrorKind::Value); }
+            idx as usize
+        }
         _ => return Value::Error(ErrorKind::Value),
     };
     let is_sorted = if args.len() == 4 {
@@ -25,10 +29,6 @@ pub fn vlookup_fn(args: &[Value]) -> Value {
     } else {
         true
     };
-
-    if col_index < 1 {
-        return Value::Error(ErrorKind::Value);
-    }
 
     let rows = flatten_to_rows(range);
     if rows.is_empty() {
@@ -60,10 +60,15 @@ pub fn vlookup_fn(args: &[Value]) -> Value {
             }
         }
     } else {
-        // Exact match
+        // Exact match — supports wildcards in search_key
         for row in &rows {
             if row.is_empty() { continue; }
-            if values_equal(&row[0], search_key) {
+            let matched = if has_wildcards(search_key) {
+                wildcard_match_value(search_key, &row[0])
+            } else {
+                values_equal(&row[0], search_key)
+            };
+            if matched {
                 if col_index > row.len() {
                     return Value::Error(ErrorKind::Ref);
                 }
@@ -84,7 +89,11 @@ pub fn hlookup_fn(args: &[Value]) -> Value {
     let search_key = &args[0];
     let range = &args[1];
     let row_index = match &args[2] {
-        Value::Number(n) => n.trunc() as usize,
+        Value::Number(n) => {
+            let idx = n.trunc() as i64;
+            if idx < 1 { return Value::Error(ErrorKind::Value); }
+            idx as usize
+        }
         _ => return Value::Error(ErrorKind::Value),
     };
     let is_sorted = if args.len() == 4 {
@@ -96,10 +105,6 @@ pub fn hlookup_fn(args: &[Value]) -> Value {
     } else {
         true
     };
-
-    if row_index < 1 {
-        return Value::Error(ErrorKind::Value);
-    }
 
     let rows = flatten_to_rows(range);
     if rows.is_empty() {
@@ -134,10 +139,15 @@ pub fn hlookup_fn(args: &[Value]) -> Value {
             }
         }
     } else {
-        // Exact match in first row
+        // Exact match in first row — supports wildcards
         let mut found_col: Option<usize> = None;
         for (i, cell) in first_row.iter().enumerate() {
-            if values_equal(cell, search_key) {
+            let matched = if has_wildcards(search_key) {
+                wildcard_match_value(search_key, cell)
+            } else {
+                values_equal(cell, search_key)
+            };
+            if matched {
                 found_col = Some(i);
                 break;
             }

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -479,7 +479,7 @@ conformance_tsv_test!(operator_conformance,         "operator.tsv");
 conformance_tsv_test!(text_conformance,        "text.tsv");
 conformance_tsv_test!(date_conformance,        "date.tsv");
 conformance_tsv_test!(engineering_conformance, "engineering.tsv");
-conformance_tsv_test_report!(lookup_conformance,      "lookup.tsv");
+conformance_tsv_test!(lookup_conformance,             "lookup.tsv");
 conformance_tsv_test!(parser_conformance,      "parser.tsv");
 conformance_tsv_test!(database_conformance,    "database.tsv");
 conformance_tsv_test!(array_conformance,       "array.tsv");

--- a/crates/core/tests/registry.rs
+++ b/crates/core/tests/registry.rs
@@ -57,25 +57,24 @@ fn alias_does_not_appear_in_metadata() {
 }
 
 #[test]
-fn context_limited_functions_return_name_error() {
+fn context_limited_functions_return_errors() {
     use std::collections::HashMap;
     use truecalc_core::{Value, ErrorKind};
-    // These functions require a cell grid — they should not be registered
-    // in the standalone evaluator. Callers should get #NAME? not #N/A.
-    let cases = [
-        "OFFSET({1,2,3},0,1)",
-        "FORMULATEXT(SUM(1,2))",
-        "GETPIVOTDATA(\"Sales\",{1})",
-    ];
-    for formula in cases {
-        let result = evaluate(formula, &HashMap::new());
-        assert_eq!(
-            result,
-            Value::Error(ErrorKind::Name),
-            "expected #NAME? for context-limited function in: {}",
-            formula
-        );
-    }
+    // FORMULATEXT has no formula text to retrieve → #N/A
+    // GETPIVOTDATA with 2+ args has no pivot table → #REF!
+    // GETPIVOTDATA with < 2 args → #N/A
+    // OFFSET is now registered and returns a tagged text value (no grid available)
+    let result = evaluate("FORMULATEXT(SUM(1,2))", &HashMap::new());
+    assert_eq!(result, Value::Error(ErrorKind::NA),
+        "FORMULATEXT should return #N/A when no formula text is available");
+
+    let result2 = evaluate("GETPIVOTDATA(\"Sales\",{1})", &HashMap::new());
+    assert_eq!(result2, Value::Error(ErrorKind::Ref),
+        "GETPIVOTDATA with 2+ args should return #REF! (no pivot table)");
+
+    let result3 = evaluate("GETPIVOTDATA(\"Sales\")", &HashMap::new());
+    assert_eq!(result3, Value::Error(ErrorKind::NA),
+        "GETPIVOTDATA with < 2 args should return #N/A");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes all lookup conformance failures against the 2026-06-08 Google Sheets fixtures and flips the test from report-only to blocking.

### Changes

- **OFFSET**: registered as lazy fn; computes target address, encodes as `__offset__:r:c:h:w` tag so ROW/COLUMN/ROWS/COLUMNS can decode geometry without a grid
- **FORMULATEXT**: registered (→ `#N/A` — no formula text in standalone evaluator)
- **GETPIVOTDATA**: registered (→ `#REF!` with 2+ args, `#N/A` with < 2 args)
- **ROWS/COLUMNS**: overridden with lazy versions via `register_internal_lazy`; decode INDIRECT/OFFSET geometry correctly instead of returning 1 for every range string
- **ROW/COLUMN**: lazy versions now detect `INDIRECT("literal")` and `OFFSET(...)` arguments and extract row/col without evaluating through the no-grid evaluator
- **MATCH type=-1**: break only on `Less` (not `None`) — incomparable types were incorrectly ending the scan early
- **MATCH**: 2D array range → `#N/A` (matches Google Sheets)
- **VLOOKUP/HLOOKUP**: col/row index < 1 → `#VALUE!`; exact match supports wildcards
- **XLOOKUP**: empty `lookup_array` → `#REF!`; `search_mode=-1` (reverse scan) now supported as 6th arg
- **conformance.rs**: flipped `lookup_conformance` from `conformance_tsv_test_report!` to `conformance_tsv_test!` (blocking)
- **registry.rs**: updated `context_limited_functions_return_name_error` → `context_limited_functions_return_errors` to match new behaviour

Closes #592