### PR TITLE
fix(core): add ErrorKind::Unsupported for Engine::excel() evaluate

### DIFF
--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -15,7 +15,7 @@ use crate::types::{ErrorKind, ParseError, Value};
 ///   historical Lotus 1-2-3 leap-year bug (serial 60 = the fictitious
 ///   1900-02-29). Conversion helpers live in
 ///   `eval::functions::date::serial`; Excel evaluation itself is still
-///   stubbed (`evaluate` returns `#N/A`).
+///   stubbed (`evaluate` returns `#UNSUPPORTED!`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
@@ -39,7 +39,7 @@ impl Engine {
     ///
     /// Excel evaluation semantics are not implemented yet (they land in a
     /// later phase): [`Engine::evaluate`] returns
-    /// `Value::Error(ErrorKind::NA)` for every formula. [`Engine::parse`]
+    /// `Value::Error(ErrorKind::Unsupported)` for every formula. [`Engine::parse`]
     /// and [`Engine::validate`] work.
     pub fn excel() -> Self {
         Self { flavor: EngineFlavor::Excel, registry: Registry::new() }
@@ -125,7 +125,7 @@ impl Engine {
     /// [`Resolver`].
     ///
     /// The engine flavor stays explicit: `Engine::excel().evaluate_with_resolver`
-    /// returns `#N/A` until Excel evaluation lands, exactly like
+    /// returns `#UNSUPPORTED!` until Excel evaluation lands, exactly like
     /// [`Engine::evaluate`].
     ///
     /// ```
@@ -169,7 +169,7 @@ impl Engine {
             }
         }
         if self.flavor == EngineFlavor::Excel {
-            return Value::Error(ErrorKind::NA);
+            return Value::Error(ErrorKind::Unsupported);
         }
         match parse_formula(formula) {
             Err(_) => Value::Error(ErrorKind::Value),
@@ -190,7 +190,7 @@ impl Engine {
     ) -> Value {
         if self.flavor == EngineFlavor::Excel {
             // Excel evaluation semantics are not implemented yet.
-            return Value::Error(ErrorKind::NA);
+            return Value::Error(ErrorKind::Unsupported);
         }
         match parse_formula(formula) {
             Err(_) => Value::Error(ErrorKind::Value),

--- a/crates/core/src/engine/tests.rs
+++ b/crates/core/src/engine/tests.rs
@@ -54,9 +54,27 @@ fn excel_parses_and_validates() {
 #[test]
 fn excel_evaluate_returns_unsupported_error() {
     // Excel evaluation semantics are not implemented yet — evaluate must
-    // return a clear error rather than silently using Sheets semantics.
+    // return a clear Unsupported error (not #N/A) so callers can distinguish
+    // "Excel eval not implemented" from a legitimate N/A result.
     let engine = Engine::excel();
     let result = engine.evaluate("=SUM(1,2)", &HashMap::new());
+    assert_eq!(result, Value::Error(ErrorKind::Unsupported));
+}
+
+#[test]
+fn excel_evaluate_is_not_na() {
+    // ErrorKind::Unsupported must be distinct from ErrorKind::NA.
+    let engine = Engine::excel();
+    let result = engine.evaluate("=1+1", &HashMap::new());
+    assert_ne!(result, Value::Error(ErrorKind::NA));
+    assert_eq!(result, Value::Error(ErrorKind::Unsupported));
+}
+
+#[test]
+fn sheets_na_formula_is_still_na() {
+    // Engine::sheets() evaluating =NA() must still return ErrorKind::NA.
+    let engine = Engine::sheets();
+    let result = engine.evaluate("=NA()", &HashMap::new());
     assert_eq!(result, Value::Error(ErrorKind::NA));
 }
 

--- a/crates/core/src/types/error.rs
+++ b/crates/core/src/types/error.rs
@@ -9,6 +9,10 @@ pub enum ErrorKind {
     Num,
     NA,
     Null,
+    /// Returned by engine operations not yet implemented for this engine flavor.
+    /// Distinct from #N/A so callers can distinguish "Excel eval not implemented"
+    /// from a legitimate N/A result (=NA() or a failed lookup).
+    Unsupported,
 }
 
 impl fmt::Display for ErrorKind {
@@ -21,6 +25,7 @@ impl fmt::Display for ErrorKind {
             ErrorKind::Num       => "#NUM!",
             ErrorKind::NA        => "#N/A",
             ErrorKind::Null      => "#NULL!",
+            ErrorKind::Unsupported => "#UNSUPPORTED!",
         };
         write!(f, "{}", s)
     }

--- a/crates/core/tests/resolver.rs
+++ b/crates/core/tests/resolver.rs
@@ -369,8 +369,8 @@ fn evaluate_with_resolver_at_rejects_non_finite_now() {
 }
 
 #[test]
-fn excel_evaluate_with_resolver_is_na() {
+fn excel_evaluate_with_resolver_is_unsupported() {
     let mut r = ModelResolver::new();
     let v = Engine::excel().evaluate_with_resolver("=Data!A1", &mut r);
-    assert_eq!(v, Value::Error(ErrorKind::NA));
+    assert_eq!(v, Value::Error(ErrorKind::Unsupported));
 }


### PR DESCRIPTION
closes #556

## Summary

- Add `ErrorKind::Unsupported` variant to the `ErrorKind` enum with display string `#UNSUPPORTED!`
- Change `Engine::excel().evaluate()` and `Engine::excel().evaluate_with_resolver()` to return `Value::Error(ErrorKind::Unsupported)` instead of `Value::Error(ErrorKind::NA)`
- Update all tests that previously asserted `ErrorKind::NA` from Excel-flavor evaluate to assert `ErrorKind::Unsupported`
- Add three new tests: `excel_evaluate_is_not_na`, `sheets_na_formula_is_still_na`, and the updated `excel_evaluate_returns_unsupported_error`

## Test plan

- [ ] `cargo clippy --workspace -- -D warnings` passes (no new warnings)
- [ ] `cargo test --workspace` passes (3334 tests)
- [ ] `Engine::excel().evaluate("=1+1", &{})` returns `Value::Error(ErrorKind::Unsupported)` (not `ErrorKind::NA`)
- [ ] `Engine::sheets().evaluate("=NA()", &{})` still returns `Value::Error(ErrorKind::NA)` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)