### PR TITLE
build(ci): publish @truecalc/workbook to npm on release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,19 +21,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Trigger npm release for truecalc-core
+      - name: Trigger npm release for truecalc-core and truecalc-workbook
         if: steps.release-plz.outputs.releases != ''
         env:
           RELEASES: ${{ steps.release-plz.outputs.releases }}
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
-          TAG=$(echo "$RELEASES" | python3 -c "
-          import json, sys
-          releases = json.load(sys.stdin)
-          r = next((r for r in releases if r['package_name'] == 'truecalc-core'), None)
-          if r:
-              print(r['tag'])
-          ")
-          if [ -n "$TAG" ]; then
-            gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --field "tag=$TAG"
-          fi
+          python3 -c "
+          import json, os, subprocess
+          releases = json.loads(os.environ['RELEASES'])
+          repo = os.environ['GITHUB_REPOSITORY']
+          for pkg in ['truecalc-core', 'truecalc-workbook']:
+              r = next((r for r in releases if r['package_name'] == pkg), None)
+              if r:
+                  subprocess.run(['gh', 'workflow', 'run', 'release.yml',
+                      '--repo', repo, '--field', 'tag=' + r['tag']], check=True)
+          "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,36 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  publish-npm-workbook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Build WASM workbook
+        run: wasm-pack build crates/wasm-workbook --target web
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish @truecalc/workbook to npm
+        run: npm publish --provenance --access public
+        working-directory: crates/wasm-workbook/pkg
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   build-binaries:
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

- Add `publish-npm-workbook` job to `release.yml` that builds `crates/wasm-workbook --target web` and publishes `@truecalc/workbook` to npm with provenance
- Update `release-plz.yml` trigger step to fire `release.yml` for both `truecalc-core` and `truecalc-workbook` releases (previously only `truecalc-core`)

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, confirm next release-plz release run triggers two `release.yml` dispatches (one per package)
- [ ] Confirm `@truecalc/workbook` appears on npm after the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)