### PR TITLE
chore(release): v0.7.0 announce + CLA gate setup

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,7 @@ jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
-      - uses: contributor-assistant/github-action@v2.3.0
+      - uses: contributor-assistant/github-action@5bfe123a0731f017d9c29550976bf724fe0870f5  # v2.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,19 @@
+name: CLA Assistant
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: contributor-assistant/github-action@v2.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://raw.githubusercontent.com/truecalc/core/main/CLA.md
+          branch: cla-signatures
+          allowlist: hhimanshu,bot*


### PR DESCRIPTION
closes #549

## Summary

- Add `.github/workflows/cla.yml` using `contributor-assistant/github-action@v2.3.0` to block unsigned external PRs
- README badges already cover version, license, conformance, and docs.rs — no changes needed
- CHANGELOG already documents the 1.0.0 release notes from P7.2

## CLA gate details

- Signatures stored in `signatures/version1/cla.json` on the `cla-signatures` branch
- CLA document: `https://raw.githubusercontent.com/truecalc/core/main/CLA.md`
- Allowlist: `hhimanshu`, `bot*`

> **Note:** `CLA_PERSONAL_ACCESS_TOKEN` secret must be configured in repo Settings → Secrets by @hhimanshu before the CLA gate is fully active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)