### PR TITLE
fix(xtask): is_self_contained — digit mid-identifier isn't a cell ref

### DIFF
--- a/functions.json
+++ b/functions.json
@@ -3011,16 +3011,16 @@
     "description": "Convert hexadecimal to decimal",
     "examples": [
       {
-        "formula": "=HEX2DEC(\"F3\")",
-        "result": "243"
-      },
-      {
         "formula": "=HEX2DEC(\"100\")",
         "result": "256"
       },
       {
         "formula": "=HEX2DEC(\"199\")",
         "result": "409"
+      },
+      {
+        "formula": "=HEX2DEC(\"F3\")",
+        "result": "243"
       }
     ]
   },

--- a/xtask/src/dump_functions/mod.rs
+++ b/xtask/src/dump_functions/mod.rs
@@ -96,14 +96,15 @@ pub fn is_self_contained(formula: &str) -> bool {
             // a cell ref's column is 1..=3 letters; longer runs are not cell refs
             let letter_run = i - j;
             // scan forward over the digit-run; if it is immediately followed by `(`
-            // then letters+digits form a function name (e.g. LOG10, ATAN2), not a
-            // cell ref — skip it.
+            // or another letter, then letters+digits form an identifier (a function
+            // name like LOG10, ATAN2, or BIN2DEC), not a cell ref — skip it.
             let mut k = i;
             while k < bytes.len() && bytes[k].is_ascii_digit() {
                 k += 1;
             }
-            let is_function_name = k < bytes.len() && bytes[k] == b'(';
-            if prev_ok && !is_function_name && (1..=3).contains(&letter_run) {
+            let is_identifier =
+                k < bytes.len() && (bytes[k] == b'(' || bytes[k].is_ascii_alphabetic());
+            if prev_ok && !is_identifier && (1..=3).contains(&letter_run) {
                 return false;
             }
         }

--- a/xtask/src/dump_functions/tests.rs
+++ b/xtask/src/dump_functions/tests.rs
@@ -76,6 +76,9 @@ fn self_contained_classification() {
     ));
     assert!(is_self_contained("=LOG10(100)")); // function name ending in digit
     assert!(is_self_contained("=ATAN2(1,1)"));
+    assert!(is_self_contained("=BIN2DEC(1100100)")); // digit mid-identifier, not a cell ref
+    assert!(is_self_contained("=DEC2HEX(255)"));
+    assert!(is_self_contained("=SUMX2MY2({1,2},{3,4})"));
     assert!(!is_self_contained("=SUM(Data!A1:A3)")); // sheet ref
     assert!(!is_self_contained("=SUM(A1:A3)")); // cell range
     assert!(!is_self_contained("=A1+B2")); // cell refs


### PR DESCRIPTION
Follow-up to the docs-side fix. The xtask `is_self_contained` (used to rank fixture examples in `functions.json`) misread the `2` in function names like `BIN2DEC`/`DEC2HEX`/`SUMX2MY2` as an A1-style cell reference.

Fix: a digit-run followed by a letter (or `(`) is part of an identifier (function name), not a cell ref. Adds regression cases (BIN2DEC, DEC2HEX, SUMX2MY2). Regenerated `functions.json` (minor example-ordering change).

clippy clean, 7/7 xtask tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)