### PR TITLE
feat(npm): @truecalc/workbook packaging — README, examples, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,39 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  examples:
+    name: npm examples (Node LTS)
+    runs-on: ubuntu-latest
+    needs: ci
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Build WASM workbook
+        run: wasm-pack build crates/wasm-workbook --target web
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run workbook-node example
+        run: WASM_PKG_PATH=./crates/wasm-workbook/pkg/truecalc_wasm_workbook.js node examples/workbook-node/index.mjs
+
   macos-golden:
     name: macOS golden byte-identity (truecalc-workbook)
     runs-on: macos-latest

--- a/crates/wasm-workbook/README.md
+++ b/crates/wasm-workbook/README.md
@@ -1,0 +1,234 @@
+# @truecalc/workbook
+
+[![npm](https://img.shields.io/npm/v/@truecalc/workbook)](https://www.npmjs.com/package/@truecalc/workbook)
+[![crates.io](https://img.shields.io/crates/v/truecalc-core)](https://crates.io/crates/truecalc-core)
+[![docs.rs](https://img.shields.io/docsrs/truecalc-core)](https://docs.rs/truecalc-core)
+[![license](https://img.shields.io/crates/l/truecalc-core)](LICENSE)
+
+Spreadsheet workbook for JavaScript — full recalculation engine compiled to WebAssembly.
+Manage multiple sheets, set cell values and formulas, and trigger recalculation with a
+single call.
+
+## Install
+
+```sh
+npm install @truecalc/workbook
+```
+
+## Usage
+
+### Node.js (ESM)
+
+```js
+import init, { JsWorkbook } from '@truecalc/workbook';
+
+await init();
+
+const wb = new JsWorkbook('sheets');
+wb.addSheet('Sheet1');
+wb.set('Sheet1', 'A1', '10');
+wb.set('Sheet1', 'A2', '=A1*2');
+wb.recalc(JSON.stringify({ timestamp_ms: 0, timezone: 'UTC', rng_seed: 0 }));
+
+const val = wb.resolved('Sheet1', 'A2');
+// => { type: 'number', value: 20 }
+```
+
+### Node.js (CJS)
+
+Node.js CJS projects can use a dynamic import:
+
+```js
+async function main() {
+  const { default: init, JsWorkbook } = await import('@truecalc/workbook');
+  await init();
+
+  const wb = new JsWorkbook('sheets');
+  wb.addSheet('Sheet1');
+  wb.set('Sheet1', 'B1', '=SUM(A1:A3)');
+  wb.set('Sheet1', 'A1', '1');
+  wb.set('Sheet1', 'A2', '2');
+  wb.set('Sheet1', 'A3', '3');
+  wb.recalc(JSON.stringify({ timestamp_ms: 0, timezone: 'UTC', rng_seed: 0 }));
+
+  console.log(wb.resolved('Sheet1', 'B1'));
+  // => { type: 'number', value: 6 }
+}
+
+main();
+```
+
+### Serialization
+
+```js
+const json = wb.toJSON();
+const wb2 = JsWorkbook.fromJSON(json);
+
+wb2.recalc(JSON.stringify({ timestamp_ms: 0, timezone: 'UTC', rng_seed: 0 }));
+console.log(wb2.resolved('Sheet1', 'A2'));
+// => { type: 'number', value: 20 }
+```
+
+### Vite
+
+Install the wasm plugin first:
+
+```sh
+npm install -D vite-plugin-wasm
+```
+
+Add it to `vite.config.js`:
+
+```js
+import wasm from 'vite-plugin-wasm';
+
+export default {
+  plugins: [wasm()],
+};
+```
+
+Then import and use normally:
+
+```js
+import init, { JsWorkbook } from '@truecalc/workbook';
+
+await init();
+
+const wb = new JsWorkbook('sheets');
+wb.addSheet('Sheet1');
+wb.set('Sheet1', 'A1', '=IF(B1 > 0, "positive", "non-positive")');
+wb.set('Sheet1', 'B1', '5');
+wb.recalc(JSON.stringify({ timestamp_ms: 0, timezone: 'UTC', rng_seed: 0 }));
+
+const result = wb.resolved('Sheet1', 'A1');
+// => { type: 'text', value: 'positive' }
+```
+
+### webpack 5
+
+webpack 5 supports WebAssembly natively. Enable the experiment in `webpack.config.js`:
+
+```js
+module.exports = {
+  experiments: {
+    asyncWebAssembly: true,
+  },
+};
+```
+
+## API Reference
+
+### `new JsWorkbook(flavor)`
+
+Creates a new empty workbook.
+
+- `flavor` — engine flavor string (use `'sheets'` for Google Sheets-compatible behavior).
+
+```js
+const wb = new JsWorkbook('sheets');
+```
+
+### `wb.addSheet(name)`
+
+Adds a new sheet to the workbook.
+
+- `name` — sheet name, e.g. `'Sheet1'`.
+
+```js
+wb.addSheet('Sheet1');
+wb.addSheet('Summary');
+```
+
+### `wb.set(sheet, cell, value)`
+
+Sets a cell to a literal value or formula. Formulas start with `=`.
+
+- `sheet` — sheet name
+- `cell` — A1-style cell reference, e.g. `'B2'`
+- `value` — string literal or formula string
+
+```js
+wb.set('Sheet1', 'A1', '42');
+wb.set('Sheet1', 'A2', '=A1 * 2');
+wb.set('Sheet1', 'A3', '=SUM(A1:A2)');
+```
+
+### `wb.clear(sheet, cell)`
+
+Clears a cell (removes its value or formula).
+
+- `sheet` — sheet name
+- `cell` — A1-style cell reference
+
+```js
+wb.clear('Sheet1', 'A1');
+```
+
+### `wb.defineName(name, expression)`
+
+Defines a named range or formula that can be referenced by name across sheets.
+
+- `name` — name identifier
+- `expression` — formula expression string
+
+```js
+wb.defineName('TaxRate', '0.2');
+wb.set('Sheet1', 'B1', '=A1 * TaxRate');
+```
+
+### `wb.recalc(context_json)`
+
+Recalculates all formulas in the workbook. Must be called after any `set`/`clear`/`defineName`
+operations before reading results.
+
+- `context_json` — JSON string with evaluation context:
+  - `timestamp_ms` — Unix timestamp in milliseconds (for `TODAY()`, `NOW()`)
+  - `timezone` — IANA timezone string, e.g. `'UTC'` or `'America/New_York'`
+  - `rng_seed` — integer seed for random functions (`RAND`, `RANDBETWEEN`)
+
+```js
+wb.recalc(JSON.stringify({ timestamp_ms: Date.now(), timezone: 'UTC', rng_seed: 0 }));
+```
+
+### `wb.resolved(sheet, cell)`
+
+Returns the evaluated result for a cell after recalculation.
+
+- `sheet` — sheet name
+- `cell` — A1-style cell reference
+
+Returns a discriminated union object tagged by `type`:
+
+| `type`   | Shape                                                  |
+|----------|--------------------------------------------------------|
+| `number` | `{ type: 'number', value: 6 }`                         |
+| `text`   | `{ type: 'text', value: 'yes' }`                       |
+| `bool`   | `{ type: 'bool', value: true }`                        |
+| `date`   | `{ type: 'date', value: 46180 }`                       |
+| `error`  | `{ type: 'error', error: '#NAME?' }`                   |
+| `empty`  | `{ type: 'empty' }`                                    |
+| `array`  | `{ type: 'array', value: [ /* EvalResult cells */ ] }` |
+
+```js
+const result = wb.resolved('Sheet1', 'A2');
+// => { type: 'number', value: 20 }
+```
+
+### `wb.toJSON()`
+
+Serializes the entire workbook state (sheets, cell values, formulas, named ranges)
+to a JSON string.
+
+```js
+const json = wb.toJSON();
+```
+
+### `JsWorkbook.fromJSON(json)`
+
+Deserializes a workbook from a JSON string produced by `toJSON()`. Returns a new
+`JsWorkbook` instance.
+
+```js
+const wb2 = JsWorkbook.fromJSON(json);
+wb2.recalc(JSON.stringify({ timestamp_ms: 0, timezone: 'UTC', rng_seed: 0 }));
+```

--- a/crates/wasm-workbook/package.json
+++ b/crates/wasm-workbook/package.json
@@ -1,9 +1,21 @@
 {
   "name": "@truecalc/workbook",
+  "description": "Spreadsheet workbook for JavaScript — full recalculation engine compiled to WebAssembly",
+  "keywords": ["spreadsheet", "workbook", "formula", "wasm", "recalc"],
   "publishConfig": {
     "provenance": true,
     "access": "public"
   },
+  "type": "module",
+  "main": "./truecalc_wasm_workbook.js",
+  "types": "./truecalc_wasm_workbook.d.ts",
+  "files": [
+    "truecalc_wasm_workbook.js",
+    "truecalc_wasm_workbook_bg.wasm",
+    "truecalc_wasm_workbook.d.ts",
+    "truecalc_wasm_workbook_bg.wasm.d.ts"
+  ],
+  "sideEffects": false,
   "scripts": {
     "prepublishOnly": "echo 'Use CI to publish' && exit 1"
   }

--- a/examples/workbook-node/index.mjs
+++ b/examples/workbook-node/index.mjs
@@ -1,0 +1,80 @@
+// Runnable Node.js 20 ESM example for @truecalc/workbook.
+//
+// Run against the local build:
+//   WASM_PKG_PATH=./crates/wasm-workbook/pkg/truecalc_wasm_workbook.js node examples/workbook-node/index.mjs
+//
+// Run against the published package (after npm install):
+//   node examples/workbook-node/index.mjs
+
+const pkgPath = process.env.WASM_PKG_PATH || '@truecalc/workbook';
+const { default: init, JsWorkbook } = await import(pkgPath);
+await init();
+
+// ── Example 1: basic formulas on a single sheet ──────────────────────────────
+
+const wb = new JsWorkbook('sheets');
+wb.addSheet('Sheet1');
+
+wb.set('Sheet1', 'A1', '10');
+wb.set('Sheet1', 'A2', '20');
+wb.set('Sheet1', 'A3', '=SUM(A1:A2)');
+wb.set('Sheet1', 'B1', '=A3 * 2');
+
+wb.recalc(JSON.stringify({ timestamp_ms: 0, timezone: 'UTC', rng_seed: 0 }));
+
+const a3 = wb.resolved('Sheet1', 'A3');
+const b1 = wb.resolved('Sheet1', 'B1');
+
+console.assert(a3.type === 'number' && a3.value === 30, `A3 expected 30, got ${JSON.stringify(a3)}`);
+console.assert(b1.type === 'number' && b1.value === 60, `B1 expected 60, got ${JSON.stringify(b1)}`);
+console.log('Sheet1 A3:', a3);  // { type: 'number', value: 30 }
+console.log('Sheet1 B1:', b1);  // { type: 'number', value: 60 }
+
+// ── Example 2: cross-sheet reference ─────────────────────────────────────────
+
+wb.addSheet('Summary');
+wb.set('Summary', 'A1', '=Sheet1!A3');
+
+wb.recalc(JSON.stringify({ timestamp_ms: 0, timezone: 'UTC', rng_seed: 0 }));
+
+const summaryA1 = wb.resolved('Summary', 'A1');
+console.assert(
+  summaryA1.type === 'number' && summaryA1.value === 30,
+  `Summary!A1 expected 30, got ${JSON.stringify(summaryA1)}`
+);
+console.log('Summary A1 (cross-sheet):', summaryA1);  // { type: 'number', value: 30 }
+
+// ── Example 3: text formulas ──────────────────────────────────────────────────
+
+wb.set('Sheet1', 'C1', 'hello');
+wb.set('Sheet1', 'C2', '=UPPER(C1)');
+
+wb.recalc(JSON.stringify({ timestamp_ms: 0, timezone: 'UTC', rng_seed: 0 }));
+
+const c2 = wb.resolved('Sheet1', 'C2');
+console.assert(c2.type === 'text' && c2.value === 'HELLO', `C2 expected 'HELLO', got ${JSON.stringify(c2)}`);
+console.log('Sheet1 C2 (UPPER):', c2);  // { type: 'text', value: 'HELLO' }
+
+// ── Example 4: serialization roundtrip ───────────────────────────────────────
+
+const json = wb.toJSON();
+console.assert(typeof json === 'string' && json.length > 0, 'toJSON() should return a non-empty string');
+
+const wb2 = JsWorkbook.fromJSON(json);
+wb2.recalc(JSON.stringify({ timestamp_ms: 0, timezone: 'UTC', rng_seed: 0 }));
+
+const a3After = wb2.resolved('Sheet1', 'A3');
+const summaryAfter = wb2.resolved('Summary', 'A1');
+
+console.assert(
+  a3After.type === 'number' && a3After.value === 30,
+  `roundtrip A3 expected 30, got ${JSON.stringify(a3After)}`
+);
+console.assert(
+  summaryAfter.type === 'number' && summaryAfter.value === 30,
+  `roundtrip Summary!A1 expected 30, got ${JSON.stringify(summaryAfter)}`
+);
+console.log('Roundtrip Sheet1 A3:', a3After);    // { type: 'number', value: 30 }
+console.log('Roundtrip Summary A1:', summaryAfter);  // { type: 'number', value: 30 }
+
+console.log('All assertions passed.');

--- a/examples/workbook-node/index.mjs
+++ b/examples/workbook-node/index.mjs
@@ -6,9 +6,18 @@
 // Run against the published package (after npm install):
 //   node examples/workbook-node/index.mjs
 
-const pkgPath = process.env.WASM_PKG_PATH || '@truecalc/workbook';
-const { default: init, JsWorkbook } = await import(pkgPath);
-await init();
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// When using a local build, resolve the path against CWD (not the file's dir)
+// and pass wasm bytes directly to avoid fetch() failure on file:// URLs.
+const wasmPkgJs = process.env.WASM_PKG_PATH
+  ? resolve(process.cwd(), process.env.WASM_PKG_PATH)
+  : null;
+const pkgSpecifier = wasmPkgJs ? pathToFileURL(wasmPkgJs).href : '@truecalc/workbook';
+const { default: init, JsWorkbook } = await import(pkgSpecifier);
+await init(wasmPkgJs ? readFileSync(wasmPkgJs.replace(/\.js$/, '_bg.wasm')) : undefined);
 
 // ── Example 1: basic formulas on a single sheet ──────────────────────────────
 


### PR DESCRIPTION
## Summary

- Update `crates/wasm-workbook/package.json` with full ESM/CJS npm fields: `type`, `main`, `types`, `files`, `keywords`, `description`, `sideEffects`
- Add `crates/wasm-workbook/README.md` with Install, Usage (Node ESM, Node CJS, Vite, webpack 5), Serialization, and API Reference sections — modelled on `@truecalc/core` README
- Add `examples/workbook-node/index.mjs`: runnable Node 20 ESM example exercising multi-sheet workbook, cross-sheet references, text formulas, and JSON serialization roundtrip
- Add `examples` CI job to `.github/workflows/ci.yml` that builds the WASM workbook via `wasm-pack` and runs the example on Node LTS

closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)