### PR TITLE
fix(conformance): flip info_conformance to blocking (256/256 pass)

### DIFF
--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -473,7 +473,7 @@ macro_rules! conformance_tsv_test_report {
 
 conformance_tsv_test!(math_conformance,        "math.tsv");
 conformance_tsv_test!(logical_conformance,            "logical.tsv");
-conformance_tsv_test_report!(info_conformance,        "info.tsv");
+conformance_tsv_test!(info_conformance,        "info.tsv");
 conformance_tsv_test!(statistical_conformance, "statistical.tsv");
 conformance_tsv_test!(operator_conformance,         "operator.tsv");
 conformance_tsv_test!(text_conformance,        "text.tsv");


### PR DESCRIPTION
## Summary

Flips `info_conformance` from `conformance_tsv_test_report!` to `conformance_tsv_test!`.

All 256 evaluated `info.tsv` rows now pass. The 2 previously failing `=SHEETS()` rows (expected 19, harness-dependent) were moved to `bugs.tsv` in the prerequisite PR #630.

## Test plan

- [ ] `info_conformance` passes as a blocking test (0 failures in info.tsv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)