### PR TITLE
fix(ci): correct @truecalc/workbook npm name and deduplicate release dispatch

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,19 +21,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Trigger npm release for truecalc-core and truecalc-workbook
+      - name: Trigger npm release
         if: steps.release-plz.outputs.releases != ''
         env:
           RELEASES: ${{ steps.release-plz.outputs.releases }}
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
         run: |
-          python3 -c "
-          import json, os, subprocess
-          releases = json.loads(os.environ['RELEASES'])
-          repo = os.environ['GITHUB_REPOSITORY']
-          for pkg in ['truecalc-core', 'truecalc-workbook']:
-              r = next((r for r in releases if r['package_name'] == pkg), None)
-              if r:
-                  subprocess.run(['gh', 'workflow', 'run', 'release.yml',
-                      '--repo', repo, '--field', 'tag=' + r['tag']], check=True)
-          "
+          TAG=$(echo "$RELEASES" | python3 -c "
+          import json, sys
+          releases = json.load(sys.stdin)
+          r = next((r for r in releases if r['package_name'] == 'truecalc-core'), None)
+          if r:
+              print(r['tag'])
+          ")
+          if [ -n "$TAG" ]; then
+            gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --field "tag=$TAG"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,10 @@ jobs:
       - name: Build WASM workbook
         run: wasm-pack build crates/wasm-workbook --target web
 
+      - name: Set npm package name
+        run: node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json')); p.name='@truecalc/workbook'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n')"
+        working-directory: crates/wasm-workbook/pkg
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
## Summary

- Add `Set npm package name` step to `publish-npm-workbook` job — `wasm-pack build` generates `pkg/package.json` using the Rust crate name (`truecalc-wasm-workbook`); this step renames it to `@truecalc/workbook` before publishing, matching what the core job already does for `@truecalc/core`
- Revert `release-plz.yml` to single dispatch (fires `release.yml` once using `truecalc-core` tag) — double-dispatching (once per package) caused E403 "cannot publish over previously published versions" on the second run, since `release.yml` already publishes both packages in one workflow

## Root cause

`release.yml` publishes **both** npm packages in a single run. Dispatching it once per released crate meant each package got a duplicate publish attempt, with the second one hitting E403.

closes: duplicate dispatch causing E403 on v1.0.1 `@truecalc/workbook` publish

## Test plan

- [ ] CI green on this PR
- [ ] Merge before #663 (v1.0.2 release PR) so the fix is live when the next release fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)