### PR TITLE
chore: release v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-core"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "calamine",
  "chrono",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-mcp"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-wasm-workbook"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "truecalc-workbook"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "workbook-budget"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "truecalc-workbook",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core", "crates/wasm", "crates/wasm-workbook", "crates/mcp", "
 resolver = "2"
 
 [workspace.package]
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 license = "MIT"
 authors = ["truecalc"]

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/truecalc/core/compare/truecalc-core-v1.0.2...truecalc-core-v2.0.0) - 2026-06-23
+
+### Added
+
+- *(core)* MIN/MAX/SORT participation for zone-aware values
+- *(core)* TZOVERLAP — working-hours overlap across N zones
+- *(core)* flagship N-timezone compare + display
+- *(core)* TZNOW (deterministic clock), TZINWINDOW, TZCANONICAL
+- *(core)* timezone arithmetic — TZDIFF and TZADD
+- *(core)* timezone construction, introspection and extraction functions
+- *(core)* add foundational timezone functions
+- *(core)* add Value::Zoned type and core-crate plumbing
+
+### Fixed
+
+- *(operator)* make Value::Date comparable as its serial number
+
+### Other
+
+- Merge pull request #686 from truecalc/feat/685-reframe-core-readme
+- Merge pull request #684 from truecalc/feat/669-tz-overlap
+- Merge pull request #672 from truecalc/feat/671-date-comparison-fix
+
 ## [1.0.2](https://github.com/truecalc/core/compare/truecalc-core-v1.0.0...truecalc-core-v1.0.2) - 2026-06-10
 
 ### Other

--- a/crates/mcp/CHANGELOG.md
+++ b/crates/mcp/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/truecalc/core/compare/truecalc-mcp-v1.0.2...truecalc-mcp-v2.0.0) - 2026-06-23
+
+### Added
+
+- *(wasm,mcp,workbook)* serialize Value::Zoned across all surfaces
+
+### Other
+
+- *(mcp)* add value pitch, quick-start snippet, and docs footer to README
+- *(mcp,wasm)* add keywords, categories and fix descriptions for crates.io
+
 ## [1.0.2](https://github.com/truecalc/core/compare/truecalc-mcp-v1.0.1...truecalc-mcp-v1.0.2) - 2026-06-10
 
 ### Other

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -14,7 +14,7 @@ name = "truecalc-mcp"
 path = "src/main.rs"
 
 [dependencies]
-truecalc-core = { path = "../core", version = "1.0" }
-truecalc-workbook = { path = "../workbook", version = "1.0" }
+truecalc-core = { path = "../core", version = "2.0" }
+truecalc-workbook = { path = "../workbook", version = "2.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/workbook/CHANGELOG.md
+++ b/crates/workbook/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/truecalc/core/compare/truecalc-workbook-v1.0.2...truecalc-workbook-v2.0.0) - 2026-06-23
+
+### Added
+
+- *(core)* TZNOW (deterministic clock), TZINWINDOW, TZCANONICAL
+- *(wasm,mcp,workbook)* serialize Value::Zoned across all surfaces
+
 ## [1.0.2](https://github.com/truecalc/core/compare/truecalc-workbook-v1.0.0...truecalc-workbook-v1.0.2) - 2026-06-10
 
 ### Other

--- a/crates/workbook/Cargo.toml
+++ b/crates/workbook/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["spreadsheet", "workbook", "formula", "excel", "sheets"]
 
 [dependencies]
-truecalc-core = { path = "../core", version = "1.0", features = ["serde"] }
+truecalc-core = { path = "../core", version = "2.0", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["float_roundtrip"] }
 ryu-js = "1"


### PR DESCRIPTION



## 🤖 New release

* `truecalc-core`: 1.0.2 -> 2.0.0 (⚠ API breaking changes)
* `truecalc-workbook`: 1.0.2 -> 2.0.0 (⚠ API breaking changes)
* `truecalc-mcp`: 1.0.2 -> 2.0.0

### ⚠ `truecalc-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Context.now_utc_nanos in /tmp/.tmpJYRaxn/core/crates/core/src/eval/context/mod.rs:19
  field Context.now_utc_nanos in /tmp/.tmpJYRaxn/core/crates/core/src/eval/context/mod.rs:19

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Value:Zoned in /tmp/.tmpJYRaxn/core/crates/core/src/types/value.rs:21
  variant Value:Zoned in /tmp/.tmpJYRaxn/core/crates/core/src/types/value.rs:21
  variant Value:Zoned in /tmp/.tmpJYRaxn/core/crates/core/src/types/value.rs:21

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  truecalc_core::engine::Engine::evaluate_with_resolver_at_keyed takes 4 parameters in /tmp/.tmpdDKOJd/truecalc-core/src/engine/mod.rs:188, but now takes 5 parameters in /tmp/.tmpJYRaxn/core/crates/core/src/engine/mod.rs:188
  truecalc_core::Engine::evaluate_with_resolver_at_keyed takes 4 parameters in /tmp/.tmpdDKOJd/truecalc-core/src/engine/mod.rs:188, but now takes 5 parameters in /tmp/.tmpJYRaxn/core/crates/core/src/engine/mod.rs:188
```

### ⚠ `truecalc-workbook` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant Value:Zoned in /tmp/.tmpJYRaxn/core/crates/workbook/src/value.rs:47
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `truecalc-core`

<blockquote>

## [2.0.0](https://github.com/truecalc/core/compare/truecalc-core-v1.0.2...truecalc-core-v2.0.0) - 2026-06-23

### Added

- *(core)* MIN/MAX/SORT participation for zone-aware values
- *(core)* TZOVERLAP — working-hours overlap across N zones
- *(core)* flagship N-timezone compare + display
- *(core)* TZNOW (deterministic clock), TZINWINDOW, TZCANONICAL
- *(core)* timezone arithmetic — TZDIFF and TZADD
- *(core)* timezone construction, introspection and extraction functions
- *(core)* add foundational timezone functions
- *(core)* add Value::Zoned type and core-crate plumbing

### Fixed

- *(operator)* make Value::Date comparable as its serial number

### Other

- Merge pull request #686 from truecalc/feat/685-reframe-core-readme
- Merge pull request #684 from truecalc/feat/669-tz-overlap
- Merge pull request #672 from truecalc/feat/671-date-comparison-fix
</blockquote>

## `truecalc-workbook`

<blockquote>

## [2.0.0](https://github.com/truecalc/core/compare/truecalc-workbook-v1.0.2...truecalc-workbook-v2.0.0) - 2026-06-23

### Added

- *(core)* TZNOW (deterministic clock), TZINWINDOW, TZCANONICAL
- *(wasm,mcp,workbook)* serialize Value::Zoned across all surfaces
</blockquote>

## `truecalc-mcp`

<blockquote>

## [2.0.0](https://github.com/truecalc/core/compare/truecalc-mcp-v1.0.2...truecalc-mcp-v2.0.0) - 2026-06-23

### Added

- *(wasm,mcp,workbook)* serialize Value::Zoned across all surfaces

### Other

- *(mcp)* add value pitch, quick-start snippet, and docs footer to README
- *(mcp,wasm)* add keywords, categories and fix descriptions for crates.io
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).