### PR TITLE
feat(core): PRF-keyed per-cell RNG (RAND/RANDBETWEEN/RANDARRAY)

### DIFF
--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -182,6 +182,36 @@ impl Engine {
         }
     }
 
+    /// Like [`Engine::evaluate_with_resolver_at`] but also injects a per-cell
+    /// RNG key. `rng_cell` is `(seed, sheet_index, row, col)`; when `None`
+    /// this degrades to the non-deterministic SystemTime fallback in RAND.
+    pub fn evaluate_with_resolver_at_keyed(
+        &self,
+        formula: &str,
+        resolver: &mut dyn Resolver,
+        now_serial: Option<f64>,
+        rng_cell: Option<(u64, u32, u32, u32)>,
+    ) -> Value {
+        if let Some(n) = now_serial {
+            if !n.is_finite() {
+                return Value::Error(ErrorKind::Num);
+            }
+        }
+        if self.flavor == EngineFlavor::Excel {
+            return Value::Error(ErrorKind::NA);
+        }
+        match parse_formula(formula) {
+            Err(_) => Value::Error(ErrorKind::Value),
+            Ok(expr) => {
+                let mut ctx = Context::empty();
+                ctx.now_serial = now_serial;
+                ctx.rng_cell = rng_cell;
+                let mut eval_ctx = EvalCtx::with_resolver(ctx, &self.registry, resolver);
+                evaluate_expr(&expr, &mut eval_ctx)
+            }
+        }
+    }
+
     fn evaluate_inner(
         &self,
         formula: &str,

--- a/crates/core/src/eval/context/mod.rs
+++ b/crates/core/src/eval/context/mod.rs
@@ -12,6 +12,9 @@ pub struct Context {
     /// fraction = time of day). `None` ⇒ the functions read the ambient
     /// local clock. Set via [`crate::Engine::evaluate_at`] (P1.4, issue #526).
     pub now_serial: Option<f64>,
+    /// Per-cell RNG key for deterministic draws: (seed, sheet_index, row, col).
+    /// Set by the workbook recalc loop; None for bare Engine::evaluate calls.
+    pub rng_cell: Option<(u64, u32, u32, u32)>,
 }
 
 impl Context {
@@ -21,12 +24,12 @@ impl Context {
         let normalized = vars.into_iter()
             .map(|(k, v)| (k.to_uppercase(), v))
             .collect();
-        Self { vars: normalized, now_serial: None }
+        Self { vars: normalized, now_serial: None, rng_cell: None }
     }
 
     /// Create an empty `Context` with no variable bindings.
     pub fn empty() -> Self {
-        Self { vars: HashMap::new(), now_serial: None }
+        Self { vars: HashMap::new(), now_serial: None, rng_cell: None }
     }
 
     /// Look up a variable by name (case-insensitive). Returns `Value::Empty` if not found.
@@ -53,6 +56,46 @@ impl Context {
     /// Remove a binding. Used to restore context after lambda/let evaluation.
     pub fn remove(&mut self, name: &str) {
         self.vars.remove(&name.to_uppercase());
+    }
+
+    /// SplitMix64-based PRF: draw a value in [0,1) for the given draw index.
+    /// Uses the per-cell key when available; falls back to SystemTime for
+    /// bare Engine::evaluate calls (non-deterministic).
+    pub fn draw_rand(&self, draw_index: u32) -> f64 {
+        if let Some((seed, si, r, c)) = self.rng_cell {
+            let key = self.splitmix_chain(seed, si, r, c, draw_index);
+            // Use upper 32 bits for [0,1)
+            (key >> 32) as f64 / (u32::MAX as f64 + 1.0)
+        } else {
+            // Non-deterministic fallback for bare Engine::evaluate.
+            // Mix draw_index into the time seed so RANDARRAY cells differ.
+            let s = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as u64)
+                .unwrap_or(12345);
+            let key = Self::mix64(s ^ Self::mix64(draw_index as u64));
+            (key >> 32) as f64 / (u32::MAX as f64 + 1.0)
+        }
+    }
+
+    /// Draw `count` values in [0,1), each using its own draw_index.
+    pub fn draw_rand_n(&self, count: usize) -> Vec<f64> {
+        (0..count as u32).map(|i| self.draw_rand(i)).collect()
+    }
+
+    fn splitmix_chain(&self, seed: u64, si: u32, r: u32, c: u32, draw: u32) -> u64 {
+        let mut h = seed;
+        for part in [si as u64, r as u64, c as u64, draw as u64] {
+            h = Self::mix64(h ^ Self::mix64(part));
+        }
+        h
+    }
+
+    fn mix64(mut x: u64) -> u64 {
+        x = x.wrapping_add(0x9e3779b97f4a7c15);
+        x = (x ^ (x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+        x = (x ^ (x >> 27)).wrapping_mul(0x94d049bb133111eb);
+        x ^ (x >> 31)
     }
 }
 

--- a/crates/core/src/eval/functions/math/mod.rs
+++ b/crates/core/src/eval/functions/math/mod.rs
@@ -68,8 +68,8 @@ pub fn register_math(registry: &mut Registry) {
     registry.register_eager("FLOOR.MATH",      ceiling_floor_math::floor_math_fn,            FunctionMeta { category: "math", signature: "FLOOR.MATH(number, [significance], [mode])",   description: "Round down to nearest multiple; handles negative numbers via mode" });
     registry.register_eager("FLOOR.PRECISE",   ceiling_floor_math::floor_precise_fn,         FunctionMeta { category: "math", signature: "FLOOR.PRECISE(number, [significance])",        description: "Round down to nearest multiple; sign of significance ignored" });
     registry.register_eager("ISO.CEILING",     ceiling_floor_math::iso_ceiling_fn,           FunctionMeta { category: "math", signature: "ISO.CEILING(number, [significance])",          description: "ISO standard ceiling; identical to CEILING.PRECISE" });
-    registry.register_eager("RAND",       rand::rand_fn,                FunctionMeta { category: "math",        signature: "RAND()",                                description: "Random number between 0 and 1" });
-    registry.register_eager("RANDBETWEEN",rand::randbetween_fn,         FunctionMeta { category: "math",        signature: "RANDBETWEEN(low, high)",                description: "Random integer between two values" });
+    registry.register_lazy("RAND",        rand::rand_lazy,              FunctionMeta { category: "math",        signature: "RAND()",                                description: "Random number between 0 and 1" });
+    registry.register_lazy("RANDBETWEEN", rand::randbetween_lazy,       FunctionMeta { category: "math",        signature: "RANDBETWEEN(low, high)",                description: "Random integer between two values" });
     registry.register_eager("PI",         trig::pi_fn,                  FunctionMeta { category: "math",        signature: "PI()",                                  description: "The value of pi (3.14159...)" });
     registry.register_eager("SIN",        trig::sin_fn,                 FunctionMeta { category: "math",        signature: "SIN(angle)",                            description: "Sine of an angle in radians" });
     registry.register_eager("COS",        trig::cos_fn,                 FunctionMeta { category: "math",        signature: "COS(angle)",                            description: "Cosine of an angle in radians" });
@@ -122,7 +122,7 @@ pub fn register_math(registry: &mut Registry) {
     registry.register_eager("ISODD",  iseven_isodd::isodd_fn,  FunctionMeta { category: "math", signature: "ISODD(number)",                            description: "Returns TRUE if number is odd" });
     registry.register_eager("MUNIT",     munit::munit_fn,       FunctionMeta { category: "math", signature: "MUNIT(dimension)",                           description: "Returns identity matrix of given dimension" });
     registry.register_eager("SEQUENCE",  sequence::sequence_fn, FunctionMeta { category: "math", signature: "SEQUENCE(rows, [cols], [start], [step])",    description: "Generate a sequence of numbers" });
-    registry.register_eager("RANDARRAY", randarray::randarray_fn, FunctionMeta { category: "math", signature: "RANDARRAY([rows], [cols])",                description: "Array of random numbers" });
+    registry.register_lazy("RANDARRAY",  randarray::randarray_lazy, FunctionMeta { category: "math", signature: "RANDARRAY([rows], [cols])",                description: "Array of random numbers" });
     registry.register_eager("SUBTOTAL",  subtotal::subtotal_fn, FunctionMeta { category: "math", signature: "SUBTOTAL(function_code, ref1, ...)",         description: "Apply function to a list (not supported with arrays)" });
 
     // Special functions

--- a/crates/core/src/eval/functions/math/rand/mod.rs
+++ b/crates/core/src/eval/functions/math/rand/mod.rs
@@ -1,35 +1,31 @@
 use crate::eval::coercion::to_number;
-use crate::eval::functions::check_arity;
+use crate::eval::evaluate_expr;
+use crate::eval::functions::{check_arity_len, EvalCtx};
+use crate::parser::ast::Expr;
 use crate::types::{ErrorKind, Value};
 
 /// `RAND()` — returns a random number in [0, 1).
-pub fn rand_fn(args: &[Value]) -> Value {
-    if let Some(err) = check_arity(args, 0, 0) {
+/// Uses a per-cell PRF key when available (workbook recalc context);
+/// falls back to SystemTime for bare Engine::evaluate calls.
+pub fn rand_lazy(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if let Some(err) = check_arity_len(args.len(), 0, 0) {
         return err;
     }
-    // Use a simple LCG seeded from system time for no-dependency randomness.
-    // For a real spreadsheet engine a proper RNG would be used, but this avoids
-    // adding external crates.
-    let seed = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.subsec_nanos())
-        .unwrap_or(12345);
-    // LCG: multiplier 1664525, addend 1013904223 (Numerical Recipes)
-    let val = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
-    let f = (val as f64) / (u32::MAX as f64 + 1.0);
-    Value::Number(f)
+    Value::Number(ctx.ctx.draw_rand(0))
 }
 
 /// `RANDBETWEEN(low, high)` — returns a random integer in [low, high] inclusive.
-pub fn randbetween_fn(args: &[Value]) -> Value {
-    if let Some(err) = check_arity(args, 2, 2) {
+pub fn randbetween_lazy(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if let Some(err) = check_arity_len(args.len(), 2, 2) {
         return err;
     }
-    let low = match to_number(args[0].clone()) {
+    let low_val = evaluate_expr(&args[0], ctx);
+    let high_val = evaluate_expr(&args[1], ctx);
+    let low = match to_number(low_val) {
         Err(e) => return e,
         Ok(v) => v,
     };
-    let high = match to_number(args[1].clone()) {
+    let high = match to_number(high_val) {
         Err(e) => return e,
         Ok(v) => v,
     };
@@ -38,14 +34,9 @@ pub fn randbetween_fn(args: &[Value]) -> Value {
     if lo > hi {
         return Value::Error(ErrorKind::Num);
     }
-    let seed = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.subsec_nanos())
-        .unwrap_or(12345);
-    let val = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
-    let range = (hi - lo + 1) as u64;
-    let result = lo + (val as u64 % range) as i64;
-    Value::Number(result as f64)
+    let raw = ctx.ctx.draw_rand(0);
+    let range = (hi - lo + 1) as f64;
+    Value::Number(lo as f64 + (raw * range).floor())
 }
 
 #[cfg(test)]

--- a/crates/core/src/eval/functions/math/rand/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/rand/tests/edge.rs
@@ -1,9 +1,11 @@
-use super::super::*;
+use crate::Engine;
 use crate::types::Value;
+use std::collections::HashMap;
 
 #[test]
 fn rand_result_is_finite() {
-    let result = rand_fn(&[]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RAND()", &HashMap::new());
     if let Value::Number(n) = result {
         assert!(n.is_finite());
     } else {
@@ -13,7 +15,8 @@ fn rand_result_is_finite() {
 
 #[test]
 fn randbetween_negative_range() {
-    let result = randbetween_fn(&[Value::Number(-5.0), Value::Number(-1.0)]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RANDBETWEEN(-5, -1)", &HashMap::new());
     if let Value::Number(n) = result {
         assert!(n >= -5.0 && n <= -1.0);
         assert_eq!(n, n.floor());
@@ -24,6 +27,7 @@ fn randbetween_negative_range() {
 
 #[test]
 fn randbetween_zero_range() {
-    let result = randbetween_fn(&[Value::Number(0.0), Value::Number(0.0)]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RANDBETWEEN(0, 0)", &HashMap::new());
     assert_eq!(result, Value::Number(0.0));
 }

--- a/crates/core/src/eval/functions/math/rand/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/rand/tests/failure.rs
@@ -1,20 +1,21 @@
-use super::super::*;
+use crate::Engine;
 use crate::types::{ErrorKind, Value};
+use std::collections::HashMap;
 
 #[test]
 fn rand_with_args_returns_value_error() {
-    assert_eq!(rand_fn(&[Value::Number(1.0)]), Value::Error(ErrorKind::NA));
+    let eng = Engine::sheets();
+    assert_eq!(eng.evaluate("=RAND(1)", &HashMap::new()), Value::Error(ErrorKind::NA));
 }
 
 #[test]
 fn randbetween_no_args_returns_value_error() {
-    assert_eq!(randbetween_fn(&[]), Value::Error(ErrorKind::NA));
+    let eng = Engine::sheets();
+    assert_eq!(eng.evaluate("=RANDBETWEEN()", &HashMap::new()), Value::Error(ErrorKind::NA));
 }
 
 #[test]
 fn randbetween_low_greater_than_high_returns_num_error() {
-    assert_eq!(
-        randbetween_fn(&[Value::Number(10.0), Value::Number(1.0)]),
-        Value::Error(ErrorKind::Num)
-    );
+    let eng = Engine::sheets();
+    assert_eq!(eng.evaluate("=RANDBETWEEN(10, 1)", &HashMap::new()), Value::Error(ErrorKind::Num));
 }

--- a/crates/core/src/eval/functions/math/rand/tests/success.rs
+++ b/crates/core/src/eval/functions/math/rand/tests/success.rs
@@ -1,9 +1,11 @@
-use super::super::*;
+use crate::Engine;
 use crate::types::Value;
+use std::collections::HashMap;
 
 #[test]
 fn rand_returns_number_in_range() {
-    let result = rand_fn(&[]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RAND()", &HashMap::new());
     if let Value::Number(n) = result {
         assert!(n >= 0.0 && n < 1.0, "RAND() must be in [0, 1), got {}", n);
     } else {
@@ -13,7 +15,8 @@ fn rand_returns_number_in_range() {
 
 #[test]
 fn randbetween_returns_number_in_range() {
-    let result = randbetween_fn(&[Value::Number(1.0), Value::Number(10.0)]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RANDBETWEEN(1, 10)", &HashMap::new());
     if let Value::Number(n) = result {
         assert!(n >= 1.0 && n <= 10.0, "RANDBETWEEN must be in [1,10], got {}", n);
         assert_eq!(n, n.floor(), "RANDBETWEEN must return an integer");
@@ -24,6 +27,7 @@ fn randbetween_returns_number_in_range() {
 
 #[test]
 fn randbetween_same_low_high() {
-    let result = randbetween_fn(&[Value::Number(5.0), Value::Number(5.0)]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RANDBETWEEN(5, 5)", &HashMap::new());
     assert_eq!(result, Value::Number(5.0));
 }

--- a/crates/core/src/eval/functions/math/randarray/mod.rs
+++ b/crates/core/src/eval/functions/math/randarray/mod.rs
@@ -1,45 +1,24 @@
 use crate::eval::coercion::to_number;
-use crate::eval::functions::check_arity;
+use crate::eval::evaluate_expr;
+use crate::eval::functions::{check_arity_len, EvalCtx};
+use crate::parser::ast::Expr;
 use crate::types::{ErrorKind, Value};
-
-/// LCG PRNG seeded from system time (Numerical Recipes constants).
-/// Returns successive values by stepping the state forward on each call.
-fn lcg_sequence(count: usize) -> Vec<f64> {
-    let seed = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos() as u64)
-        .unwrap_or(12345);
-    // Mix in a higher-entropy seed using the full nanosecond count
-    let mut state = seed
-        .wrapping_mul(6_364_136_223_846_793_005)
-        .wrapping_add(1_442_695_040_888_963_407);
-    let mut out = Vec::with_capacity(count);
-    for _ in 0..count {
-        state = state
-            .wrapping_mul(6_364_136_223_846_793_005)
-            .wrapping_add(1_442_695_040_888_963_407);
-        // Use upper 32 bits for better quality
-        let val = (state >> 32) as u32;
-        out.push((val as f64) / (u32::MAX as f64 + 1.0));
-    }
-    out
-}
 
 /// `RANDARRAY([rows], [cols], [min], [max], [integer])`
 ///
 /// Returns an array of random numbers.
 /// With no args: returns a single random number (equivalent to RAND()).
 /// With rows/cols: returns a nested 2D array (rows × cols).
-pub fn randarray_fn(args: &[Value]) -> Value {
+/// Uses a per-cell PRF key when available; falls back to SystemTime.
+pub fn randarray_lazy(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
     if args.is_empty() {
-        // No args: return single random number
-        let vals = lcg_sequence(1);
-        return Value::Number(vals[0]);
+        return Value::Number(ctx.ctx.draw_rand(0));
     }
-    if let Some(err) = check_arity(args, 1, 5) {
+    if let Some(err) = check_arity_len(args.len(), 1, 5) {
         return err;
     }
-    let rows = match to_number(args[0].clone()) {
+    let rows_val = evaluate_expr(&args[0], ctx);
+    let rows = match to_number(rows_val) {
         Err(e) => return e,
         Ok(v) => v,
     };
@@ -48,7 +27,8 @@ pub fn randarray_fn(args: &[Value]) -> Value {
     }
     let rows = rows as usize;
     let cols = if args.len() >= 2 {
-        match to_number(args[1].clone()) {
+        let cv = evaluate_expr(&args[1], ctx);
+        match to_number(cv) {
             Err(e) => return e,
             Ok(v) => {
                 if v <= 0.0 {
@@ -60,17 +40,10 @@ pub fn randarray_fn(args: &[Value]) -> Value {
     } else {
         1
     };
-
     let total = rows * cols;
-    let nums = lcg_sequence(total);
-    // Always return nested 2D array so ROWS/COLUMNS work correctly
+    let nums = ctx.ctx.draw_rand_n(total);
     let outer: Vec<Value> = (0..rows)
-        .map(|r| {
-            let row: Vec<Value> = (0..cols)
-                .map(|c| Value::Number(nums[r * cols + c]))
-                .collect();
-            Value::Array(row)
-        })
+        .map(|r| Value::Array((0..cols).map(|c| Value::Number(nums[r * cols + c])).collect()))
         .collect();
     Value::Array(outer)
 }

--- a/crates/core/src/eval/functions/math/randarray/tests/edge.rs
+++ b/crates/core/src/eval/functions/math/randarray/tests/edge.rs
@@ -1,13 +1,11 @@
-use super::super::randarray_fn;
+use crate::Engine;
 use crate::types::Value;
-
-fn n(v: f64) -> Value {
-    Value::Number(v)
-}
+use std::collections::HashMap;
 
 #[test]
 fn one_by_one_array_returns_single_nested_value() {
-    let result = randarray_fn(&[n(1.0), n(1.0)]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RANDARRAY(1, 1)", &HashMap::new());
     if let Value::Array(outer) = result {
         assert_eq!(outer.len(), 1);
         if let Value::Array(inner) = &outer[0] {
@@ -23,7 +21,8 @@ fn one_by_one_array_returns_single_nested_value() {
 
 #[test]
 fn fractional_rows_truncates_to_integer() {
-    let result = randarray_fn(&[n(2.9)]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RANDARRAY(2.9)", &HashMap::new());
     if let Value::Array(outer) = result {
         assert_eq!(outer.len(), 2);
     } else {

--- a/crates/core/src/eval/functions/math/randarray/tests/failure.rs
+++ b/crates/core/src/eval/functions/math/randarray/tests/failure.rs
@@ -1,35 +1,37 @@
-use super::super::randarray_fn;
+use crate::Engine;
 use crate::types::{ErrorKind, Value};
-
-fn n(v: f64) -> Value {
-    Value::Number(v)
-}
+use std::collections::HashMap;
 
 #[test]
 fn zero_rows_returns_num_error() {
-    assert_eq!(randarray_fn(&[n(0.0)]), Value::Error(ErrorKind::Num));
+    let eng = Engine::sheets();
+    assert_eq!(eng.evaluate("=RANDARRAY(0)", &HashMap::new()), Value::Error(ErrorKind::Num));
 }
 
 #[test]
 fn negative_rows_returns_num_error() {
-    assert_eq!(randarray_fn(&[n(-1.0)]), Value::Error(ErrorKind::Num));
+    let eng = Engine::sheets();
+    assert_eq!(eng.evaluate("=RANDARRAY(-1)", &HashMap::new()), Value::Error(ErrorKind::Num));
 }
 
 #[test]
 fn zero_cols_returns_num_error() {
-    assert_eq!(randarray_fn(&[n(2.0), n(0.0)]), Value::Error(ErrorKind::Num));
+    let eng = Engine::sheets();
+    assert_eq!(eng.evaluate("=RANDARRAY(2, 0)", &HashMap::new()), Value::Error(ErrorKind::Num));
 }
 
 #[test]
 fn negative_cols_returns_num_error() {
-    assert_eq!(
-        randarray_fn(&[n(2.0), n(-3.0)]),
-        Value::Error(ErrorKind::Num)
-    );
+    let eng = Engine::sheets();
+    assert_eq!(eng.evaluate("=RANDARRAY(2, -3)", &HashMap::new()), Value::Error(ErrorKind::Num));
 }
 
 #[test]
 fn too_many_args_returns_na() {
-    let args = vec![n(1.0); 6];
-    assert_eq!(randarray_fn(&args), Value::Error(ErrorKind::NA));
+    let eng = Engine::sheets();
+    // 6 arguments exceed the max of 5
+    assert_eq!(
+        eng.evaluate("=RANDARRAY(1, 1, 0, 1, TRUE, EXTRA)", &HashMap::new()),
+        Value::Error(ErrorKind::NA)
+    );
 }

--- a/crates/core/src/eval/functions/math/randarray/tests/success.rs
+++ b/crates/core/src/eval/functions/math/randarray/tests/success.rs
@@ -1,13 +1,11 @@
-use super::super::randarray_fn;
+use crate::Engine;
 use crate::types::Value;
-
-fn n(v: f64) -> Value {
-    Value::Number(v)
-}
+use std::collections::HashMap;
 
 #[test]
 fn no_args_returns_single_number_in_0_1() {
-    let result = randarray_fn(&[]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RANDARRAY()", &HashMap::new());
     assert!(
         matches!(result, Value::Number(_)),
         "expected Number, got {:?}",
@@ -20,7 +18,8 @@ fn no_args_returns_single_number_in_0_1() {
 
 #[test]
 fn one_arg_rows_returns_nested_2d_array() {
-    let result = randarray_fn(&[n(3.0)]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RANDARRAY(3)", &HashMap::new());
     assert!(matches!(result, Value::Array(_)));
     if let Value::Array(outer) = result {
         assert_eq!(outer.len(), 3);
@@ -36,7 +35,8 @@ fn one_arg_rows_returns_nested_2d_array() {
 
 #[test]
 fn two_args_rows_cols_returns_correct_shape() {
-    let result = randarray_fn(&[n(2.0), n(4.0)]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RANDARRAY(2, 4)", &HashMap::new());
     if let Value::Array(outer) = result {
         assert_eq!(outer.len(), 2, "expected 2 rows");
         for row in &outer {
@@ -53,7 +53,8 @@ fn two_args_rows_cols_returns_correct_shape() {
 
 #[test]
 fn values_are_numbers() {
-    let result = randarray_fn(&[n(2.0), n(2.0)]);
+    let eng = Engine::sheets();
+    let result = eng.evaluate("=RANDARRAY(2, 2)", &HashMap::new());
     if let Value::Array(outer) = result {
         for row in &outer {
             if let Value::Array(inner) = row {

--- a/crates/workbook/src/recalc.rs
+++ b/crates/workbook/src/recalc.rs
@@ -335,6 +335,7 @@ impl Workbook {
         to_eval: BTreeSet<CellRef>,
     ) -> Vec<Change> {
         let now_serial = ctx.now_serial();
+        let rng_seed = ctx.rng_seed();
 
         // Cells on a cycle short-circuit to the circular error; the rest are
         // evaluated in topological order. `topological_order` returns the full
@@ -399,6 +400,7 @@ impl Workbook {
                 let raw = self.eval_formula_cell(
                     cell,
                     now_serial,
+                    rng_seed,
                     &next_values,
                     &next_spills,
                     &new_values,
@@ -439,6 +441,7 @@ impl Workbook {
         &self,
         cell: &CellRef,
         now_serial: Option<f64>,
+        rng_seed: u64,
         new_values: &BTreeMap<CellRef, Value>,
         spills: &BTreeMap<CellRef, SpillRect>,
         prev_values: &BTreeMap<CellRef, Value>,
@@ -454,6 +457,13 @@ impl Workbook {
             EngineFlavor::Sheets => Engine::sheets(),
             EngineFlavor::Excel => Engine::excel(),
         };
+        let folder = CaseMapperBorrowed::new();
+        let sheet_index = self
+            .sheets()
+            .iter()
+            .position(|ws| simple_fold(&folder, ws.name()) == cell.sheet)
+            .unwrap_or(0) as u32;
+        let rng_cell = Some((rng_seed, sheet_index, cell.addr.row, cell.addr.column));
         let mut resolver = GridResolver {
             workbook: self,
             own_sheet: &cell.sheet,
@@ -464,7 +474,12 @@ impl Workbook {
             cycle,
             recomputed,
         };
-        let core = engine.evaluate_with_resolver_at(&formula, &mut resolver, now_serial);
+        let core = engine.evaluate_with_resolver_at_keyed(
+            &formula,
+            &mut resolver,
+            now_serial,
+            rng_cell,
+        );
         core_to_workbook(core)
     }
 

--- a/crates/workbook/tests/rng_determinism.rs
+++ b/crates/workbook/tests/rng_determinism.rs
@@ -1,0 +1,111 @@
+//! PRF-keyed per-cell RNG determinism tests (issue #588).
+//!
+//! Verifies that RAND/RANDBETWEEN/RANDARRAY produce byte-identical values
+//! when evaluated under the same RecalcContext, and differ when the seed or
+//! cell position changes.
+
+use truecalc_workbook::{Address, CellInput, EngineFlavor, RecalcContext, Value, Workbook, Worksheet};
+
+fn a1(s: &str) -> Address {
+    Address::from_a1(s).unwrap()
+}
+
+fn ctx(seed: u64) -> RecalcContext {
+    RecalcContext::new(1_780_878_600_000, "Etc/GMT", seed).unwrap()
+}
+
+fn wb_with_formula(formula: &str) -> Workbook {
+    let mut wb = Workbook::new(EngineFlavor::Sheets);
+    wb.add_sheet(Worksheet::new("Sheet1")).unwrap();
+    wb.set("Sheet1", a1("A1"), CellInput::Formula(formula.into())).unwrap();
+    wb
+}
+
+/// Same context, two workbooks with RAND() in A1 → identical values.
+#[test]
+fn rand_same_context_is_deterministic() {
+    let c = ctx(42);
+    let mut w1 = wb_with_formula("=RAND()");
+    let mut w2 = wb_with_formula("=RAND()");
+    w1.recalc(&c);
+    w2.recalc(&c);
+    assert_eq!(
+        w1.get("Sheet1", a1("A1")).unwrap().value(),
+        w2.get("Sheet1", a1("A1")).unwrap().value(),
+        "same context => same RAND() value"
+    );
+}
+
+/// Different rng_seed → different RAND() value.
+#[test]
+fn rand_different_seed_differs() {
+    let mut w1 = wb_with_formula("=RAND()");
+    let mut w2 = wb_with_formula("=RAND()");
+    w1.recalc(&ctx(1));
+    w2.recalc(&ctx(2));
+    assert_ne!(
+        w1.get("Sheet1", a1("A1")).unwrap().value(),
+        w2.get("Sheet1", a1("A1")).unwrap().value(),
+        "different seed => different RAND() value"
+    );
+}
+
+/// RAND() in different cells (A1 vs B1) with the same context produces
+/// different values (different col key).
+#[test]
+fn rand_different_cells_differ() {
+    let mut wb = Workbook::new(EngineFlavor::Sheets);
+    wb.add_sheet(Worksheet::new("Sheet1")).unwrap();
+    wb.set("Sheet1", a1("A1"), CellInput::Formula("=RAND()".into())).unwrap();
+    wb.set("Sheet1", a1("B1"), CellInput::Formula("=RAND()".into())).unwrap();
+    wb.recalc(&ctx(99));
+    let va = wb.get("Sheet1", a1("A1")).unwrap().value().clone();
+    let vb = wb.get("Sheet1", a1("B1")).unwrap().value().clone();
+    assert_ne!(va, vb, "RAND() in A1 vs B1 must differ (different col key)");
+}
+
+/// Two-sheet workbook: RAND() on Sheet1/A1 and Sheet2/A1 with the same context
+/// produces different values (different sheet_index key).
+#[test]
+fn rand_different_sheets_differ() {
+    let mut wb = Workbook::new(EngineFlavor::Sheets);
+    wb.add_sheet(Worksheet::new("Sheet1")).unwrap();
+    wb.add_sheet(Worksheet::new("Sheet2")).unwrap();
+    wb.set("Sheet1", a1("A1"), CellInput::Formula("=RAND()".into())).unwrap();
+    wb.set("Sheet2", a1("A1"), CellInput::Formula("=RAND()".into())).unwrap();
+    wb.recalc(&ctx(7));
+    let v1 = wb.get("Sheet1", a1("A1")).unwrap().value().clone();
+    let v2 = wb.get("Sheet2", a1("A1")).unwrap().value().clone();
+    assert_ne!(v1, v2, "RAND() on Sheet1 vs Sheet2 must differ (different sheet_index key)");
+}
+
+/// RANDARRAY(2,2) in A1 produces an identical array on two recalcs with the
+/// same context.
+#[test]
+fn randarray_same_context_is_deterministic() {
+    let c = ctx(55);
+    let mut w1 = wb_with_formula("=RANDARRAY(2,2)");
+    let mut w2 = wb_with_formula("=RANDARRAY(2,2)");
+    w1.recalc(&c);
+    w2.recalc(&c);
+    assert_eq!(
+        w1.get("Sheet1", a1("A1")).unwrap().value(),
+        w2.get("Sheet1", a1("A1")).unwrap().value(),
+        "same context => same RANDARRAY values"
+    );
+}
+
+/// RANDBETWEEN(1,1000) same context → same result.
+#[test]
+fn randbetween_same_context_is_deterministic() {
+    let c = ctx(13);
+    let mut w1 = wb_with_formula("=RANDBETWEEN(1,1000)");
+    let mut w2 = wb_with_formula("=RANDBETWEEN(1,1000)");
+    w1.recalc(&c);
+    w2.recalc(&c);
+    assert_eq!(
+        w1.get("Sheet1", a1("A1")).unwrap().value(),
+        w2.get("Sheet1", a1("A1")).unwrap().value(),
+        "same context => same RANDBETWEEN value"
+    );
+}


### PR DESCRIPTION
## Summary

- Route RAND/RANDBETWEEN/RANDARRAY to a SplitMix64-based PRF when a per-cell key is available, keeping SystemTime fallback for bare `Engine::evaluate` calls
- Extend `Context` with `rng_cell: Option<(u64, u32, u32, u32)>` and `draw_rand`/`draw_rand_n` methods; convert the three RNG functions from `EagerFn` to `LazyFn` so they read `ctx.ctx.draw_rand()`
- Add `Engine::evaluate_with_resolver_at_keyed` to inject `rng_cell`; thread `rng_seed` through `Workbook::recompute` → `eval_formula_cell`, computing the per-cell key `(rng_seed, sheet_index, row, col)`
- Add 6 determinism tests in `crates/workbook/tests/rng_determinism.rs`

closes #588

## Test plan

- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo test -p truecalc-core` passes (3058 tests)
- [ ] `cargo test -p truecalc-workbook` passes (264 tests, 6 new rng_determinism tests)
- [ ] `rng_determinism::rand_same_context_is_deterministic` — same seed → same value
- [ ] `rng_determinism::rand_different_seed_differs` — different seed → different value
- [ ] `rng_determinism::rand_different_cells_differ` — A1 vs B1 differ
- [ ] `rng_determinism::rand_different_sheets_differ` — Sheet1 vs Sheet2 differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)