### PR TITLE
feat(ci): publish conformance-summary.json to gh-pages on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,50 @@ jobs:
           cp /tmp/conformance.html index.html
           rm -rf coverage && cp -r /tmp/coverage-html coverage
           touch .nojekyll
-          git add conformance-badge.json coverage-badge.json index.html .nojekyll coverage/
+          python3 - <<'PYEOF'
+import json, re, datetime, subprocess
+
+with open("target/conformance-report.json") as f:
+    report = json.load(f)
+
+cargo_toml = open("Cargo.toml").read()
+version = re.search(r'^version\s*=\s*"([^"]+)"', cargo_toml, re.MULTILINE).group(1)
+
+git_sha = subprocess.check_output(["git", "rev-parse", "--short=7", "HEAD"]).decode().strip()
+
+blocking_categories = {
+    "math", "logical", "info", "statistical", "operator", "text",
+    "date", "engineering", "lookup", "parser", "database", "array",
+    "filter", "web", "financial",
+}
+
+categories = []
+for name, stats in sorted(report.get("by_category", {}).items()):
+    categories.append({
+        "name": name,
+        "passed": stats["passed"],
+        "total": stats["total"],
+        "blocking": name in blocking_categories,
+    })
+
+summary = {
+    "generated": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "version": version,
+    "git_sha": git_sha,
+    "categories": categories,
+    "overall": {
+        "passed": report["passed"],
+        "total": report["total"],
+    },
+}
+
+with open("conformance-summary.json", "w") as f:
+    json.dump(summary, f, indent=2)
+    f.write("\n")
+
+print(f"conformance-summary.json written: {report['passed']}/{report['total']} passed, {len(categories)} categories")
+PYEOF
+          git add conformance-badge.json coverage-badge.json index.html .nojekyll coverage/ conformance-summary.json
           git diff --cached --quiet || git commit -m "chore: update conformance + coverage report [skip ci]"
           git push --force origin gh-pages
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,38 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
+      - name: Generate conformance-summary.json
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: python
+        run: |
+          import json, re, datetime, subprocess
+          with open("target/conformance-report.json") as f:
+              report = json.load(f)
+          cargo_toml = open("Cargo.toml").read()
+          version = re.search(r'^version\s*=\s*"([^"]+)"', cargo_toml, re.MULTILINE).group(1)
+          git_sha = subprocess.check_output(["git", "rev-parse", "--short=7", "HEAD"]).decode().strip()
+          blocking_categories = {
+              "math", "logical", "info", "statistical", "operator", "text",
+              "date", "engineering", "lookup", "parser", "database", "array",
+              "filter", "web", "financial",
+          }
+          categories = [
+              {"name": name, "passed": stats["passed"], "total": stats["total"],
+               "blocking": name in blocking_categories}
+              for name, stats in sorted(report.get("by_category", {}).items())
+          ]
+          summary = {
+              "generated": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "version": version,
+              "git_sha": git_sha,
+              "categories": categories,
+              "overall": {"passed": report["passed"], "total": report["total"]},
+          }
+          with open("/tmp/conformance-summary.json", "w") as f:
+              json.dump(summary, f, indent=2)
+              f.write("\n")
+          print(f"conformance-summary.json: {report['passed']}/{report['total']} passed, {len(categories)} categories")
+
       - name: Publish conformance report to gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
@@ -167,49 +199,7 @@ jobs:
           cp /tmp/conformance.html index.html
           rm -rf coverage && cp -r /tmp/coverage-html coverage
           touch .nojekyll
-          python3 - <<'PYEOF'
-import json, re, datetime, subprocess
-
-with open("target/conformance-report.json") as f:
-    report = json.load(f)
-
-cargo_toml = open("Cargo.toml").read()
-version = re.search(r'^version\s*=\s*"([^"]+)"', cargo_toml, re.MULTILINE).group(1)
-
-git_sha = subprocess.check_output(["git", "rev-parse", "--short=7", "HEAD"]).decode().strip()
-
-blocking_categories = {
-    "math", "logical", "info", "statistical", "operator", "text",
-    "date", "engineering", "lookup", "parser", "database", "array",
-    "filter", "web", "financial",
-}
-
-categories = []
-for name, stats in sorted(report.get("by_category", {}).items()):
-    categories.append({
-        "name": name,
-        "passed": stats["passed"],
-        "total": stats["total"],
-        "blocking": name in blocking_categories,
-    })
-
-summary = {
-    "generated": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "version": version,
-    "git_sha": git_sha,
-    "categories": categories,
-    "overall": {
-        "passed": report["passed"],
-        "total": report["total"],
-    },
-}
-
-with open("conformance-summary.json", "w") as f:
-    json.dump(summary, f, indent=2)
-    f.write("\n")
-
-print(f"conformance-summary.json written: {report['passed']}/{report['total']} passed, {len(categories)} categories")
-PYEOF
+          cp /tmp/conformance-summary.json conformance-summary.json
           git add conformance-badge.json coverage-badge.json index.html .nojekyll coverage/ conformance-summary.json
           git diff --cached --quiet || git commit -m "chore: update conformance + coverage report [skip ci]"
           git push --force origin gh-pages


### PR DESCRIPTION
## Summary

- Adds a Python inline script in the existing `Publish conformance report to gh-pages` CI step (gated by `push` to `main`) that reads `target/conformance-report.json` and writes `conformance-summary.json` to the gh-pages checkout directory
- The JSON includes: ISO UTC timestamp, truecalc-core version (from workspace `Cargo.toml`), 7-char git SHA, per-category `passed`/`total`/`blocking` entries (all current categories hard-coded as `blocking: true`), and overall `passed`/`total`
- Updates the `git add` line to include `conformance-summary.json` alongside the existing badge and HTML files

## Test plan

- [ ] CI passes on this PR (the new step is gated to `push` to `main` so it won't run on PR builds — verify the YAML is syntactically valid)
- [ ] After merging, confirm `conformance-summary.json` appears in the `gh-pages` branch with the expected shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)