### PR TITLE
feat(mcp): add workbook session tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,6 +2314,7 @@ dependencies = [
  "calamine",
  "chrono",
  "csv",
+ "libm",
  "nom",
  "proptest",
  "regex-lite",
@@ -2328,6 +2329,7 @@ dependencies = [
  "serde",
  "serde_json",
  "truecalc-core",
+ "truecalc-workbook",
 ]
 
 [[package]]
@@ -2338,6 +2340,18 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "truecalc-core",
+ "tsify-next",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
+name = "truecalc-wasm-workbook"
+version = "0.9.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "truecalc-workbook",
  "tsify-next",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -13,5 +13,6 @@ path = "src/main.rs"
 
 [dependencies]
 truecalc-core = { path = "../core", version = "0.9" }
+truecalc-workbook = { path = "../workbook", version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 
 use truecalc_core::{Engine, Expr, Registry, Value};
+use truecalc_workbook::{Address, CellInput, EngineFlavor as WbEngine, RecalcContext, Value as WbValue, Workbook};
 use serde_json::{json, Value as JsonValue};
 
 // ─── Conformance ─────────────────────────────────────────────────────────────
@@ -37,12 +38,63 @@ fn parse_conformance_arg(args: &[String]) -> String {
     "google-sheets".to_string()
 }
 
+// ─── Session store ────────────────────────────────────────────────────────────
+
+const MAX_WORKBOOKS: usize = 32;
+const MAX_TOTAL_BYTES: usize = 256 * 1024 * 1024;
+
+struct SessionStore {
+    workbooks: std::collections::HashMap<String, Workbook>,
+    total_json_bytes: usize,
+    next_id: u64,
+}
+
+impl SessionStore {
+    fn new() -> Self {
+        Self { workbooks: std::collections::HashMap::new(), total_json_bytes: 0, next_id: 0 }
+    }
+
+    fn allocate_id(&mut self) -> String {
+        let id = format!("wb_{}", self.next_id);
+        self.next_id += 1;
+        id
+    }
+
+    fn create(&mut self, engine: WbEngine) -> Result<String, String> {
+        if self.workbooks.len() >= MAX_WORKBOOKS {
+            return Err(format!("session limit reached: max {} workbooks per process", MAX_WORKBOOKS));
+        }
+        let id = self.allocate_id();
+        self.workbooks.insert(id.clone(), Workbook::new(engine));
+        Ok(id)
+    }
+
+    fn import(&mut self, json: &str) -> Result<String, String> {
+        if self.workbooks.len() >= MAX_WORKBOOKS {
+            return Err(format!("session limit reached: max {} workbooks per process", MAX_WORKBOOKS));
+        }
+        if self.total_json_bytes.saturating_add(json.len()) > MAX_TOTAL_BYTES {
+            return Err(format!("memory limit would be exceeded: aggregate session size capped at {} MiB", MAX_TOTAL_BYTES / (1024 * 1024)));
+        }
+        let wb = Workbook::from_json(json.as_bytes()).map_err(|e| e.to_string())?;
+        let id = self.allocate_id();
+        self.total_json_bytes = self.total_json_bytes.saturating_add(json.len());
+        self.workbooks.insert(id.clone(), wb);
+        Ok(id)
+    }
+
+    fn get_mut(&mut self, id: &str) -> Option<&mut Workbook> {
+        self.workbooks.get_mut(id)
+    }
+}
+
 // ─── Entry point ─────────────────────────────────────────────────────────────
 
 fn main() {
     let cli_args: Vec<String> = std::env::args().collect();
     let default_conformance = parse_conformance_arg(&cli_args);
     let engines = Engines::new();
+    let mut session_store = SessionStore::new();
 
     let stdin = io::stdin();
     let stdout = io::stdout();
@@ -86,7 +138,7 @@ fn main() {
             continue;
         }
 
-        let response = handle_request(&request, &default_conformance, &engines);
+        let response = handle_request(&request, &default_conformance, &engines, &mut session_store);
         let mut response_str = serde_json::to_string(&response).expect("serialisation error");
         response_str.push('\n');
         out.write_all(response_str.as_bytes()).expect("stdout write error");
@@ -94,7 +146,7 @@ fn main() {
     }
 }
 
-fn handle_request(req: &JsonValue, default_conformance: &str, engines: &Engines) -> JsonValue {
+fn handle_request(req: &JsonValue, default_conformance: &str, engines: &Engines, store: &mut SessionStore) -> JsonValue {
     let id = &req["id"];
     let method = req["method"].as_str().unwrap_or("");
     let params = &req["params"];
@@ -119,7 +171,7 @@ fn handle_request(req: &JsonValue, default_conformance: &str, engines: &Engines)
         "tools/call" => {
             let name = params["name"].as_str().unwrap_or("");
             let args = &params["arguments"];
-            let result = dispatch_tool(name, args, default_conformance, engines);
+            let result = dispatch_tool(name, args, default_conformance, engines, store);
             let is_error = result.get("error").is_some();
             let mut tool_result = json!({
                 "content": [{ "type": "text", "text": serde_json::to_string(&result).expect("result serialisation is infallible") }]
@@ -144,7 +196,7 @@ fn handle_request(req: &JsonValue, default_conformance: &str, engines: &Engines)
 
 // ─── Tool dispatch ────────────────────────────────────────────────────────────
 
-fn dispatch_tool(name: &str, args: &JsonValue, default_conformance: &str, engines: &Engines) -> JsonValue {
+fn dispatch_tool(name: &str, args: &JsonValue, default_conformance: &str, engines: &Engines, store: &mut SessionStore) -> JsonValue {
     match name {
         "evaluate" => tool_evaluate(args, default_conformance, engines),
         "validate" => tool_validate(args, engines),
@@ -152,6 +204,12 @@ fn dispatch_tool(name: &str, args: &JsonValue, default_conformance: &str, engine
         "batch_evaluate" => tool_batch_evaluate(args, default_conformance, engines),
         "list_functions" => tool_list_functions(),
         "get_stats" => tool_get_stats(),
+        "workbook_create" => tool_workbook_create(args, store),
+        "workbook_set" => tool_workbook_set(args, store),
+        "workbook_get" => tool_workbook_get(args, store),
+        "workbook_recalc" => tool_workbook_recalc(args, store),
+        "workbook_export" => tool_workbook_export(args, store),
+        "workbook_import" => tool_workbook_import(args, store),
         _ => json!({ "error": format!("Unknown tool: {}", name) }),
     }
 }
@@ -265,7 +323,179 @@ fn tool_get_stats() -> JsonValue {
     })
 }
 
+// ─── Workbook tools ───────────────────────────────────────────────────────────
+
+fn tool_workbook_create(args: &JsonValue, store: &mut SessionStore) -> JsonValue {
+    let engine_str = match args["engine"].as_str() {
+        Some(e) => e,
+        None => return json!({ "error": "missing engine" }),
+    };
+    let engine = match engine_str {
+        "sheets" => WbEngine::Sheets,
+        "excel" => WbEngine::Excel,
+        other => return json!({ "error": format!("unknown engine: {}", other) }),
+    };
+    match store.create(engine) {
+        Ok(id) => json!({ "workbook_id": id }),
+        Err(e) => json!({ "error": e }),
+    }
+}
+
+fn tool_workbook_set(args: &JsonValue, store: &mut SessionStore) -> JsonValue {
+    let workbook_id = match args["workbook_id"].as_str() {
+        Some(id) => id,
+        None => return json!({ "error": "missing workbook_id" }),
+    };
+    let sheet = match args["sheet"].as_str() {
+        Some(s) => s,
+        None => return json!({ "error": "missing sheet" }),
+    };
+    let cell = match args["cell"].as_str() {
+        Some(c) => c,
+        None => return json!({ "error": "missing cell" }),
+    };
+    let value = match args["value"].as_str() {
+        Some(v) => v,
+        None => return json!({ "error": "missing value" }),
+    };
+
+    let wb = match store.get_mut(workbook_id) {
+        Some(wb) => wb,
+        None => return json!({ "error": format!("workbook not found: {}", workbook_id) }),
+    };
+
+    let addr = match Address::from_a1(&cell.to_uppercase()) {
+        Some(a) => a,
+        None => return json!({ "error": format!("invalid cell address: {}", cell) }),
+    };
+
+    let input = if value.starts_with('=') {
+        CellInput::Formula(value.to_owned())
+    } else if value == "TRUE" || value == "true" {
+        CellInput::Literal(WbValue::Boolean(true))
+    } else if value == "FALSE" || value == "false" {
+        CellInput::Literal(WbValue::Boolean(false))
+    } else if let Ok(n) = value.parse::<f64>() {
+        CellInput::Literal(WbValue::Number(n))
+    } else {
+        CellInput::Literal(WbValue::Text(value.to_owned()))
+    };
+
+    match wb.set(sheet, addr, input) {
+        Ok(_) => json!({ "ok": true }),
+        Err(e) => json!({ "error": e.to_string() }),
+    }
+}
+
+fn tool_workbook_get(args: &JsonValue, store: &mut SessionStore) -> JsonValue {
+    let workbook_id = match args["workbook_id"].as_str() {
+        Some(id) => id,
+        None => return json!({ "error": "missing workbook_id" }),
+    };
+    let sheet = match args["sheet"].as_str() {
+        Some(s) => s,
+        None => return json!({ "error": "missing sheet" }),
+    };
+    let cell = match args["cell"].as_str() {
+        Some(c) => c,
+        None => return json!({ "error": "missing cell" }),
+    };
+
+    let wb = match store.get_mut(workbook_id) {
+        Some(wb) => wb,
+        None => return json!({ "error": format!("workbook not found: {}", workbook_id) }),
+    };
+
+    let addr = match Address::from_a1(&cell.to_uppercase()) {
+        Some(a) => a,
+        None => return json!({ "error": format!("invalid cell address: {}", cell) }),
+    };
+
+    match wb.resolved(sheet, addr) {
+        Some(resolved) => wb_value_to_json(&resolved.value),
+        None => json!({ "error": "cell is empty or not found" }),
+    }
+}
+
+fn tool_workbook_recalc(args: &JsonValue, store: &mut SessionStore) -> JsonValue {
+    let workbook_id = match args["workbook_id"].as_str() {
+        Some(id) => id,
+        None => return json!({ "error": "missing workbook_id" }),
+    };
+
+    let timestamp_ms = args["timestamp_ms"].as_i64().unwrap_or(0);
+    let timezone = args["timezone"].as_str().unwrap_or("UTC");
+    let rng_seed = args["rng_seed"].as_u64().unwrap_or(0);
+
+    let ctx = match RecalcContext::new(timestamp_ms, timezone, rng_seed) {
+        Some(c) => c,
+        None => return json!({ "error": format!("unknown timezone: {}", timezone) }),
+    };
+
+    let wb = match store.get_mut(workbook_id) {
+        Some(wb) => wb,
+        None => return json!({ "error": format!("workbook not found: {}", workbook_id) }),
+    };
+
+    let changes = wb.recalc(&ctx);
+    let change_list: Vec<JsonValue> = changes
+        .iter()
+        .map(|c| json!({
+            "sheet": c.sheet,
+            "cell": c.addr.to_a1(),
+            "before": wb_value_to_json(&c.old),
+            "after": wb_value_to_json(&c.new),
+        }))
+        .collect();
+    json!({ "changes": change_list })
+}
+
+fn tool_workbook_export(args: &JsonValue, store: &mut SessionStore) -> JsonValue {
+    let workbook_id = match args["workbook_id"].as_str() {
+        Some(id) => id,
+        None => return json!({ "error": "missing workbook_id" }),
+    };
+
+    let wb = match store.get_mut(workbook_id) {
+        Some(wb) => wb,
+        None => return json!({ "error": format!("workbook not found: {}", workbook_id) }),
+    };
+
+    wb.to_json()
+        .map(|s| json!({ "json": s }))
+        .unwrap_or_else(|e| json!({ "error": e.to_string() }))
+}
+
+fn tool_workbook_import(args: &JsonValue, store: &mut SessionStore) -> JsonValue {
+    let json_str = match args["json"].as_str() {
+        Some(s) => s,
+        None => return json!({ "error": "missing json" }),
+    };
+
+    match store.import(json_str) {
+        Ok(id) => json!({ "workbook_id": id }),
+        Err(e) => json!({ "error": e }),
+    }
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+fn wb_value_to_json(v: &WbValue) -> JsonValue {
+    match v {
+        WbValue::Number(n) => json!({ "type": "number", "value": n }),
+        WbValue::Text(s) => json!({ "type": "text", "value": s }),
+        WbValue::Boolean(b) => json!({ "type": "boolean", "value": b }),
+        WbValue::Error(e) => json!({ "type": "error", "error": e }),
+        WbValue::Empty => json!({ "type": "empty", "value": null }),
+        WbValue::Date(d) => json!({ "type": "date", "value": d }),
+        WbValue::Array(rows) => {
+            let arr: Vec<Vec<JsonValue>> = rows.iter()
+                .map(|r| r.iter().map(wb_value_to_json).collect())
+                .collect();
+            json!({ "type": "array", "value": arr })
+        }
+    }
+}
 
 fn parse_variables(vars_json: &JsonValue) -> HashMap<String, Value> {
     let mut map = HashMap::new();
@@ -381,7 +611,80 @@ fn tools_list() -> JsonValue {
             "name": "get_stats",
             "description": "Return the total number of supported functions, the library version, and a per-category breakdown.",
             "inputSchema": { "type": "object", "properties": {} }
+        },
+        {
+            "name": "workbook_create",
+            "description": "Create a new in-memory workbook. Engine is locked at creation.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "engine": { "type": "string", "enum": ["sheets", "excel"], "description": "Spreadsheet dialect" }
+                },
+                "required": ["engine"]
+            }
+        },
+        {
+            "name": "workbook_set",
+            "description": "Write a value or formula to a cell in an existing workbook sheet.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "workbook_id": { "type": "string", "description": "Workbook session ID" },
+                    "sheet": { "type": "string", "description": "Sheet name" },
+                    "cell": { "type": "string", "description": "Cell address in A1 notation" },
+                    "value": { "type": "string", "description": "Cell value; prefix with '=' for a formula" }
+                },
+                "required": ["workbook_id", "sheet", "cell", "value"]
+            }
+        },
+        {
+            "name": "workbook_get",
+            "description": "Read the effective value of a cell (resolves spills).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "workbook_id": { "type": "string" },
+                    "sheet": { "type": "string" },
+                    "cell": { "type": "string", "description": "Cell address in A1 notation" }
+                },
+                "required": ["workbook_id", "sheet", "cell"]
+            }
+        },
+        {
+            "name": "workbook_recalc",
+            "description": "Recalculate all formula cells and return the list of changed cells.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "workbook_id": { "type": "string" },
+                    "timestamp_ms": { "type": "integer", "description": "UTC epoch milliseconds for NOW()/TODAY() (default: 0)" },
+                    "timezone": { "type": "string", "description": "IANA timezone name (default: UTC)" },
+                    "rng_seed": { "type": "integer", "description": "RNG seed for RAND() etc. (default: 0)" }
+                },
+                "required": ["workbook_id"]
+            }
+        },
+        {
+            "name": "workbook_export",
+            "description": "Export a workbook session as canonical JSON.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "workbook_id": { "type": "string" }
+                },
+                "required": ["workbook_id"]
+            }
+        },
+        {
+            "name": "workbook_import",
+            "description": "Import a workbook from canonical JSON and return a new session ID.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "json": { "type": "string", "description": "Canonical workbook JSON" }
+                },
+                "required": ["json"]
+            }
         }
     ])
 }
-

--- a/crates/mcp/tests/workbook_tools.rs
+++ b/crates/mcp/tests/workbook_tools.rs
@@ -1,0 +1,149 @@
+use serde_json::{json, Value as JsonValue};
+use std::io::Write;
+
+/// Run a sequence of JSON-RPC requests against a single MCP server process.
+/// Returns the parsed inner tool payloads (the `text` content of each
+/// tools/call response, already parsed as JSON) in the same order.
+fn run_session(requests: &[JsonValue]) -> Vec<JsonValue> {
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_truecalc-mcp"))
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to start truecalc-mcp");
+
+    let stdin = child.stdin.as_mut().expect("stdin");
+    for req in requests {
+        writeln!(stdin, "{}", serde_json::to_string(req).unwrap()).unwrap();
+    }
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output().expect("wait");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|line| {
+            let resp: JsonValue = serde_json::from_str(line).expect("json response");
+            // tools/call responses wrap the result in content[0].text
+            if let Some(text) = resp["result"]["content"][0]["text"].as_str() {
+                serde_json::from_str(text).expect("inner json")
+            } else {
+                resp["result"].clone()
+            }
+        })
+        .collect()
+}
+
+fn call(id: u64, tool: &str, args: JsonValue) -> JsonValue {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": { "name": tool, "arguments": args }
+    })
+}
+
+/// Canonical workbook JSON with one sheet "Sheet1" and no cells.
+fn empty_workbook_json() -> String {
+    r#"{"engine":"sheets","names":[],"sheets":[{"cells":{},"name":"Sheet1"}],"version":"1"}"#.to_owned()
+}
+
+#[test]
+fn workbook_create_returns_id() {
+    let results = run_session(&[
+        call(1, "workbook_create", json!({ "engine": "sheets" })),
+    ]);
+    let result = &results[0];
+    assert!(result.get("workbook_id").is_some(), "expected workbook_id, got: {result}");
+    let id = result["workbook_id"].as_str().unwrap();
+    assert!(id.starts_with("wb_"), "id should start with wb_, got: {id}");
+}
+
+#[test]
+fn workbook_create_excel_engine() {
+    let results = run_session(&[
+        call(1, "workbook_create", json!({ "engine": "excel" })),
+    ]);
+    assert!(results[0].get("workbook_id").is_some(), "expected workbook_id, got: {}", results[0]);
+}
+
+#[test]
+fn workbook_set_recalc_get_sum_formula() {
+    // Import a workbook with Sheet1, set cells A1/B1, recalc, then get A1.
+    let results = run_session(&[
+        call(1, "workbook_import", json!({ "json": empty_workbook_json() })),
+        call(2, "workbook_set", json!({ "workbook_id": "wb_0", "sheet": "Sheet1", "cell": "B1", "value": "3" })),
+        call(3, "workbook_set", json!({ "workbook_id": "wb_0", "sheet": "Sheet1", "cell": "C1", "value": "4" })),
+        call(4, "workbook_set", json!({ "workbook_id": "wb_0", "sheet": "Sheet1", "cell": "A1", "value": "=SUM(B1,C1)" })),
+        call(5, "workbook_recalc", json!({ "workbook_id": "wb_0" })),
+        call(6, "workbook_get", json!({ "workbook_id": "wb_0", "sheet": "Sheet1", "cell": "A1" })),
+    ]);
+
+    // Import should succeed
+    assert!(results[0].get("workbook_id").is_some(), "import: {}", results[0]);
+
+    // Three set calls should succeed
+    assert_eq!(results[1]["ok"], json!(true), "set B1: {}", results[1]);
+    assert_eq!(results[2]["ok"], json!(true), "set C1: {}", results[2]);
+    assert_eq!(results[3]["ok"], json!(true), "set A1: {}", results[3]);
+
+    // Recalc should report A1 changed from empty to 7
+    let changes = results[4]["changes"].as_array().expect("changes array");
+    let a1_change = changes.iter().find(|c| c["cell"] == "A1").expect("A1 in changes");
+    assert_eq!(a1_change["before"]["type"], "empty", "before: {}", a1_change);
+    assert_eq!(a1_change["after"]["type"], "number", "after type: {}", a1_change);
+    assert_eq!(a1_change["after"]["value"], json!(7.0), "after value: {}", a1_change);
+
+    // Get should return 7
+    assert_eq!(results[5]["type"], "number", "get type: {}", results[5]);
+    assert_eq!(results[5]["value"], json!(7.0), "get value: {}", results[5]);
+}
+
+#[test]
+fn workbook_export_import_roundtrip() {
+    // Import a bare workbook, set a cell, export, re-import, and read back.
+    let results = run_session(&[
+        call(1, "workbook_import", json!({ "json": empty_workbook_json() })),
+        call(2, "workbook_set", json!({ "workbook_id": "wb_0", "sheet": "Sheet1", "cell": "A1", "value": "42" })),
+        call(3, "workbook_export", json!({ "workbook_id": "wb_0" })),
+    ]);
+
+    assert!(results[0].get("workbook_id").is_some());
+    assert_eq!(results[1]["ok"], json!(true));
+    let exported = results[2]["json"].as_str().expect("exported json string").to_owned();
+
+    // Re-import the exported JSON and read A1
+    let results2 = run_session(&[
+        call(1, "workbook_import", json!({ "json": &exported })),
+        call(2, "workbook_get", json!({ "workbook_id": "wb_0", "sheet": "Sheet1", "cell": "A1" })),
+    ]);
+    assert!(results2[0].get("workbook_id").is_some());
+    assert_eq!(results2[1]["type"], "number", "get result: {}", results2[1]);
+    assert_eq!(results2[1]["value"], json!(42.0));
+}
+
+#[test]
+fn workbook_session_limit_enforced() {
+    // Create 33 workbooks; the 33rd must return a "session limit" error.
+    let requests: Vec<JsonValue> = (0..33_u64)
+        .map(|i| call(i, "workbook_create", json!({ "engine": "sheets" })))
+        .collect();
+
+    let results = run_session(&requests);
+    assert_eq!(results.len(), 33);
+
+    // First 32 must succeed
+    for r in results.iter().take(32) {
+        assert!(r.get("workbook_id").is_some(), "expected workbook_id, got: {r}");
+    }
+
+    // 33rd must be an error containing "session limit"
+    let last = &results[32];
+    assert!(last.get("error").is_some(), "expected error for 33rd workbook, got: {last}");
+    assert!(
+        last["error"].as_str().unwrap_or("").contains("session limit"),
+        "expected 'session limit' in error, got: {}",
+        last["error"]
+    );
+}


### PR DESCRIPTION
## Summary

- Add 6 MCP tools: `workbook_create`, `workbook_set`, `workbook_get`, `workbook_recalc`, `workbook_export`, `workbook_import`
- Add bounded `SessionStore` (max 32 workbooks per process, 256 MiB aggregate JSON)
- Add integration tests in `crates/mcp/tests/workbook_tools.rs`

closes #545

## Test plan

- [x] `workbook_create` returns a session ID
- [x] `workbook_set` + `workbook_recalc` + `workbook_get` correctly evaluates `=SUM(B1,C1)`
- [x] `workbook_export` / `workbook_import` round-trip preserves cell values
- [x] Session limit: 32nd workbook succeeds, 33rd returns `session limit` error
- [x] `cargo clippy --workspace -- -D warnings` passes clean
- [x] `cargo test -p truecalc-mcp` passes (8 tests)
- [x] `cargo test -p truecalc-workbook` passes (258 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)