### PR TITLE
chore(release): version bump to 1.0.0 + coordinated release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to the truecalc workspace are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-06-11
+
+### Breaking
+
+- Engine flavor is now required: use `Engine::sheets()` or `Engine::excel()`. Free
+  `evaluate`/`parse`/`validate` functions are deprecated and will be removed in this release.
+- `Engine::google_sheets()` is deprecated; use `Engine::sheets()`.
+
+### Added
+
+- **truecalc-workbook**: workbook runtime (recalc, serialization, JSON schema v1).
+- **truecalc-mcp**: workbook session tools (`workbook_create` / `workbook_set` /
+  `workbook_get` / `workbook_recalc` / `workbook_export` / `workbook_import`).
+- **@truecalc/workbook** (`crates/wasm-workbook`): full Workbook API compiled to
+  WebAssembly, published to npm as `@truecalc/workbook`.
+- PRF-keyed per-cell RNG: `RAND` / `RANDBETWEEN` / `RANDARRAY` are now deterministic
+  under `RecalcContext`.
+- `ErrorKind::Unsupported` for `Engine::excel()` evaluate (distinct from `#N/A`).
+
+### Fixed
+
+- `Engine::excel().evaluate` now returns `#UNSUPPORTED!` instead of `#N/A` for
+  Google-Sheets-only functions.
+
+## Packages
+
+| Package                   | Version | Registry      |
+|---------------------------|---------|---------------|
+| `truecalc-core`           | 1.0.0   | crates.io     |
+| `truecalc-workbook`       | 1.0.0   | crates.io     |
+| `truecalc-mcp`            | 1.0.0   | crates.io     |
+| `@truecalc/core`          | 1.0.0   | npm           |
+| `@truecalc/workbook`      | 1.0.0   | npm           |
+
+> **Note**: Publishing to crates.io and npm is owner-triggered per ADR Decision 6.
+> Git tags will be created post-merge using the crate-prefixed convention, e.g.
+> `truecalc-core-v1.0.0`, `truecalc-workbook-v1.0.0`, etc.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "calamine",
  "chrono",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm-workbook"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-workbook"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/wasm-workbook", "crates/mcp", "
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -12,7 +12,7 @@ name = "truecalc-mcp"
 path = "src/main.rs"
 
 [dependencies]
-truecalc-core = { path = "../core", version = "0.9" }
-truecalc-workbook = { path = "../workbook", version = "0.9" }
+truecalc-core = { path = "../core", version = "1.0" }
+truecalc-workbook = { path = "../workbook", version = "1.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/workbook/Cargo.toml
+++ b/crates/workbook/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["spreadsheet", "workbook", "formula", "excel", "sheets"]
 
 [dependencies]
-truecalc-core = { path = "../core", version = "0.9", features = ["serde"] }
+truecalc-core = { path = "../core", version = "1.0", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["float_roundtrip"] }
 ryu-js = "1"


### PR DESCRIPTION
closes #547

## Versioning decision

Unified versioning — all five packages move to **1.0.0** in a single coordinated bump.

The workspace was already at `0.9.0` (tags `truecalc-core-v0.9.0`, `truecalc-workbook-v0.9.0`, `truecalc-mcp-v0.9.0`). Per the rule "versions only move forward", the next release is `1.0.0`.

## Packages

| Package | Old | New | Registry |
|---|---|---|---|
| `truecalc-core` | 0.9.0 | 1.0.0 | crates.io |
| `truecalc-workbook` | 0.9.0 | 1.0.0 | crates.io |
| `truecalc-mcp` | 0.9.0 | 1.0.0 | crates.io |
| `@truecalc/core` | 0.9.0 | 1.0.0 | npm |
| `@truecalc/workbook` | 0.9.0 | 1.0.0 | npm |

## Changes

- Bumped `[workspace.package] version` in root `Cargo.toml` from `0.9.0` → `1.0.0`
- Updated internal dependency version pins (`version = "0.9"` → `"1.0"`) in `crates/workbook/Cargo.toml` and `crates/mcp/Cargo.toml`
- Updated `Cargo.lock`
- Added `CHANGELOG.md` documenting breaking changes, additions, and fixes in 1.0.0

## Tag convention

Post-merge, git tags follow the crate-prefixed convention already established in this repo:

```
truecalc-core-v1.0.0
truecalc-workbook-v1.0.0
truecalc-mcp-v1.0.0
```

WASM packages (`@truecalc/core`, `@truecalc/workbook`) derive their npm version from the workspace version via `wasm-pack`.

## Publish

This PR prepares the release only. Actual publish to crates.io/npm is owner-triggered per ADR Decision 6.