### PR TITLE
fix(ci): restore working tree after gh-pages checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,8 @@ jobs:
           git add conformance-badge.json coverage-badge.json index.html .nojekyll coverage/ conformance-summary.json
           git diff --cached --quiet || git commit -m "chore: update conformance + coverage report [skip ci]"
           git push --force origin gh-pages
+          # Restore working tree so subsequent steps (Clippy, wasm-pack) see source files.
+          git checkout "$GITHUB_SHA"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- The "Publish conformance report to gh-pages" step in the `ci` job switches the working tree to the `gh-pages` branch (via `git checkout gh-pages`) but never restores it afterward
- This causes all subsequent steps — Clippy, Build WASM, **Build WASM workbook** — to fail with `crate directory is missing a Cargo.toml file` on every push to main
- Fix: add `git checkout "$GITHUB_SHA"` after the gh-pages push to restore the source tree

## Test plan

- [ ] CI passes on this PR (the fix only runs on push to main, so the PR itself just needs to not regress)
- [ ] After merging, verify that the next push to main runs Clippy + Build WASM workbook successfully

closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)