### PR TITLE
fixtures(workbook): import pipeline-evaluated workbook fixture JSONs (P3.6)

### DIFF
--- a/crates/workbook/tests/fixtures/workbook/cross-sheet/cross_sheet_basic.expected.json
+++ b/crates/workbook/tests/fixtures/workbook/cross-sheet/cross_sheet_basic.expected.json
@@ -1,0 +1,117 @@
+{
+  "id": "cross_sheet_basic",
+  "engine": "sheets",
+  "meta": {
+    "locale": "en_US",
+    "timezone": "Etc/GMT",
+    "evaluatedAt": "2026-06-08T18:44:46.493Z"
+  },
+  "steps": [
+    {
+      "label": "initial",
+      "grid": {
+        "Calc": {
+          "A1": {
+            "value": "10",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "30",
+            "type": "number",
+            "serial": null
+          },
+          "A3": {
+            "value": "60",
+            "type": "number",
+            "serial": null
+          },
+          "A4": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "A5": {
+            "value": "100",
+            "type": "number",
+            "serial": null
+          },
+          "A6": {
+            "value": "600",
+            "type": "number",
+            "serial": null
+          },
+          "A7": {
+            "value": "hello",
+            "type": "string",
+            "serial": null
+          },
+          "A8": {
+            "value": "TRUE",
+            "type": "boolean",
+            "serial": null
+          },
+          "A9": {
+            "value": "big",
+            "type": "string",
+            "serial": null
+          },
+          "A10": {
+            "value": "#REF!",
+            "type": "error",
+            "serial": null
+          }
+        },
+        "Data": {
+          "A1": {
+            "value": "10",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "A3": {
+            "value": "30",
+            "type": "number",
+            "serial": null
+          },
+          "B1": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "C1": {
+            "value": "hello",
+            "type": "string",
+            "serial": null
+          },
+          "D1": {
+            "value": "TRUE",
+            "type": "boolean",
+            "serial": null
+          }
+        },
+        "Quoted Name": {
+          "A1": {
+            "value": "100",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "200",
+            "type": "number",
+            "serial": null
+          },
+          "A3": {
+            "value": "300",
+            "type": "number",
+            "serial": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/workbook/tests/fixtures/workbook/cross-sheet/cross_sheet_basic.input.json
+++ b/crates/workbook/tests/fixtures/workbook/cross-sheet/cross_sheet_basic.input.json
@@ -1,0 +1,41 @@
+{
+  "id": "cross_sheet_basic",
+  "category": "cross-sheet",
+  "description": "Cross-sheet references: a Calc sheet reads cells and ranges on a Data sheet (incl. a quoted-name sheet), and a missing-sheet ref produces #REF!.",
+  "workbook": {
+    "engine": "sheets",
+    "sheets": [
+      {
+        "name": "Data",
+        "cells": {
+          "A1": 10,
+          "A2": 20,
+          "A3": 30,
+          "B1": "=A1*2",
+          "C1": "hello",
+          "D1": true
+        }
+      },
+      {
+        "name": "Quoted Name",
+        "cells": { "A1": 100, "A2": 200, "A3": 300 }
+      },
+      {
+        "name": "Calc",
+        "cells": {
+          "A1": "=Data!A1",
+          "A2": "=Data!A1+Data!B1",
+          "A3": "=SUM(Data!A1:A3)",
+          "A4": "=AVERAGE(Data!A1:A3)",
+          "A5": "='Quoted Name'!A1",
+          "A6": "=SUM('Quoted Name'!A1:A3)",
+          "A7": "=Data!C1",
+          "A8": "=Data!D1",
+          "A9": "=IF(Data!A1>5,\"big\",\"small\")",
+          "A10": "=MissingSheet!A1"
+        }
+      }
+    ],
+    "names": []
+  }
+}

--- a/crates/workbook/tests/fixtures/workbook/cycles/cycle_and_downstream.expected.json
+++ b/crates/workbook/tests/fixtures/workbook/cycles/cycle_and_downstream.expected.json
@@ -1,0 +1,43 @@
+{
+  "id": "cycle_and_downstream",
+  "engine": "sheets",
+  "meta": {
+    "locale": "en_US",
+    "timezone": "Etc/GMT",
+    "evaluatedAt": "2026-06-08T18:44:50.690Z"
+  },
+  "steps": [
+    {
+      "label": "initial",
+      "grid": {
+        "S": {
+          "A1": {
+            "value": "#REF!",
+            "type": "error",
+            "serial": null
+          },
+          "A2": {
+            "value": "#REF!",
+            "type": "error",
+            "serial": null
+          },
+          "A3": {
+            "value": "#REF!",
+            "type": "error",
+            "serial": null
+          },
+          "B1": {
+            "value": "#REF!",
+            "type": "error",
+            "serial": null
+          },
+          "C1": {
+            "value": "#REF!",
+            "type": "error",
+            "serial": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/workbook/tests/fixtures/workbook/cycles/cycle_and_downstream.input.json
+++ b/crates/workbook/tests/fixtures/workbook/cycles/cycle_and_downstream.input.json
@@ -1,0 +1,21 @@
+{
+  "id": "cycle_and_downstream",
+  "category": "cycles",
+  "description": "A two-cell circular dependency (A1->A2->A1) and a cell downstream of the cycle (B1=A1+1). Records Sheets' circular-dependency error semantics for every cell on the cycle and its downstream propagation.",
+  "workbook": {
+    "engine": "sheets",
+    "sheets": [
+      {
+        "name": "S",
+        "cells": {
+          "A1": "=A2",
+          "A2": "=A1",
+          "B1": "=A1+1",
+          "C1": "=A3+1",
+          "A3": "=A3"
+        }
+      }
+    ],
+    "names": []
+  }
+}

--- a/crates/workbook/tests/fixtures/workbook/date-type/date_type_production.expected.json
+++ b/crates/workbook/tests/fixtures/workbook/date-type/date_type_production.expected.json
@@ -1,0 +1,68 @@
+{
+  "id": "date_type_production",
+  "engine": "sheets",
+  "meta": {
+    "locale": "en_US",
+    "timezone": "Etc/GMT",
+    "evaluatedAt": "2026-06-08T18:44:54.307Z"
+  },
+  "steps": [
+    {
+      "label": "initial",
+      "grid": {
+        "S": {
+          "A1": {
+            "value": "46180",
+            "type": "date",
+            "serial": 46180
+          },
+          "A2": {
+            "value": "46181",
+            "type": "date",
+            "serial": 46181
+          },
+          "A3": {
+            "value": "6",
+            "type": "number",
+            "serial": null
+          },
+          "A4": {
+            "value": "46180",
+            "type": "number",
+            "serial": null
+          },
+          "A5": {
+            "value": "2026-06-07",
+            "type": "string",
+            "serial": null
+          },
+          "A6": {
+            "value": "46203",
+            "type": "date",
+            "serial": 46203
+          },
+          "A7": {
+            "value": "46180",
+            "type": "number",
+            "serial": null
+          },
+          "A8": {
+            "value": "TRUE",
+            "type": "boolean",
+            "serial": null
+          },
+          "B1": {
+            "value": "46180",
+            "type": "date",
+            "serial": 46180
+          },
+          "B2": {
+            "value": "46180",
+            "type": "date",
+            "serial": 46180
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/workbook/tests/fixtures/workbook/date-type/date_type_production.input.json
+++ b/crates/workbook/tests/fixtures/workbook/date-type/date_type_production.input.json
@@ -1,0 +1,26 @@
+{
+  "id": "date_type_production",
+  "category": "date-type",
+  "description": "Which operations produce a Date-typed cell vs a plain number, under the pinned context. Mirrors the per-row DATE_TYPE cases at the workbook level so the produced/propagated date type is observed in a real grid.",
+  "workbook": {
+    "engine": "sheets",
+    "sheets": [
+      {
+        "name": "S",
+        "cells": {
+          "A1": "=DATE(2026,6,7)",
+          "A2": "=DATE(2026,6,7)+1",
+          "A3": "=DATE(2026,6,7)-DATE(2026,6,1)",
+          "A4": "=N(DATE(2026,6,7))",
+          "A5": "=TEXT(DATE(2026,6,7),\"yyyy-mm-dd\")",
+          "A6": "=EOMONTH(DATE(2026,6,7),0)",
+          "A7": "=DATEVALUE(\"2026-06-07\")",
+          "A8": "=ISDATE(DATE(2026,6,7))",
+          "B1": "=A1",
+          "B2": "=A1+0"
+        }
+      }
+    ],
+    "names": []
+  }
+}

--- a/crates/workbook/tests/fixtures/workbook/named-ranges/named_ranges_basic.expected.json
+++ b/crates/workbook/tests/fixtures/workbook/named-ranges/named_ranges_basic.expected.json
@@ -1,0 +1,122 @@
+{
+  "id": "named_ranges_basic",
+  "engine": "sheets",
+  "meta": {
+    "locale": "en_US",
+    "timezone": "Etc/GMT",
+    "evaluatedAt": "2026-06-08T18:45:02.054Z"
+  },
+  "steps": [
+    {
+      "label": "initial",
+      "grid": {
+        "Calc": {
+          "A1": {
+            "value": "0.0825",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "8.25",
+            "type": "number",
+            "serial": null
+          },
+          "A3": {
+            "value": "60",
+            "type": "number",
+            "serial": null
+          },
+          "A4": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "A5": {
+            "value": "30",
+            "type": "number",
+            "serial": null
+          },
+          "A6": {
+            "value": "10",
+            "type": "number",
+            "serial": null
+          },
+          "A7": {
+            "value": "2",
+            "type": "number",
+            "serial": null
+          },
+          "A8": {
+            "value": "300",
+            "type": "number",
+            "serial": null
+          },
+          "A9": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "A10": {
+            "value": "#NAME?",
+            "type": "error",
+            "serial": null
+          }
+        },
+        "Data": {
+          "A1": {
+            "value": "0.0825",
+            "type": "number",
+            "serial": null
+          },
+          "B1": {
+            "value": "10",
+            "type": "number",
+            "serial": null
+          },
+          "B2": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "B3": {
+            "value": "30",
+            "type": "number",
+            "serial": null
+          },
+          "C1": {
+            "value": "1",
+            "type": "number",
+            "serial": null
+          },
+          "C2": {
+            "value": "2",
+            "type": "number",
+            "serial": null
+          },
+          "D1": {
+            "value": "3",
+            "type": "number",
+            "serial": null
+          },
+          "D2": {
+            "value": "4",
+            "type": "number",
+            "serial": null
+          }
+        },
+        "Quoted Name": {
+          "A1": {
+            "value": "100",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "200",
+            "type": "number",
+            "serial": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/workbook/tests/fixtures/workbook/named-ranges/named_ranges_basic.input.json
+++ b/crates/workbook/tests/fixtures/workbook/named-ranges/named_ranges_basic.input.json
@@ -1,0 +1,43 @@
+{
+  "id": "named_ranges_basic",
+  "category": "named-ranges",
+  "description": "Workbook-scoped named ranges: scalar (TaxRate), column (Prices), rectangular (Grid), and a name targeting a quoted sheet (QuotedVals); plus a missing-name #NAME? case.",
+  "workbook": {
+    "engine": "sheets",
+    "sheets": [
+      {
+        "name": "Data",
+        "cells": {
+          "A1": 0.0825,
+          "B1": 10, "B2": 20, "B3": 30,
+          "C1": 1, "C2": 2, "D1": 3, "D2": 4
+        }
+      },
+      {
+        "name": "Quoted Name",
+        "cells": { "A1": 100, "A2": 200 }
+      },
+      {
+        "name": "Calc",
+        "cells": {
+          "A1": "=TaxRate",
+          "A2": "=TaxRate*100",
+          "A3": "=SUM(Prices)",
+          "A4": "=AVERAGE(Prices)",
+          "A5": "=MAX(Prices)",
+          "A6": "=SUM(Grid)",
+          "A7": "=COLUMNS(Grid)",
+          "A8": "=SUM(QuotedVals)",
+          "A9": "=INDEX(Prices,2)",
+          "A10": "=NotADefinedName"
+        }
+      }
+    ],
+    "names": [
+      { "name": "TaxRate", "ref": "Data!A1" },
+      { "name": "Prices", "ref": "Data!B1:B3" },
+      { "name": "Grid", "ref": "Data!C1:D2" },
+      { "name": "QuotedVals", "ref": "'Quoted Name'!A1:A2" }
+    ]
+  }
+}

--- a/crates/workbook/tests/fixtures/workbook/recalc-after-edit/recalc_after_edit.expected.json
+++ b/crates/workbook/tests/fixtures/workbook/recalc-after-edit/recalc_after_edit.expected.json
@@ -1,0 +1,211 @@
+{
+  "id": "recalc_after_edit",
+  "engine": "sheets",
+  "meta": {
+    "locale": "en_US",
+    "timezone": "Etc/GMT",
+    "evaluatedAt": "2026-06-08T18:45:59.049Z"
+  },
+  "steps": [
+    {
+      "label": "initial",
+      "grid": {
+        "Calc": {
+          "A1": {
+            "value": "60",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "10",
+            "type": "number",
+            "serial": null
+          },
+          "A3": {
+            "value": "10",
+            "type": "number",
+            "serial": null
+          }
+        },
+        "Data": {
+          "A1": {
+            "value": "10",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "B1": {
+            "value": "30",
+            "type": "number",
+            "serial": null
+          }
+        }
+      }
+    },
+    {
+      "label": "edit[0]",
+      "grid": {
+        "Calc": {
+          "A1": {
+            "value": "238",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          },
+          "A3": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          }
+        },
+        "Data": {
+          "A1": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "B1": {
+            "value": "119",
+            "type": "number",
+            "serial": null
+          }
+        }
+      }
+    },
+    {
+      "label": "edit[1]",
+      "grid": {
+        "Calc": {
+          "A1": {
+            "value": "238",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "A3": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          }
+        },
+        "Data": {
+          "A1": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "B1": {
+            "value": "119",
+            "type": "number",
+            "serial": null
+          }
+        }
+      }
+    },
+    {
+      "label": "edit[2]",
+      "grid": {
+        "Calc": {
+          "A1": {
+            "value": "238",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "A3": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          },
+          "A4": {
+            "value": "119",
+            "type": "number",
+            "serial": null
+          }
+        },
+        "Data": {
+          "A1": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "B1": {
+            "value": "119",
+            "type": "number",
+            "serial": null
+          }
+        }
+      }
+    },
+    {
+      "label": "edit[3]",
+      "grid": {
+        "Calc": {
+          "A1": {
+            "value": "198",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "",
+            "type": "string",
+            "serial": null
+          },
+          "A3": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          },
+          "A4": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          }
+        },
+        "Data": {
+          "A1": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          },
+          "B1": {
+            "value": "99",
+            "type": "number",
+            "serial": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/workbook/tests/fixtures/workbook/recalc-after-edit/recalc_after_edit.input.json
+++ b/crates/workbook/tests/fixtures/workbook/recalc-after-edit/recalc_after_edit.input.json
@@ -1,0 +1,29 @@
+{
+  "id": "recalc_after_edit",
+  "category": "recalc-after-edit",
+  "description": "An initial workbook with a dependency chain, then an edit script: set Data!A1, retarget a named range, set a downstream cell to a formula, and clear a cell. Each step records the full recalced grid.",
+  "workbook": {
+    "engine": "sheets",
+    "sheets": [
+      {
+        "name": "Data",
+        "cells": { "A1": 10, "A2": 20, "B1": "=A1+A2" }
+      },
+      {
+        "name": "Calc",
+        "cells": {
+          "A1": "=Data!B1*2",
+          "A2": "=Rate",
+          "A3": "=Data!A1"
+        }
+      }
+    ],
+    "names": [ { "name": "Rate", "ref": "Data!A1" } ]
+  },
+  "edits": [
+    { "sheet": "Data", "cell": "A1", "input": 99 },
+    { "defineName": { "name": "Rate", "ref": "Data!A2" } },
+    { "sheet": "Calc", "cell": "A4", "input": "=Data!A1+Data!A2" },
+    { "sheet": "Data", "cell": "A2", "clear": true }
+  ]
+}

--- a/crates/workbook/tests/fixtures/workbook/spill/spill_basic_and_blocked.expected.json
+++ b/crates/workbook/tests/fixtures/workbook/spill/spill_basic_and_blocked.expected.json
@@ -1,0 +1,63 @@
+{
+  "id": "spill_basic_and_blocked",
+  "engine": "sheets",
+  "meta": {
+    "locale": "en_US",
+    "timezone": "Etc/GMT",
+    "evaluatedAt": "2026-06-08T18:46:10.820Z"
+  },
+  "steps": [
+    {
+      "label": "initial",
+      "grid": {
+        "S": {
+          "A1": {
+            "value": "1",
+            "type": "number",
+            "serial": null
+          },
+          "A2": {
+            "value": "2",
+            "type": "number",
+            "serial": null
+          },
+          "A3": {
+            "value": "3",
+            "type": "number",
+            "serial": null
+          },
+          "C1": {
+            "value": "10",
+            "type": "number",
+            "serial": null
+          },
+          "C2": {
+            "value": "20",
+            "type": "number",
+            "serial": null
+          },
+          "D1": {
+            "value": "15",
+            "type": "number",
+            "serial": null
+          },
+          "D2": {
+            "value": "25",
+            "type": "number",
+            "serial": null
+          },
+          "F1": {
+            "value": "#REF!",
+            "type": "error",
+            "serial": null
+          },
+          "F2": {
+            "value": "blocker",
+            "type": "string",
+            "serial": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/workbook/tests/fixtures/workbook/spill/spill_basic_and_blocked.input.json
+++ b/crates/workbook/tests/fixtures/workbook/spill/spill_basic_and_blocked.input.json
@@ -1,0 +1,20 @@
+{
+  "id": "spill_basic_and_blocked",
+  "category": "spill",
+  "description": "Array formulas that spill into neighbour cells (SORT, SEQUENCE) plus a blocked spill where a literal sits in the spill range. Records the evaluated value of every spilled cell and the blocked-spill error at the anchor.",
+  "workbook": {
+    "engine": "sheets",
+    "sheets": [
+      {
+        "name": "S",
+        "cells": {
+          "A1": "=SORT({3;1;2})",
+          "C1": "=SEQUENCE(2,2,10,5)",
+          "F1": "=SEQUENCE(3)",
+          "F2": "blocker"
+        }
+      }
+    ],
+    "names": []
+  }
+}

--- a/crates/workbook/tests/fixtures/workbook/volatile-with-fixed-context/volatile_today.expected.json
+++ b/crates/workbook/tests/fixtures/workbook/volatile-with-fixed-context/volatile_today.expected.json
@@ -1,0 +1,43 @@
+{
+  "id": "volatile_today",
+  "engine": "sheets",
+  "meta": {
+    "locale": "en_US",
+    "timezone": "Etc/GMT",
+    "evaluatedAt": "2026-06-08T18:46:20.805Z"
+  },
+  "steps": [
+    {
+      "label": "initial",
+      "grid": {
+        "S": {
+          "A1": {
+            "value": "46181",
+            "type": "date",
+            "serial": 46181
+          },
+          "A2": {
+            "value": "TRUE",
+            "type": "boolean",
+            "serial": null
+          },
+          "A3": {
+            "value": "0",
+            "type": "number",
+            "serial": null
+          },
+          "A4": {
+            "value": "46181",
+            "type": "number",
+            "serial": null
+          },
+          "A5": {
+            "value": "2026",
+            "type": "number",
+            "serial": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/crates/workbook/tests/fixtures/workbook/volatile-with-fixed-context/volatile_today.input.json
+++ b/crates/workbook/tests/fixtures/workbook/volatile-with-fixed-context/volatile_today.input.json
@@ -1,0 +1,21 @@
+{
+  "id": "volatile_today",
+  "category": "volatile-with-fixed-context",
+  "description": "Volatile date functions (TODAY/NOW) evaluated under the pinned en_US / Etc/GMT context. The recorded serials are only meaningful together with meta.evaluatedAt from the same run.",
+  "workbook": {
+    "engine": "sheets",
+    "sheets": [
+      {
+        "name": "S",
+        "cells": {
+          "A1": "=TODAY()",
+          "A2": "=ISDATE(TODAY())",
+          "A3": "=TODAY()-TODAY()",
+          "A4": "=N(TODAY())",
+          "A5": "=YEAR(TODAY())"
+        }
+      }
+    ],
+    "names": []
+  }
+}


### PR DESCRIPTION
## Summary

- Imports 7 categories of workbook fixture pairs (`.input.json` + `.expected.json`) from the fixtures pipeline into `crates/workbook/tests/fixtures/workbook/`
- All `expected.json` files were produced by the GAS pipeline against a real Google Sheet (locale `en_US`, timezone `Etc/GMT`, evaluated `2026-06-08T18:44:50Z`) — no values hand-authored
- Categories: `cycles/`, `spill/`, `cross-sheet/`, `named-ranges/`, `date-type/`, `recalc-after-edit/`, `volatile-with-fixed-context/`
- Two key confirmations from the pipeline output:
  - `cycle_and_downstream`: all cycle/downstream cells → `#REF!` — confirms `CIRCULAR_ERROR = "#REF!"`
  - `spill_basic_and_blocked`: blocked spill anchor → `#REF!` — confirms `BLOCKED_SPILL_ERROR = "#REF!"`

The conformance test that exercises these fixtures comes in the follow-up code PR (also targeting #589).

closes #589

## Test plan

- [ ] No production code changes — CI passes trivially (no compilation, no test logic changed)
- [ ] Verify all 14 fixture files land under `crates/workbook/tests/fixtures/workbook/` with correct JSON structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)