### PR TITLE
fix(operator): Value::Date comparison (=DATE=DATE returned FALSE)

### DIFF
--- a/crates/core/src/eval/functions/operator/mod.rs
+++ b/crates/core/src/eval/functions/operator/mod.rs
@@ -110,10 +110,10 @@ pub fn divide_fn(args: &[Value]) -> Value {
 
 // ── Issue #52 — Comparison aliases ────────────────────────────────────────────
 
-/// Type rank for cross-type ordered comparisons: Number < Text < Bool
+/// Type rank for cross-type ordered comparisons: Number/Date < Text < Bool
 fn type_rank(v: &Value) -> u8 {
     match v {
-        Value::Number(_) | Value::Empty => 0,
+        Value::Number(_) | Value::Date(_) | Value::Empty => 0,
         Value::Text(_) => 1,
         Value::Bool(_) => 2,
         _ => 255,
@@ -124,7 +124,8 @@ fn type_rank(v: &Value) -> u8 {
 /// Returns Some(Ordering) when both values are the same type, None for cross-type.
 fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
     match (a, b) {
-        (Value::Number(x), Value::Number(y)) => x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal),
+        (Value::Number(x) | Value::Date(x), Value::Number(y) | Value::Date(y)) =>
+            x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal),
         (Value::Text(x), Value::Text(y)) => x.to_lowercase().cmp(&y.to_lowercase()),
         (Value::Bool(x), Value::Bool(y)) => x.cmp(y),
         _ => type_rank(a).cmp(&type_rank(b)),
@@ -135,7 +136,7 @@ fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
 fn same_type(a: &Value, b: &Value) -> bool {
     matches!(
         (a, b),
-        (Value::Number(_), Value::Number(_))
+        (Value::Number(_) | Value::Date(_), Value::Number(_) | Value::Date(_))
             | (Value::Text(_), Value::Text(_))
             | (Value::Bool(_), Value::Bool(_))
             | (Value::Empty, Value::Empty)

--- a/crates/core/src/eval/functions/operator/tests/comparisons.rs
+++ b/crates/core/src/eval/functions/operator/tests/comparisons.rs
@@ -132,3 +132,31 @@ fn percent_wrong_arity_returns_na() { assert_eq!(unary_percent_fn(&[n(1.0), n(2.
 
 #[test]
 fn percent_non_numeric_returns_error() { assert_eq!(unary_percent_fn(&[t("abc")]), Value::Error(ErrorKind::Value)); }
+
+// ── Date comparison (issue #671 — =DATE=DATE returned FALSE) ───────────────────
+
+fn d(v: f64) -> Value { Value::Date(v) }
+
+#[test]
+fn eq_equal_dates() { assert_eq!(eq_fn(&[d(43831.0), d(43831.0)]), b(true)); }
+
+#[test]
+fn eq_unequal_dates() { assert_eq!(eq_fn(&[d(43831.0), d(43832.0)]), b(false)); }
+
+#[test]
+fn ne_equal_dates() { assert_eq!(ne_fn(&[d(43831.0), d(43831.0)]), b(false)); }
+
+#[test]
+fn eq_date_equals_serial_number() {
+    // Google Sheets treats a date as its serial number.
+    assert_eq!(eq_fn(&[d(43831.0), n(43831.0)]), b(true));
+}
+
+#[test]
+fn lt_dates() { assert_eq!(lt_fn(&[d(43831.0), d(43832.0)]), b(true)); }
+
+#[test]
+fn gt_dates() { assert_eq!(gt_fn(&[d(43832.0), d(43831.0)]), b(true)); }
+
+#[test]
+fn gte_equal_dates() { assert_eq!(gte_fn(&[d(43831.0), d(43831.0)]), b(true)); }


### PR DESCRIPTION
## Phase 1 of #666 (timezone-aware functions epic)

`type_rank`/`compare_values`/`same_type` in `operator/mod.rs` omitted `Value::Date`, so `=DATE(2020,1,1)=DATE(2020,1,1)` returned **FALSE**. This makes `Date` numeric-equivalent to `Number` for ordering and equality, matching Google Sheets (a date is its serial number).

This is the prerequisite for adding `Value::Zoned` to the comparison framework (#667).

### Changes
- `type_rank`: `Date` ranks with `Number` (0)
- `compare_values`: `Number`/`Date` compare interchangeably by serial
- `same_type`: `(Number|Date, Number|Date)` counts as same type
- 7 new unit tests in `operator/tests/comparisons.rs`

### Verification
- `cargo test -p truecalc-core`: 3069 passed
- `cargo clippy --workspace -- -D warnings`: clean
- Semantic already fixture-backed: `workbook.tsv` asserts `=DATE(2026,6,7)=N(DATE(2026,6,7))` is `TRUE`. A direct `=DATE()=DATE()` conformance row can be added via the fixtures pipeline (not self-confirmed here).

closes #671