### PR TITLE
chore: release v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "calamine",
  "chrono",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm-workbook"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-workbook"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "workbook-budget"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "truecalc-workbook",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/wasm-workbook", "crates/mcp", "
 resolver = "2"
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/truecalc/core/compare/truecalc-core-v1.0.0...truecalc-core-v1.0.1) - 2026-06-10
+
+### Other
+
+- rustdoc, READMEs, cookbook, migration guide ([#548](https://github.com/truecalc/core/pull/548))
+
 ## [0.9.0](https://github.com/truecalc/core/compare/truecalc-core-v0.8.0...truecalc-core-v0.9.0) - 2026-06-10
 
 ### Added

--- a/crates/workbook/CHANGELOG.md
+++ b/crates/workbook/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/truecalc/core/compare/truecalc-workbook-v1.0.0...truecalc-workbook-v1.0.1) - 2026-06-10
+
+### Other
+
+- rustdoc, READMEs, cookbook, migration guide ([#548](https://github.com/truecalc/core/pull/548))
+
 ## [0.8.0](https://github.com/truecalc/core/compare/truecalc-workbook-v0.7.0...truecalc-workbook-v0.8.0) - 2026-06-08
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `truecalc-workbook`: 1.0.0 -> 1.0.1 (✓ API compatible changes)
* `truecalc-mcp`: 1.0.0 -> 1.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [1.0.1](https://github.com/truecalc/core/compare/truecalc-core-v1.0.0...truecalc-core-v1.0.1) - 2026-06-10

### Other

- rustdoc, READMEs, cookbook, migration guide ([#548](https://github.com/truecalc/core/pull/548))
</blockquote>

## `truecalc-workbook`

<blockquote>

## [1.0.1](https://github.com/truecalc/core/compare/truecalc-workbook-v1.0.0...truecalc-workbook-v1.0.1) - 2026-06-10

### Other

- rustdoc, READMEs, cookbook, migration guide ([#548](https://github.com/truecalc/core/pull/548))
</blockquote>

## `truecalc-mcp`

<blockquote>

## [0.9.0](https://github.com/truecalc/core/compare/truecalc-mcp-v0.8.0...truecalc-mcp-v0.9.0) - 2026-06-10

### Other

- release v0.8.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).