### PR TITLE
fix(fixtures): move SHEETS() harness-dependent rows from info.tsv to bugs.tsv

### DIFF
--- a/crates/core/tests/fixtures/google_sheets/bugs.tsv
+++ b/crates/core/tests/fixtures/google_sheets/bugs.tsv
@@ -2633,3 +2633,5 @@ SHEET() returns current sheet number	=SHEET()	14	edge	number
 SHEET result used in arithmetic	=SHEET()*1	14	nested	number
 SHEET inside IF	=IF(SHEET()=1,"first sheet","other")	other	nested	string
 STEYX with floating-point coordinates	=STEYX({1.1,2.2,3.3,4.4},{0.9,1.8,2.7,3.6})	#NUM!	compatibility	error
+SHEETS with no argument returns count of sheets	=SHEETS()	19	official	number
+GS and Excel both have SHEETS function	=SHEETS()	19	compatibility	number

--- a/crates/core/tests/fixtures/google_sheets/info.tsv
+++ b/crates/core/tests/fixtures/google_sheets/info.tsv
@@ -235,13 +235,11 @@ IFNA catches NA	=IFNA(NA(),"not available")	not available	nested	string
 nested — NA in arithmetic caught by IFERROR	=IFERROR(5+NA(),"error")	error	nested	string
 NA() with argument returns error	=NA(1)	#N/A	error	error
 ISNA detects NA correctly	=ISNA(NA())	TRUE	compatibility	boolean
-SHEETS with no argument returns count of sheets	=SHEETS()	19	official	number
 SHEETS returns a positive integer	=SHEETS()>0	TRUE	official	boolean
 ISNUMBER of SHEETS result	=ISNUMBER(SHEETS())	TRUE	edge	boolean
 SHEETS() is at least 1	=SHEETS()>=1	TRUE	edge	boolean
 too many arguments returns error	=SHEETS(1,2)	#N/A	error	error
 nested IF using SHEETS count	=IF(SHEETS()>=1,"has sheets","no sheets")	has sheets	nested	string
-GS and Excel both have SHEETS function	=SHEETS()	19	compatibility	number
 TYPE of number returns 1	=TYPE(42)	1	official	number
 TYPE of text returns 2	=TYPE("hello")	2	official	number
 TYPE of boolean returns 4	=TYPE(TRUE)	4	official	number


### PR DESCRIPTION
## Summary

Move 2 rows from `info.tsv` to `bugs.tsv`:

- `=SHEETS()` → 19 (row 238, official)
- `=SHEETS()` → 19 (row 244, compatibility)

`=SHEETS()` returns 19 in the GS test workbook because that workbook had 19 sheets. Our stateless evaluator always returns 1 — this is a **harness limitation**, not an engine bug. The remaining `SHEETS()` rows in `info.tsv` pass because they test `>0`, `>=1`, `ISNUMBER`, or `IF` comparisons that hold for any sheet count ≥ 1.

Prerequisite for: flipping `info_conformance` from report-only to blocking.

## Test plan

- [ ] `conformance_tsv_test_report!(info_conformance, "info.tsv")` shows 0 failures after this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)