### PR TITLE
docs: add CLA.md for contributor-assistant CLA gate

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,7 @@
+# Contributor License Agreement
+
+By submitting a pull request to this repository, you agree to license your contribution under the same license as the project ([MIT](LICENSE)) and confirm that you have the right to do so.
+
+If you are contributing on behalf of an employer, you must have authorization from your employer to make this contribution.
+
+To sign, add a comment on your pull request: `I have read the CLA Document and I hereby sign the CLA.`


### PR DESCRIPTION
Adds the CLA document the contributor-assistant action looks up at setup.

Companion to #660 (CLA gate PR). Unblocks the CLAAssistant check on #633 and future PRs.

The `cla-signatures` branch has also been initialised with an empty `signatures/version1/cla.json`.

**Owner action required:** Add a `CLA_PERSONAL_ACCESS_TOKEN` secret in repo Settings → Secrets → Actions. The token needs `repo` scope so the action can write signatures back to the `cla-signatures` branch.