### PR TITLE
docs: rustdoc, READMEs, cookbook, migration guide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,6 +2933,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "workbook-budget"
+version = "0.9.0"
+dependencies = [
+ "truecalc-workbook",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/core", "crates/wasm", "crates/wasm-workbook", "crates/mcp", "crates/workbook", "xtask"]
+members = ["crates/core", "crates/wasm", "crates/wasm-workbook", "crates/mcp", "crates/workbook", "xtask", "examples/workbook-budget"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/core/MIGRATION.md
+++ b/crates/core/MIGRATION.md
@@ -1,0 +1,102 @@
+# Migration guide: 0.6.x → 0.7.0
+
+This guide covers the **engine-flavor-explicit** breaking change introduced in
+0.7.0 (ADR 2026-04-27-engine-flavor-explicit-everywhere).
+
+## Summary
+
+The free `evaluate()` function in `truecalc-core` and the `Engine::google_sheets()`
+constructor are deprecated in 0.7.0. Both will be removed in a coordinated
+release. Update call sites now to eliminate deprecation warnings.
+
+---
+
+## `truecalc-core`: free `evaluate()` function
+
+### Before (0.6.x)
+
+```rust
+use std::collections::HashMap;
+use truecalc_core::{evaluate, Value};
+
+let mut vars = HashMap::new();
+vars.insert("A1".to_string(), Value::Number(10.0));
+
+let result = evaluate("=A1 * 2", &vars);
+```
+
+### After (0.7+)
+
+```rust
+use std::collections::HashMap;
+use truecalc_core::{Engine, Value};
+
+let mut vars = HashMap::new();
+vars.insert("A1".to_string(), Value::Number(10.0));
+
+let result = Engine::sheets().evaluate("=A1 * 2", &vars);
+```
+
+The engine instance is cheap to create and stateless (no heap allocation beyond
+the function registry, which is computed once). Creating one per call site is fine.
+
+---
+
+## `truecalc-core`: `Engine::google_sheets()` constructor
+
+### Before (0.6.x / early 0.7.x)
+
+```rust
+use truecalc_core::Engine;
+
+let engine = Engine::google_sheets();
+```
+
+### After (0.7+)
+
+```rust
+use truecalc_core::Engine;
+
+let engine = Engine::sheets();
+```
+
+`Engine::google_sheets()` is a deprecated alias for `Engine::sheets()`. Both
+constructors produce an identical `EngineFlavor::Sheets` engine; only the name
+changed to make the API consistent with the `excel()` constructor.
+
+---
+
+## Why the change?
+
+Before 0.7, the engine flavor was implicit in the free function and had no
+effect on callers — all evaluation silently targeted Google Sheets semantics.
+As Excel support and the workbook layer were added, the flavor became load-
+bearing: the date serial system, cross-surface JSON contracts, and the workbook's
+recalc layer all need to know which engine a workbook is locked to.
+
+Making the flavor explicit at the call site:
+
+- Prevents accidental cross-flavor workbooks.
+- Makes the engine's date system unambiguous.
+- Aligns the Rust, WASM, MCP, and REST surfaces — they all require an explicit
+  `"engine": "sheets"` / `"engine": "excel"` field.
+
+---
+
+## `Engine::excel()` — parse/validate only
+
+`Engine::excel()` is available for callers targeting Excel conformance, but
+**Excel evaluation is not yet implemented**. Calling `Engine::excel().evaluate()`
+returns `Value::Error(ErrorKind::Unsupported)` for every formula.
+`Engine::excel().parse()` and `Engine::excel().validate()` work.
+
+Excel evaluation lands in a later phase; this guide will be updated when it does.
+
+---
+
+## Checking for deprecated usage
+
+```sh
+# Compile with deprecation warnings promoted to errors to find every call site:
+RUSTFLAGS="-D deprecated" cargo check -p truecalc-core
+```

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://img.shields.io/docsrs/truecalc-core)](https://docs.rs/truecalc-core)
 [![license](https://img.shields.io/crates/l/truecalc-core)](LICENSE)
 
-Spreadsheet formula engine — parser and evaluator for Excel-compatible formulas.
+Spreadsheet formula engine — parser and evaluator for Excel-compatible formulas with Google Sheets conformance.
 
 Also available as a WebAssembly npm package: [`@truecalc/core`](https://www.npmjs.com/package/@truecalc/core)
 
@@ -12,13 +12,29 @@ Also available as a WebAssembly npm package: [`@truecalc/core`](https://www.npmj
 
 ```toml
 [dependencies]
-truecalc-core = "0.1"
+truecalc-core = "0.9"
 ```
 
 Or via cargo:
 
 ```sh
 cargo add truecalc-core
+```
+
+## Quick start
+
+```rust
+use std::collections::HashMap;
+use truecalc_core::{Engine, Value};
+
+let engine = Engine::sheets();
+
+let mut vars = HashMap::new();
+vars.insert("A1".to_string(), Value::Number(100.0));
+vars.insert("B1".to_string(), Value::Number(200.0));
+
+let result = engine.evaluate("=SUM(A1,B1)", &vars);
+assert_eq!(result, Value::Number(300.0));
 ```
 
 ## Usage
@@ -35,7 +51,7 @@ let mut vars = HashMap::new();
 vars.insert("A1".to_string(), Value::Number(100.0));
 vars.insert("B1".to_string(), Value::Number(200.0));
 
-let result = engine.evaluate("SUM(A1, B1)", &vars);
+let result = engine.evaluate("=SUM(A1, B1)", &vars);
 assert_eq!(result, Value::Number(300.0));
 ```
 
@@ -48,7 +64,7 @@ use truecalc_core::{Engine, Value};
 let mut vars = HashMap::new();
 vars.insert("score".to_string(), Value::Number(85.0));
 
-match Engine::sheets().evaluate("IF(score >= 60, \"pass\", \"fail\")", &vars) {
+match Engine::sheets().evaluate("=IF(score >= 60, \"pass\", \"fail\")", &vars) {
     Value::Text(s)   => println!("{s}"),           // "pass"
     Value::Number(n) => println!("{n}"),
     Value::Bool(b)   => println!("{b}"),
@@ -63,7 +79,7 @@ match Engine::sheets().evaluate("IF(score >= 60, \"pass\", \"fail\")", &vars) {
 ```rust
 use truecalc_core::Engine;
 
-match Engine::sheets().validate("SUM(A1, B1)") {
+match Engine::sheets().validate("=SUM(A1, B1)") {
     Ok(_)  => println!("valid"),
     Err(e) => eprintln!("parse error at position {}: {}", e.position, e.message),
 }
@@ -74,9 +90,46 @@ match Engine::sheets().validate("SUM(A1, B1)") {
 ```rust
 use truecalc_core::Engine;
 
-let expr = Engine::sheets().parse("1 + 2 * 3").expect("valid formula");
+let expr = Engine::sheets().parse("=1 + 2 * 3").expect("valid formula");
 // expr is an Expr tree you can walk yourself
 ```
+
+### Evaluate with a Resolver (workbook integration)
+
+For workbook-backed evaluation where references should be resolved against a
+live cell grid, implement the [`Resolver`](https://docs.rs/truecalc-core/latest/truecalc_core/eval/trait.Resolver.html) trait:
+
+```rust
+use truecalc_core::{Engine, ErrorKind, Ref, Resolver, Value};
+
+struct OneSheet;
+impl Resolver for OneSheet {
+    fn resolve(&mut self, r: &Ref) -> Value {
+        match r {
+            Ref::Cell { sheet: Some(s), .. } if s == "Data" => Value::Number(10.0),
+            Ref::Cell { sheet: Some(_), .. } => Value::Error(ErrorKind::Ref),
+            _ => Value::Empty,
+        }
+    }
+}
+
+let engine = Engine::sheets();
+assert_eq!(engine.evaluate_with_resolver("=Data!A1", &mut OneSheet), Value::Number(10.0));
+```
+
+For a full workbook implementation, see [`truecalc-workbook`](https://docs.rs/truecalc-workbook).
+
+## Engine flavors
+
+The engine flavor controls formula semantics and the date serial system:
+
+| Constructor | Semantics | Date system |
+|---|---|---|
+| `Engine::sheets()` | Google Sheets | Day 0 = 1899-12-30, no 1900 leap bug |
+| `Engine::excel()` | Excel | Serial 1 = 1900-01-01, Lotus leap-year bug |
+
+> **Note:** Excel evaluation is not yet implemented. `Engine::excel().evaluate()` returns
+> `#UNSUPPORTED!`. `parse()` and `validate()` work for both flavors.
 
 ## Types
 
@@ -115,6 +168,18 @@ for (name, meta) in registry.list_functions() {
     println!("{} ({}): {}", name, meta.category, meta.description);
 }
 ```
+
+## Migration from 0.6.x
+
+See [`MIGRATION.md`](MIGRATION.md) for the full guide.
+
+**Summary:** The free `evaluate()` function and `Engine::google_sheets()` constructor
+were deprecated in 0.7.0. Replace them with `Engine::sheets().evaluate()`.
+
+## Related crates
+
+- [`truecalc-workbook`](https://crates.io/crates/truecalc-workbook): full workbook layer with
+  engine-locked workbook, worksheet, cell mutation, and recalc.
 
 ## License
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,69 @@
-// truecalc-core: spreadsheet formula parser and evaluator
+//! Spreadsheet formula parser and evaluator for Google Sheets and Excel
+//! conformance.
+//!
+//! # Quick start
+//!
+//! ```rust
+//! use std::collections::HashMap;
+//! use truecalc_core::{Engine, Value};
+//!
+//! let engine = Engine::sheets();
+//!
+//! let mut vars = HashMap::new();
+//! vars.insert("A1".to_string(), Value::Number(10.0));
+//! vars.insert("A2".to_string(), Value::Number(20.0));
+//! vars.insert("A3".to_string(), Value::Number(30.0));
+//!
+//! let result = engine.evaluate("=SUM(A1,A2,A3)", &vars);
+//! assert_eq!(result, Value::Number(60.0));
+//! ```
+//!
+//! # Engine flavors
+//!
+//! The engine flavor is **required and immutable**: create one engine per
+//! evaluation context and reuse it.
+//!
+//! | Constructor | Target conformance |
+//! |---|---|
+//! | [`Engine::sheets()`] | Google Sheets |
+//! | [`Engine::excel()`] | Excel (parse/validate only; evaluation pending) |
+//!
+//! # Evaluation modes
+//!
+//! - **Variable map** — [`Engine::evaluate`]: references are looked up in a
+//!   `HashMap<String, Value>`. Suitable for ad-hoc formula evaluation outside a
+//!   workbook.
+//! - **Resolver** — [`Engine::evaluate_with_resolver`]: every cell, range, and
+//!   name reference is resolved through a [`Resolver`] implementation. This is
+//!   the workbook layer's entry point; see `truecalc-workbook`.
+//! - **Pinned clock** — [`Engine::evaluate_at`] / [`Engine::evaluate_with_resolver_at`]:
+//!   volatile functions (`NOW`, `TODAY`) are pinned to a fixed spreadsheet serial,
+//!   producing deterministic results.
+//!
+//! # Migration from 0.6.x
+//!
+//! The free `evaluate()` function and `Engine::google_sheets()` constructor were
+//! deprecated in 0.7.0. Update call sites as follows:
+//!
+//! ```rust
+//! // Before (0.6.x):
+//! // use truecalc_core::evaluate;
+//! // let result = evaluate("=SUM(A1,A2)", &vars);
+//!
+//! // After (0.7+):
+//! use std::collections::HashMap;
+//! use truecalc_core::{Engine, Value};
+//! let vars: HashMap<String, Value> = HashMap::new();
+//! let result = Engine::sheets().evaluate("=SUM(A1,A2)", &vars);
+//! ```
+//!
+//! See [`MIGRATION.md`](https://github.com/truecalc/core/blob/main/crates/core/MIGRATION.md)
+//! for the full migration guide.
+//!
+//! # Related crates
+//!
+//! - [`truecalc-workbook`](https://docs.rs/truecalc-workbook): full workbook
+//!   layer — engine-locked workbook, worksheet, cell mutation, and recalc.
 
 pub mod display;
 pub mod engine;

--- a/crates/workbook/README.md
+++ b/crates/workbook/README.md
@@ -6,13 +6,109 @@
 
 Workbook layer for the [truecalc](https://github.com/truecalc/core) spreadsheet engine: engine-locked workbook, worksheet, and cell value types with a canonical JSON serialization contract.
 
-Status: under active development (workbook v1, schema version `"1"`). APIs may change until the first published release.
+## Install
+
+```toml
+[dependencies]
+truecalc-workbook = "0.9"
+```
+
+Or via cargo:
+
+```sh
+cargo add truecalc-workbook
+```
+
+## Quick start
+
+```rust
+use truecalc_workbook::{Address, CellInput, EngineFlavor, RecalcContext, Value, Workbook, Worksheet};
+
+// Create a workbook locked to Google Sheets semantics.
+let mut wb = Workbook::new(EngineFlavor::Sheets);
+
+// Add a sheet and write some cells.
+wb.add_sheet(Worksheet::new("Budget")).unwrap();
+let a1 = Address::from_a1("A1").unwrap();
+let a2 = Address::from_a1("A2").unwrap();
+let a3 = Address::from_a1("A3").unwrap();
+wb.set("Budget", a1, CellInput::Literal(Value::Number(1000.0))).unwrap();
+wb.set("Budget", a2, CellInput::Literal(Value::Number(500.0))).unwrap();
+wb.set("Budget", a3, CellInput::Formula("=SUM(A1:A2)".to_string())).unwrap();
+
+// Recalculate to evaluate all formulas.
+// RecalcContext::new(unix_ms, iana_tz, rng_seed)
+let ctx = RecalcContext::new(1_780_000_000_000, "Etc/GMT", 0).unwrap();
+let _changes = wb.recalc(&ctx);
+
+// Read back the computed result.
+assert_eq!(wb.get("Budget", a3).unwrap().value(), &Value::Number(1500.0));
+```
 
 ## Design
 
-- A `Workbook` is a **value object** — no hidden state, no callbacks. `Clone + PartialEq + Hash + Serialize + Deserialize`.
-- The **engine flavor** (`sheets` | `excel`) is required at creation and immutable for the workbook's lifetime.
-- The **JSON schema is the cross-surface contract**: canonical serialization (RFC 8785 / JCS) produces byte-identical output across Rust, WASM, MCP, and REST surfaces.
+- A `Workbook` is a **value object** — `Clone + PartialEq + Hash`, no hidden state, no
+  callbacks. Mutate via [`Workbook::set`] / [`Workbook::clear`], then drive recalc.
+
+- The **engine flavor** (`sheets` | `excel`) is required at creation and immutable for the
+  workbook's lifetime. It controls formula semantics and the date serial system.
+
+- **[`RecalcContext`]** pins volatile functions (`NOW`, `TODAY`) to a fixed UTC instant +
+  IANA timezone via the vendored `chrono-tz` database (not the host OS tz tables).
+  Same workbook + same context ⇒ byte-identical recomputed grid.
+
+- **[`CellInput`]** distinguishes `Literal(value)` from `Formula("=...".to_string())`.
+  Formula syntax is validated against the locked engine at `set` time.
+
+## Recalc modes
+
+- [`Workbook::recalc`] — full recalc, evaluates every formula cell in topological order.
+- [`Workbook::recalc_incremental`] — incremental recalc, recomputes only the transitive
+  dependents of the edited cells (plus all volatile cells). Produces the same result as
+  full recalc.
+
+Both return an ordered list of [`Change`] values describing every cell that changed.
+
+## JSON serialization
+
+[`Workbook::to_json`] / [`Workbook::from_json`] implement the canonical RFC 8785 / JCS
+serialization boundary — byte-identical output across Rust, WASM, MCP, and REST surfaces.
+The JSON schema is the cross-surface contract; see `schema/` for the JSON Schema spec.
+
+### Schema summary
+
+```json
+{
+  "version": "1",
+  "engine": "sheets",
+  "names": [],
+  "sheets": [
+    {
+      "name": "Budget",
+      "cells": {
+        "A1": { "value": 1000.0 },
+        "A3": { "formula": "=SUM(A1:A2)", "value": 1500.0 }
+      }
+    }
+  ]
+}
+```
+
+Key schema invariants:
+- `engine` is `"sheets"` or `"excel"` — required, immutable.
+- `version` is the string `"1"` — compared by exact match.
+- Cells without a formula have only `value`; formula cells store `formula` + last `value`.
+- Named ranges are validated against existing sheets at deserialize time.
+
+## Cookbook example
+
+See [`examples/workbook-budget/`](../../examples/workbook-budget/) for a worked example
+that creates a budget workbook, sets income and expense formulas, recalcs, and prints the
+results.
+
+## Related crates
+
+- [`truecalc-core`](https://crates.io/crates/truecalc-core): the formula parser and evaluator.
 
 ## License
 

--- a/crates/workbook/src/lib.rs
+++ b/crates/workbook/src/lib.rs
@@ -1,20 +1,61 @@
-//! truecalc-workbook: the workbook layer for the truecalc spreadsheet engine.
+//! Workbook layer for the [truecalc](https://docs.rs/truecalc-core) spreadsheet
+//! engine: engine-locked workbook, worksheet, and cell value types with a
+//! canonical JSON serialization contract.
 //!
-//! A [`Workbook`] is a *value object*: an engine-locked collection of ordered
-//! worksheets, sparse cell grids, and workbook-scoped named ranges. Its JSON
-//! schema is the cross-surface contract — the same canonical bytes are
-//! produced on every distribution surface (Rust, WASM, MCP, REST).
+//! # Quick start
 //!
-//! The engine flavor (`sheets` | `excel`) is explicit and required at
-//! workbook creation and immutable for the workbook's lifetime
-//! (ADR 2026-04-27-engine-flavor-explicit-everywhere).
+//! ```rust
+//! use truecalc_workbook::{Address, CellInput, EngineFlavor, RecalcContext, Value, Workbook, Worksheet};
 //!
-//! This crate is MIT-licensed and ships separately from `truecalc-core`
-//! (ADR 2026-04-27-workbook-crate-separate-mit).
+//! // 1. Create a workbook locked to Google Sheets semantics.
+//! let mut wb = Workbook::new(EngineFlavor::Sheets);
 //!
-//! [`Workbook::to_json`] / [`Workbook::from_json`] are the canonical
+//! // 2. Add a sheet and write some cells.
+//! wb.add_sheet(Worksheet::new("Budget")).unwrap();
+//! let a1 = Address::from_a1("A1").unwrap();
+//! let a2 = Address::from_a1("A2").unwrap();
+//! let a3 = Address::from_a1("A3").unwrap();
+//! wb.set("Budget", a1, CellInput::Literal(Value::Number(1000.0))).unwrap();
+//! wb.set("Budget", a2, CellInput::Literal(Value::Number(500.0))).unwrap();
+//! wb.set("Budget", a3, CellInput::Formula("=SUM(A1:A2)".to_string())).unwrap();
+//!
+//! // 3. Recalculate to evaluate all formulas.
+//! // timestamp_ms = Unix epoch in ms, tz = IANA timezone id, rng_seed = 0
+//! let ctx = RecalcContext::new(1_780_000_000_000, "Etc/GMT", 0).unwrap();
+//! let _changes = wb.recalc(&ctx);
+//! assert_eq!(wb.get("Budget", a3).unwrap().value(), &Value::Number(1500.0));
+//! ```
+//!
+//! # Core concepts
+//!
+//! - **[`Workbook`]** is a *value object*: `Clone + PartialEq + Hash`, no
+//!   hidden state or callbacks. Mutate with [`Workbook::set`] / [`Workbook::clear`]
+//!   and then drive recalc with [`Workbook::recalc`] or
+//!   [`Workbook::recalc_incremental`].
+//!
+//! - **Engine flavor** ([`EngineFlavor`]) is required at creation
+//!   ([`Workbook::new`]) and immutable for the workbook's lifetime. It controls
+//!   formula semantics and the date serial system.
+//!
+//! - **[`RecalcContext`]** pins volatile functions (`NOW`, `TODAY`) to a fixed
+//!   UTC instant + IANA timezone. Same workbook + same context ⇒ byte-identical
+//!   recomputed grid.
+//!
+//! - **[`CellInput`]** is the discriminated input type for [`Workbook::set`]:
+//!   `CellInput::Literal(value)` or `CellInput::Formula("=...".to_string())`.
+//!   Formula syntax is validated against the locked engine on `set`.
+//!
+//! # Serialization
+//!
+//! [`Workbook::to_json`] / [`Workbook::from_json`] implement the canonical
 //! (RFC 8785 / JCS) serialization boundary — the byte-identical cross-surface
-//! contract of schema spec §8.
+//! contract used across Rust, WASM, MCP, and REST surfaces.
+//!
+//! # Related crates
+//!
+//! - [`truecalc-core`](https://docs.rs/truecalc-core): the formula parser and
+//!   evaluator; the [`Engine`](truecalc_core::Engine) type and all formula
+//!   evaluation lives there.
 
 mod address;
 mod canonical;

--- a/examples/workbook-budget/Cargo.toml
+++ b/examples/workbook-budget/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "workbook-budget"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Cookbook example: budget workbook with income/expense sheets"
+repository.workspace = true
+publish = false
+
+[[bin]]
+name = "workbook-budget"
+path = "src/main.rs"
+
+[dependencies]
+truecalc-workbook = { path = "../../crates/workbook" }

--- a/examples/workbook-budget/src/main.rs
+++ b/examples/workbook-budget/src/main.rs
@@ -1,0 +1,95 @@
+//! Cookbook example: a simple budget workbook.
+//!
+//! Creates a workbook with two sheets (Income and Expenses), sets literal
+//! values and SUM formulas, recalculates, and prints the results.
+//!
+//! Run:
+//!   cargo run -p workbook-budget
+
+use truecalc_workbook::{Address, CellInput, EngineFlavor, RecalcContext, Value, Workbook, Worksheet};
+
+fn addr(a1: &str) -> Address {
+    Address::from_a1(a1).expect("valid A1 address")
+}
+
+fn set_num(wb: &mut Workbook, sheet: &str, cell: &str, n: f64) {
+    wb.set(sheet, addr(cell), CellInput::Literal(Value::Number(n))).unwrap();
+}
+
+fn set_formula(wb: &mut Workbook, sheet: &str, cell: &str, formula: &str) {
+    wb.set(sheet, addr(cell), CellInput::Formula(formula.to_string())).unwrap();
+}
+
+fn get_num(wb: &Workbook, sheet: &str, cell: &str) -> f64 {
+    match wb.get(sheet, addr(cell)).unwrap().value() {
+        Value::Number(n) => *n,
+        v => panic!("expected number at {cell}, got {v:?}"),
+    }
+}
+
+fn main() {
+    // ── Build the workbook ───────────────────────────────────────────────────
+
+    let mut wb = Workbook::new(EngineFlavor::Sheets);
+
+    // Income sheet: monthly income sources
+    wb.add_sheet(Worksheet::new("Income")).unwrap();
+    set_num(&mut wb, "Income", "A1", 5000.0); // Salary
+    set_num(&mut wb, "Income", "A2", 800.0);  // Freelance
+    set_num(&mut wb, "Income", "A3", 200.0);  // Interest
+    // A4: total income
+    set_formula(&mut wb, "Income", "A4", "=SUM(A1:A3)");
+
+    // Expenses sheet: monthly expense categories
+    wb.add_sheet(Worksheet::new("Expenses")).unwrap();
+    set_num(&mut wb, "Expenses", "A1", 1500.0); // Rent
+    set_num(&mut wb, "Expenses", "A2", 400.0);  // Groceries
+    set_num(&mut wb, "Expenses", "A3", 150.0);  // Utilities
+    set_num(&mut wb, "Expenses", "A4", 300.0);  // Transport
+    // A5: total expenses
+    set_formula(&mut wb, "Expenses", "A5", "=SUM(A1:A4)");
+
+    // Summary sheet: net = income - expenses
+    wb.add_sheet(Worksheet::new("Summary")).unwrap();
+    set_formula(&mut wb, "Summary", "A1", "=Income!A4");      // total income
+    set_formula(&mut wb, "Summary", "A2", "=Expenses!A5");    // total expenses
+    set_formula(&mut wb, "Summary", "A3", "=A1-A2");          // net
+
+    // ── Recalculate ──────────────────────────────────────────────────────────
+
+    // RecalcContext pins NOW/TODAY and the RNG; use a fixed instant for
+    // deterministic output. Substitute the real UTC millisecond timestamp for a
+    // live workbook.
+    let ctx = RecalcContext::new(1_780_000_000_000, "Etc/GMT", 0)
+        .expect("valid IANA timezone");
+
+    let changes = wb.recalc(&ctx);
+    println!("Recalculated {} formula cell(s).\n", changes.len());
+
+    // ── Print results ────────────────────────────────────────────────────────
+
+    let total_income   = get_num(&wb, "Income",   "A4");
+    let total_expenses = get_num(&wb, "Expenses", "A5");
+    let net            = get_num(&wb, "Summary",  "A3");
+
+    println!("Monthly Budget");
+    println!("==============");
+    println!("  Total income:    {:>10.2}", total_income);
+    println!("  Total expenses:  {:>10.2}", total_expenses);
+    println!("  Net:             {:>10.2}", net);
+
+    if net >= 0.0 {
+        println!("\nSurplus of {:.2}", net);
+    } else {
+        println!("\nDeficit of {:.2}", net.abs());
+    }
+
+    // ── Round-trip to JSON ───────────────────────────────────────────────────
+
+    let json = wb.to_json().expect("serialization must succeed");
+    println!("\nWorkbook JSON ({} bytes)", json.len());
+
+    let wb2 = Workbook::from_json(json.as_bytes()).expect("round-trip must succeed");
+    assert_eq!(wb, wb2, "round-trip produces identical workbook");
+    println!("Round-trip check: OK");
+}


### PR DESCRIPTION
## Summary

- Improves rustdoc for `truecalc-core` (`crates/core/src/lib.rs`) with a quick-start example, engine flavor table, evaluation mode docs, and migration note
- Improves rustdoc for `truecalc-workbook` (`crates/workbook/src/lib.rs`) with a quick-start example, core concept table, and cross-crate links
- Expands `crates/core/README.md` with full usage examples (evaluate, pattern match, validate, parse, Resolver integration), type tables, and migration link
- Expands `crates/workbook/README.md` with quick-start, design notes, recalc modes, JSON schema summary, and cookbook reference
- Adds `examples/workbook-budget/` — a runnable Rust binary cookbook example (income + expense sheets, SUM formulas, recalc, JSON round-trip)
- Adds `crates/core/MIGRATION.md` — migration guide for the 0.6.x → 0.7.0 engine-flavor-explicit break (`evaluate()` free fn and `Engine::google_sheets()` → `Engine::sheets()`)

All doctests pass (`cargo test --doc`). Clippy clean. Budget example runs successfully.

closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)