### PR TITLE
fix(core): deprecation 'since' attribute and conformance comment cleanup

### DIFF
--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -46,7 +46,7 @@ impl Engine {
     }
 
     /// Deprecated alias for [`Engine::sheets`].
-    #[deprecated(note = "use Engine::sheets() — engine flavor is required; see ADR 2026-04-27")]
+    #[deprecated(since = "0.7.0", note = "use Engine::sheets() — engine flavor is required; see ADR 2026-04-27; removal target: 0.7.0 coordinated release")]
     pub fn google_sheets() -> Self {
         Self::sheets()
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 /// Evaluate a formula string with named variables, targeting Google Sheets conformance.
 ///
 /// Returns `Value::Error(ErrorKind::Value)` on parse failure.
-#[deprecated(note = "use Engine::sheets()/Engine::excel() and engine.evaluate() — engine flavor is required; see ADR 2026-04-27")]
+#[deprecated(since = "0.7.0", note = "use Engine::sheets()/Engine::excel() and engine.evaluate() — engine flavor is required; see ADR 2026-04-27; removal target: 0.7.0 coordinated release")]
 pub fn evaluate(formula: &str, variables: &HashMap<String, Value>) -> Value {
     Engine::sheets().evaluate(formula, variables)
 }

--- a/crates/core/src/parser/mod.rs
+++ b/crates/core/src/parser/mod.rs
@@ -452,7 +452,7 @@ fn is_cell_ref(name: &str) -> bool {
 ///
 /// The formula must start with `=`. Returns a [`ParseError`] if the input
 /// is not a valid formula.
-#[deprecated(note = "use Engine::sheets()/Engine::excel() and engine.parse() — engine flavor is required; see ADR 2026-04-27")]
+#[deprecated(since = "0.7.0", note = "use Engine::sheets()/Engine::excel() and engine.parse() — engine flavor is required; see ADR 2026-04-27; removal target: 0.7.0 coordinated release")]
 pub fn parse(formula: &str) -> Result<Expr, ParseError> {
     parse_formula(formula)
 }
@@ -485,7 +485,7 @@ pub(crate) fn parse_formula(formula: &str) -> Result<Expr, ParseError> {
 }
 
 /// Validate that a formula string is syntactically correct without returning the AST.
-#[deprecated(note = "use Engine::sheets()/Engine::excel() and engine.validate() — engine flavor is required; see ADR 2026-04-27")]
+#[deprecated(since = "0.7.0", note = "use Engine::sheets()/Engine::excel() and engine.validate() — engine flavor is required; see ADR 2026-04-27; removal target: 0.7.0 coordinated release")]
 pub fn validate(formula: &str) -> Result<(), ParseError> {
     parse_formula(formula).map(|_| ())
 }

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -21,7 +21,7 @@
 //!   test_category   basic / edge / coercion / error / nested
 //!   expected_type   number / string / boolean / error / array / date
 //!
-//! The test evaluates the formula with `truecalc_core::evaluate` and compares
+//! The test evaluates the formula with `Engine::sheets().evaluate` and compares
 //! against the canonical value.  Number comparisons allow 1e-4 relative tolerance.
 
 use truecalc_core::{ErrorKind, Value};


### PR DESCRIPTION
## Summary

- Add `since = "0.7.0"` to all four deprecated engine-less entry points (`Engine::google_sheets()`, `evaluate()`, `parse()`, `validate()`) so tooling and docs can surface the removal milestone
- Fix stale doc comment in `conformance.rs` that referenced the removed `truecalc_core::evaluate` free function; updated to `Engine::sheets().evaluate`

closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)