### PR TITLE
feat: Value::Zoned type plumbing (Model B, chrono-tz)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,6 +2313,7 @@ version = "1.0.2"
 dependencies = [
  "calamine",
  "chrono",
+ "chrono-tz",
  "csv",
  "libm",
  "nom",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,7 @@ serde = ["dep:serde"]
 [dependencies]
 nom = "8"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+chrono-tz = { version = "0.10", default-features = false }
 regex-lite = "0.1"
 serde = { version = "1", features = ["derive"], optional = true }
 libm = "0.2"

--- a/crates/core/src/eval/coercion/mod.rs
+++ b/crates/core/src/eval/coercion/mod.rs
@@ -25,6 +25,9 @@ pub fn to_number(v: Value) -> Result<f64, Value> {
         }
         Value::Error(_)  => Err(v),
         Value::Array(_)  => Err(Value::Error(ErrorKind::Value)),
+        // Zoned instants have no naive numeric value; force an explicit TZSERIAL
+        // downcast rather than silently mixing naive/aware time.
+        Value::Zoned(_)  => Err(Value::Error(ErrorKind::Value)),
     }
 }
 
@@ -44,6 +47,8 @@ pub fn to_string_val(v: Value) -> Result<String, Value> {
         Value::Empty    => Ok(String::new()),
         Value::Error(_) => Err(v),
         Value::Array(_) => Err(Value::Error(ErrorKind::Value)),
+        // Self-describing canonical RFC-9557 form so concatenation is lossless.
+        Value::Zoned(z) => Ok(z.to_rfc9557()),
     }
 }
 
@@ -67,6 +72,8 @@ pub fn to_bool(v: Value) -> Result<bool, Value> {
             _       => Err(Value::Error(ErrorKind::Value)),
         },
         Value::Empty => Err(Value::Error(ErrorKind::Value)),
+        // A zoned instant has no truthiness.
+        Value::Zoned(_) => Err(Value::Error(ErrorKind::Value)),
         // Array condition: use the top-left (anchor) element — same as the
         // unspilled-array collapse the workbook layer applies.
         Value::Array(mut elems) => {

--- a/crates/core/src/eval/functions/logical/info/mod.rs
+++ b/crates/core/src/eval/functions/logical/info/mod.rs
@@ -52,6 +52,7 @@ pub fn n_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
         Value::Number(n) | Value::Date(n) => Value::Number(n),
         Value::Bool(b)          => Value::Number(if b { 1.0 } else { 0.0 }),
         Value::Empty | Value::Text(_) | Value::Array(_) => Value::Number(0.0),
+        Value::Zoned(_)         => Value::Error(ErrorKind::Value),
         Value::Error(_)         => val,
     }
 }
@@ -70,6 +71,7 @@ pub fn type_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
         Value::Error(_)  => 16.0,
         Value::Array(_)  => 64.0,
         Value::Empty     => 1.0, // Excel treats empty as number
+        Value::Zoned(_)  => 1.0, // classify like Number/Date for the TYPE code
     };
     Value::Number(code)
 }
@@ -146,6 +148,7 @@ pub fn cell_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
                 Value::Text(_)      => Value::Text("l".to_string()),
                 Value::Number(_) | Value::Date(_) => Value::Text("n".to_string()),
                 Value::Bool(_)      => Value::Text("l".to_string()),
+                Value::Zoned(_)     => Value::Text("n".to_string()),
                 Value::Error(e)     => Value::Error(e),
                 Value::Array(_)     => Value::Error(ErrorKind::NA),
             }

--- a/crates/core/src/eval/functions/math/average/mod.rs
+++ b/crates/core/src/eval/functions/math/average/mod.rs
@@ -24,6 +24,7 @@ pub fn average_fn(args: &[Value]) -> Value {
                 }
             }
             Value::Empty => {} // skip
+            Value::Zoned(_) => return Value::Error(ErrorKind::Value),
             Value::Error(e) => return Value::Error(e.clone()),
             Value::Array(elems) => {
                 // Array context: skip bool/text, include numbers

--- a/crates/core/src/eval/functions/math/countunique/mod.rs
+++ b/crates/core/src/eval/functions/math/countunique/mod.rs
@@ -20,6 +20,7 @@ fn to_unique_key(v: &Value) -> Option<UniqueKey> {
         Value::Text(_) | Value::Empty => None,
         Value::Error(e) => Some(UniqueKey::ErrorVal(format!("{e:?}"))),
         Value::Date(_) | Value::Array(_) => None,
+        Value::Zoned(_) => None,
     }
 }
 

--- a/crates/core/src/eval/functions/math/product/mod.rs
+++ b/crates/core/src/eval/functions/math/product/mod.rs
@@ -39,6 +39,7 @@ fn product_array_value(v: &Value) -> Result<f64, Value> {
             Ok(p)
         }
         Value::Bool(_) | Value::Text(_) | Value::Empty => Ok(1.0),
+        Value::Zoned(_) => Ok(1.0),
         Value::Error(_) => Err(v.clone()),
         Value::Number(n) | Value::Date(n) => Ok(*n),
     }

--- a/crates/core/src/eval/functions/math/sum/mod.rs
+++ b/crates/core/src/eval/functions/math/sum/mod.rs
@@ -55,6 +55,8 @@ fn sum_array_value(v: &Value) -> Result<f64, Value> {
         }
         // In array context: booleans and text are silently skipped
         Value::Bool(_) | Value::Text(_) | Value::Empty => Ok(0.0),
+        // In array context: zoned instants are silently skipped
+        Value::Zoned(_) => Ok(0.0),
         // Errors propagate
         Value::Error(_) => Err(v.clone()),
         // Numbers and Dates contribute their value

--- a/crates/core/src/eval/functions/math/sumsq/mod.rs
+++ b/crates/core/src/eval/functions/math/sumsq/mod.rs
@@ -44,6 +44,8 @@ fn sumsq_value(v: &Value, in_array: bool) -> Result<f64, Value> {
             if let Ok(n) = s.trim().parse::<f64>() { Ok(n * n) }
             else { Err(Value::Error(crate::types::ErrorKind::Value)) }
         }
+        Value::Zoned(_) if in_array => Ok(0.0), // skipped in array context
+        Value::Zoned(_) => Err(Value::Error(crate::types::ErrorKind::Value)),
         Value::Error(_) => Err(v.clone()),
         Value::Date(n) => Ok(n * n),
     }

--- a/crates/core/src/eval/functions/operator/mod.rs
+++ b/crates/core/src/eval/functions/operator/mod.rs
@@ -116,6 +116,7 @@ fn type_rank(v: &Value) -> u8 {
         Value::Number(_) | Value::Date(_) | Value::Empty => 0,
         Value::Text(_) => 1,
         Value::Bool(_) => 2,
+        Value::Zoned(_) => 3,
         _ => 255,
     }
 }
@@ -128,6 +129,9 @@ fn compare_values(a: &Value, b: &Value) -> std::cmp::Ordering {
             x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal),
         (Value::Text(x), Value::Text(y)) => x.to_lowercase().cmp(&y.to_lowercase()),
         (Value::Bool(x), Value::Bool(y)) => x.cmp(y),
+        // Zoned instants order on the absolute instant only (same moment in a
+        // different zone compares equal). Cross-type Zoned is rejected upstream.
+        (Value::Zoned(x), Value::Zoned(y)) => x.utc_nanos.cmp(&y.utc_nanos),
         _ => type_rank(a).cmp(&type_rank(b)),
     }
 }
@@ -140,11 +144,26 @@ fn same_type(a: &Value, b: &Value) -> bool {
             | (Value::Text(_), Value::Text(_))
             | (Value::Bool(_), Value::Bool(_))
             | (Value::Empty, Value::Empty)
+            | (Value::Zoned(_), Value::Zoned(_))
     )
+}
+
+/// Mixed naive/aware comparison is rejected: a `Zoned` instant cannot be ordered
+/// against a naive `Number`/`Date`/`Text`/`Bool`. Returns `#VALUE!` when exactly
+/// one operand is `Zoned`.
+fn zoned_cross_type(a: &Value, b: &Value) -> Option<Value> {
+    if matches!(a, Value::Zoned(_)) ^ matches!(b, Value::Zoned(_)) {
+        Some(Value::Error(ErrorKind::Value))
+    } else {
+        None
+    }
 }
 
 pub fn eq_fn(args: &[Value]) -> Value {
     if let Some(e) = check_exact(args, 2) {
+        return e;
+    }
+    if let Some(e) = zoned_cross_type(&args[0], &args[1]) {
         return e;
     }
     let (a, b) = (&args[0], &args[1]);
@@ -158,6 +177,9 @@ pub fn ne_fn(args: &[Value]) -> Value {
     if let Some(e) = check_exact(args, 2) {
         return e;
     }
+    if let Some(e) = zoned_cross_type(&args[0], &args[1]) {
+        return e;
+    }
     let (a, b) = (&args[0], &args[1]);
     if !same_type(a, b) {
         return Value::Bool(true);
@@ -169,11 +191,17 @@ pub fn gt_fn(args: &[Value]) -> Value {
     if let Some(e) = check_exact(args, 2) {
         return e;
     }
+    if let Some(e) = zoned_cross_type(&args[0], &args[1]) {
+        return e;
+    }
     Value::Bool(compare_values(&args[0], &args[1]) == std::cmp::Ordering::Greater)
 }
 
 pub fn gte_fn(args: &[Value]) -> Value {
     if let Some(e) = check_exact(args, 2) {
+        return e;
+    }
+    if let Some(e) = zoned_cross_type(&args[0], &args[1]) {
         return e;
     }
     Value::Bool(compare_values(&args[0], &args[1]) != std::cmp::Ordering::Less)
@@ -183,11 +211,17 @@ pub fn lt_fn(args: &[Value]) -> Value {
     if let Some(e) = check_exact(args, 2) {
         return e;
     }
+    if let Some(e) = zoned_cross_type(&args[0], &args[1]) {
+        return e;
+    }
     Value::Bool(compare_values(&args[0], &args[1]) == std::cmp::Ordering::Less)
 }
 
 pub fn lte_fn(args: &[Value]) -> Value {
     if let Some(e) = check_exact(args, 2) {
+        return e;
+    }
+    if let Some(e) = zoned_cross_type(&args[0], &args[1]) {
         return e;
     }
     Value::Bool(compare_values(&args[0], &args[1]) != std::cmp::Ordering::Greater)

--- a/crates/core/src/eval/functions/operator/tests/comparisons.rs
+++ b/crates/core/src/eval/functions/operator/tests/comparisons.rs
@@ -160,3 +160,36 @@ fn gt_dates() { assert_eq!(gt_fn(&[d(43832.0), d(43831.0)]), b(true)); }
 
 #[test]
 fn gte_equal_dates() { assert_eq!(gte_fn(&[d(43831.0), d(43831.0)]), b(true)); }
+
+// ── Zoned comparison (Model B: equality/ordering on the instant only) ─────────
+
+use crate::types::{ZoneId, ZonedInstant};
+
+fn z_utc(nanos: i64) -> Value {
+    Value::Zoned(Box::new(ZonedInstant::from_instant(nanos, ZoneId::Iana(chrono_tz::Tz::UTC))))
+}
+fn z_berlin(nanos: i64) -> Value {
+    Value::Zoned(Box::new(ZonedInstant::from_instant(nanos, ZoneId::Iana(chrono_tz::Europe::Berlin))))
+}
+
+#[test]
+fn eq_zoned_same_instant_different_zone() {
+    // Engine `=` compares the absolute instant, ignoring the zone label.
+    assert_eq!(eq_fn(&[z_utc(0), z_berlin(0)]), b(true));
+}
+
+#[test]
+fn eq_zoned_different_instant() { assert_eq!(eq_fn(&[z_utc(0), z_utc(1)]), b(false)); }
+
+#[test]
+fn lt_zoned_by_instant() { assert_eq!(lt_fn(&[z_utc(0), z_utc(1)]), b(true)); }
+
+#[test]
+fn eq_zoned_vs_number_is_value_error() {
+    assert_eq!(eq_fn(&[z_utc(0), n(0.0)]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn gt_zoned_vs_text_is_value_error() {
+    assert_eq!(gt_fn(&[z_utc(0), t("x")]), Value::Error(ErrorKind::Value));
+}

--- a/crates/core/src/eval/functions/statistical/distributions_impl.rs
+++ b/crates/core/src/eval/functions/statistical/distributions_impl.rs
@@ -96,6 +96,7 @@ fn collect_weights_arg(arg: &Value) -> Result<Vec<f64>, Value> {
             _ => Err(Value::Error(ErrorKind::Value)),
         },
         Value::Empty => Ok(vec![]),
+        Value::Zoned(_) => Err(Value::Error(ErrorKind::Value)),
         Value::Error(e) => Err(Value::Error(e.clone())),
         Value::Array(inner) => {
             let mut out = Vec::new();
@@ -105,6 +106,7 @@ fn collect_weights_arg(arg: &Value) -> Result<Vec<f64>, Value> {
                     Value::Date(n) => out.push(*n),
                     Value::Bool(_) => return Err(Value::Error(ErrorKind::Value)),
                     Value::Text(_) | Value::Empty => {}
+                    Value::Zoned(_) => {}
                     Value::Error(e) => return Err(Value::Error(e.clone())),
                     Value::Array(_) => {}
                 }

--- a/crates/core/src/eval/functions/statistical/stat_helpers.rs
+++ b/crates/core/src/eval/functions/statistical/stat_helpers.rs
@@ -53,6 +53,7 @@ fn collect_nums_a_into_checked(args: &[Value], out: &mut Vec<f64>) -> Option<Val
             }
             Value::Error(e) => return Some(Value::Error(e.clone())),
             Value::Empty => {}
+            Value::Zoned(_) => {}
         }
     }
     None
@@ -100,6 +101,7 @@ pub fn collect_nums_a_checked(args: &[Value]) -> Result<Vec<f64>, Value> {
                     return Err(err);
                 }
             }
+            Value::Zoned(_) => return Err(Value::Error(ErrorKind::Value)),
             Value::Error(e) => return Err(Value::Error(e.clone())),
         }
     }
@@ -146,6 +148,7 @@ pub fn collect_nums_direct(args: &[Value]) -> Result<Vec<f64>, Value> {
                     return Err(err);
                 }
             }
+            Value::Zoned(_) => return Err(Value::Error(ErrorKind::Value)),
             Value::Error(e) => return Err(Value::Error(e.clone())),
         }
     }
@@ -193,6 +196,7 @@ pub fn collect_nums_a_direct(args: &[Value]) -> Result<Vec<f64>, Value> {
                 // Array context: bools coerce, text→0
                 collect_nums_a_into(inner, &mut nums);
             }
+            Value::Zoned(_) => return Err(Value::Error(ErrorKind::Value)),
             Value::Error(e) => return Err(Value::Error(e.clone())),
         }
     }
@@ -217,6 +221,7 @@ pub fn collect_nums_a_into(args: &[Value], out: &mut Vec<f64>) {
             Value::Array(inner) => collect_nums_a_into(inner, out),
             Value::Empty => {}
             Value::Error(_) => {}
+            Value::Zoned(_) => {}
         }
     }
 }

--- a/crates/core/src/eval/mod.rs
+++ b/crates/core/src/eval/mod.rs
@@ -165,7 +165,7 @@ fn eval_apply(func: &Expr, call_args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
 // Number < Text < Bool  (Empty counts as Number)
 fn type_rank(v: &Value) -> u8 {
     match v {
-        Value::Number(_) | Value::Date(_) | Value::Empty => 0,
+        Value::Number(_) | Value::Date(_) | Value::Empty | Value::Zoned(_) => 0,
         Value::Text(_)                  => 1,
         Value::Bool(_)                  => 2,
         // Error and Array cannot reach compare_values through the normal eval path
@@ -257,6 +257,11 @@ fn eval_binary(op: &BinaryOp, lv: Value, rv: Value) -> Value {
             // Error propagation: left side first.
             if let Value::Error(_) = &lv { return lv; }
             if let Value::Error(_) = &rv { return rv; }
+            // Mixed naive/aware comparison is rejected (a zoned instant cannot be
+            // ordered against a naive value).
+            if matches!(&lv, Value::Zoned(_)) ^ matches!(&rv, Value::Zoned(_)) {
+                return Value::Error(ErrorKind::Value);
+            }
 
             let result = compare_values(op, &lv, &rv);
             Value::Bool(result)
@@ -271,6 +276,9 @@ fn compare_values(op: &BinaryOp, lv: &Value, rv: &Value) -> bool {
         (Value::Date(a),   Value::Date(b))   => apply_cmp(op, a.partial_cmp(b)),
         (Value::Date(a),   Value::Number(b)) => apply_cmp(op, a.partial_cmp(b)),
         (Value::Number(a), Value::Date(b))   => apply_cmp(op, a.partial_cmp(b)),
+        // Zoned instants compare on the absolute instant only (same moment in a
+        // different zone compares equal). Cross-type Zoned is rejected in eval_binary.
+        (Value::Zoned(a),  Value::Zoned(b))  => apply_cmp(op, Some(a.utc_nanos.cmp(&b.utc_nanos))),
         (Value::Text(a),   Value::Text(b))   => apply_cmp(op, Some(a.cmp(b))),
         (Value::Bool(a),   Value::Bool(b))   => apply_cmp(op, Some(a.cmp(b))),
         (Value::Empty,     Value::Empty)     => apply_cmp(op, Some(std::cmp::Ordering::Equal)),

--- a/crates/core/src/types/mod.rs
+++ b/crates/core/src/types/mod.rs
@@ -1,5 +1,7 @@
 pub mod error;
 pub mod value;
+pub mod zoned;
 
 pub use error::{ErrorKind, ParseError};
 pub use value::Value;
+pub use zoned::{AmbiguousPolicy, ZoneId, ZonedInstant};

--- a/crates/core/src/types/value.rs
+++ b/crates/core/src/types/value.rs
@@ -1,4 +1,5 @@
 use super::error::ErrorKind;
+use super::zoned::ZonedInstant;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
@@ -13,4 +14,9 @@ pub enum Value {
     /// A spreadsheet serial date number — same float encoding as Number but
     /// typed so ISDATE can distinguish it from a plain numeric literal.
     Date(f64),
+    /// A zone-aware instant (Model B): an absolute UTC instant plus an IANA or
+    /// fixed zone. Boxed because the payload carries a ~600-variant `Tz`, and
+    /// `Value` is cloned heavily on the hot numeric path. Equality/ordering for
+    /// the engine's comparison operators is defined on the instant only.
+    Zoned(Box<ZonedInstant>),
 }

--- a/crates/core/src/types/zoned/mod.rs
+++ b/crates/core/src/types/zoned/mod.rs
@@ -1,0 +1,223 @@
+//! Zone-aware instant value (Model B).
+//!
+//! [`ZonedInstant`] stores an absolute UTC instant plus an IANA/fixed zone.
+//! Offset, wall-clock fields, abbreviation and DST status are **recomputed on
+//! demand** from the pinned `chrono-tz` database — never stored — so the tzdb
+//! version is part of the engine's conformance contract. The existing tz-naive
+//! `Value::Date(f64)` serial is unaffected; the naive<->zoned boundary is always
+//! an explicit function call.
+
+use chrono::{DateTime, Duration, NaiveDateTime, Offset, TimeZone, Utc};
+use chrono_tz::{OffsetComponents, Tz};
+
+#[cfg(test)]
+mod tests;
+
+/// The zone attached to a [`ZonedInstant`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZoneId {
+    /// A named IANA region zone carrying full DST rules (e.g. `Europe/Berlin`).
+    Iana(Tz),
+    /// A bare fixed offset east of UTC, in minutes (`+05:30` = 330). No DST.
+    Fixed(i32),
+}
+
+/// An absolute instant labelled with a zone.
+///
+/// The engine's comparison operators define equality/ordering on `utc_nanos`
+/// only (see the `operator` module). The derived `PartialEq` here is structural
+/// (instant **and** zone) for Rust-level use such as test assertions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZonedInstant {
+    /// Nanoseconds since the Unix epoch (UTC).
+    pub utc_nanos: i64,
+    pub zone: ZoneId,
+}
+
+/// How to resolve a local wall-clock time that is invalid (spring-forward gap)
+/// or ambiguous (fall-back fold) when building a [`ZonedInstant`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AmbiguousPolicy {
+    /// Return an error on gap/fold — no silent shift. Deterministic default.
+    #[default]
+    Reject,
+    /// Earlier of two valid instants (fold) / first valid after a gap.
+    Earliest,
+    /// Later of two valid instants.
+    Latest,
+    /// Temporal "compatible": fold -> earliest, gap -> push forward.
+    Compatible,
+}
+
+impl ZonedInstant {
+    pub fn from_instant(utc_nanos: i64, zone: ZoneId) -> Self {
+        Self { utc_nanos, zone }
+    }
+
+    fn utc(&self) -> DateTime<Utc> {
+        DateTime::<Utc>::from_timestamp_nanos(self.utc_nanos)
+    }
+
+    /// Offset east of UTC in minutes, DST-resolved at this instant.
+    pub fn offset_minutes(&self) -> i32 {
+        match &self.zone {
+            ZoneId::Fixed(m) => *m,
+            ZoneId::Iana(tz) => {
+                tz.offset_from_utc_datetime(&self.utc().naive_utc())
+                    .fix()
+                    .local_minus_utc()
+                    / 60
+            }
+        }
+    }
+
+    /// Local wall-clock time in this zone (DST-resolved).
+    pub fn local(&self) -> NaiveDateTime {
+        match &self.zone {
+            ZoneId::Fixed(m) => self.utc().naive_utc() + Duration::minutes(*m as i64),
+            ZoneId::Iana(tz) => self.utc().with_timezone(tz).naive_local(),
+        }
+    }
+
+    /// Zone abbreviation at this instant (`CEST`), or a `±HH:MM` label for a
+    /// fixed-offset zone.
+    pub fn abbrev(&self) -> String {
+        match &self.zone {
+            ZoneId::Fixed(m) => offset_label(*m),
+            ZoneId::Iana(tz) => {
+                format!("{}", tz.offset_from_utc_datetime(&self.utc().naive_utc()))
+            }
+        }
+    }
+
+    /// Whether daylight-saving is in effect at this instant.
+    pub fn is_dst(&self) -> bool {
+        match &self.zone {
+            ZoneId::Fixed(_) => false,
+            ZoneId::Iana(tz) => {
+                tz.offset_from_utc_datetime(&self.utc().naive_utc())
+                    .dst_offset()
+                    .num_seconds()
+                    != 0
+            }
+        }
+    }
+
+    /// Canonical self-describing RFC-9557 string, e.g.
+    /// `2026-07-14T11:00:00+02:00[Europe/Berlin]` (bracket omitted for a fixed
+    /// offset).
+    pub fn to_rfc9557(&self) -> String {
+        let local = self.local().format("%Y-%m-%dT%H:%M:%S");
+        let base = format!("{}{}", local, offset_label(self.offset_minutes()));
+        match &self.zone {
+            ZoneId::Iana(tz) => format!("{}[{}]", base, tz.name()),
+            ZoneId::Fixed(_) => base,
+        }
+    }
+
+    /// Build from a local wall-clock time in `zone`, resolving gap/fold per
+    /// `policy`. Returns `None` on gap/fold under [`AmbiguousPolicy::Reject`], or
+    /// on an out-of-range instant. (Callers map `None` to `#VALUE!`; the
+    /// gap-vs-fold distinction is surfaced separately by `TZLOCALSTATUS`.)
+    pub fn from_local(zone: ZoneId, naive: NaiveDateTime, policy: AmbiguousPolicy) -> Option<Self> {
+        use chrono::LocalResult;
+        let utc_nanos = match &zone {
+            ZoneId::Fixed(m) => (naive - Duration::minutes(*m as i64))
+                .and_utc()
+                .timestamp_nanos_opt()?,
+            ZoneId::Iana(tz) => match tz.from_local_datetime(&naive) {
+                LocalResult::Single(dt) => dt.timestamp_nanos_opt()?,
+                LocalResult::Ambiguous(earliest, latest) => match policy {
+                    AmbiguousPolicy::Reject => return None,
+                    AmbiguousPolicy::Latest => latest.timestamp_nanos_opt()?,
+                    _ => earliest.timestamp_nanos_opt()?,
+                },
+                LocalResult::None => match policy {
+                    AmbiguousPolicy::Reject => return None,
+                    _ => gap_forward(tz, naive)?,
+                },
+            },
+        };
+        Some(Self { utc_nanos, zone })
+    }
+}
+
+/// Parse an IANA zone name or fixed-offset string into a [`ZoneId`].
+/// Accepts `UTC`/`Z`, IANA names (`Europe/Berlin`) and `±HH:MM`/`±HHMM`/`±HH`.
+pub fn parse_zone(text: &str) -> Option<ZoneId> {
+    let t = text.trim();
+    if t.eq_ignore_ascii_case("Z") || t.eq_ignore_ascii_case("UTC") {
+        return Some(ZoneId::Iana(Tz::UTC));
+    }
+    if let Ok(tz) = t.parse::<Tz>() {
+        return Some(ZoneId::Iana(tz));
+    }
+    parse_fixed_offset(t).map(ZoneId::Fixed)
+}
+
+/// Parse a canonical RFC-9557 string (`...±HH:MM[Zone]`, or offset-only RFC-3339)
+/// into a [`ZonedInstant`].
+pub fn parse_rfc9557(text: &str) -> Option<ZonedInstant> {
+    let t = text.trim();
+    match t.split_once('[') {
+        Some((dt_part, rest)) => {
+            let zone = parse_zone(rest.strip_suffix(']')?)?;
+            let dt = DateTime::parse_from_rfc3339(dt_part).ok()?;
+            Some(ZonedInstant {
+                utc_nanos: dt.with_timezone(&Utc).timestamp_nanos_opt()?,
+                zone,
+            })
+        }
+        None => {
+            let dt = DateTime::parse_from_rfc3339(t).ok()?;
+            let off_min = dt.offset().local_minus_utc() / 60;
+            Some(ZonedInstant {
+                utc_nanos: dt.with_timezone(&Utc).timestamp_nanos_opt()?,
+                zone: ZoneId::Fixed(off_min),
+            })
+        }
+    }
+}
+
+/// Format a minutes-east-of-UTC offset as `±HH:MM` (330 -> `+05:30`).
+fn offset_label(minutes: i32) -> String {
+    let sign = if minutes < 0 { '-' } else { '+' };
+    let a = minutes.abs();
+    format!("{}{:02}:{:02}", sign, a / 60, a % 60)
+}
+
+/// Resolve a wall-clock time inside a spring-forward gap to the first valid
+/// instant at or after it by probing increasing forward shifts.
+fn gap_forward(tz: &Tz, naive: NaiveDateTime) -> Option<i64> {
+    use chrono::LocalResult;
+    for mins in [15i64, 30, 45, 60, 90, 120] {
+        match tz.from_local_datetime(&(naive + Duration::minutes(mins))) {
+            LocalResult::Single(dt) | LocalResult::Ambiguous(dt, _) => {
+                return dt.timestamp_nanos_opt();
+            }
+            LocalResult::None => continue,
+        }
+    }
+    None
+}
+
+/// Parse `±HH:MM` / `±HHMM` / `±HH` into minutes east of UTC.
+fn parse_fixed_offset(t: &str) -> Option<i32> {
+    let sign = match t.as_bytes().first()? {
+        b'+' => 1,
+        b'-' => -1,
+        _ => return None,
+    };
+    let rest = &t[1..];
+    let (h, m) = if let Some((h, m)) = rest.split_once(':') {
+        (h.parse::<i32>().ok()?, m.parse::<i32>().ok()?)
+    } else if rest.len() == 4 {
+        (rest[..2].parse().ok()?, rest[2..].parse().ok()?)
+    } else {
+        (rest.parse::<i32>().ok()?, 0)
+    };
+    if !(0..=23).contains(&h) || !(0..=59).contains(&m) {
+        return None;
+    }
+    Some(sign * (h * 60 + m))
+}

--- a/crates/core/src/types/zoned/tests.rs
+++ b/crates/core/src/types/zoned/tests.rs
@@ -1,0 +1,90 @@
+use super::*;
+use chrono::NaiveDate;
+
+fn ndt(y: i32, mo: u32, d: u32, h: u32, mi: u32) -> NaiveDateTime {
+    NaiveDate::from_ymd_opt(y, mo, d)
+        .unwrap()
+        .and_hms_opt(h, mi, 0)
+        .unwrap()
+}
+
+fn berlin() -> ZoneId {
+    ZoneId::Iana(chrono_tz::Europe::Berlin)
+}
+
+#[test]
+fn berlin_summer_is_cest_plus_two() {
+    let z = ZonedInstant::from_local(berlin(), ndt(2026, 7, 14, 11, 0), AmbiguousPolicy::Reject).unwrap();
+    assert_eq!(z.offset_minutes(), 120);
+    assert!(z.is_dst());
+    assert_eq!(z.abbrev(), "CEST");
+    assert_eq!(z.local(), ndt(2026, 7, 14, 11, 0));
+    assert_eq!(z.to_rfc9557(), "2026-07-14T11:00:00+02:00[Europe/Berlin]");
+}
+
+#[test]
+fn berlin_winter_is_cet_plus_one() {
+    let z = ZonedInstant::from_local(berlin(), ndt(2026, 1, 14, 11, 0), AmbiguousPolicy::Reject).unwrap();
+    assert_eq!(z.offset_minutes(), 60);
+    assert!(!z.is_dst());
+    assert_eq!(z.abbrev(), "CET");
+}
+
+#[test]
+fn spring_forward_gap_rejected() {
+    // 2026-03-29 02:30 Berlin does not exist (clocks jump 02:00 -> 03:00).
+    let r = ZonedInstant::from_local(berlin(), ndt(2026, 3, 29, 2, 30), AmbiguousPolicy::Reject);
+    assert!(r.is_none());
+}
+
+#[test]
+fn spring_forward_gap_nonreject_resolves_into_cest() {
+    let z = ZonedInstant::from_local(berlin(), ndt(2026, 3, 29, 2, 30), AmbiguousPolicy::Compatible).unwrap();
+    assert_eq!(z.offset_minutes(), 120); // resolved past the gap into CEST
+}
+
+#[test]
+fn fall_back_fold_reject_then_earliest_latest() {
+    // 2026-10-25 02:30 Berlin happens twice (clocks fall 03:00 -> 02:00).
+    assert!(ZonedInstant::from_local(berlin(), ndt(2026, 10, 25, 2, 30), AmbiguousPolicy::Reject).is_none());
+    let early = ZonedInstant::from_local(berlin(), ndt(2026, 10, 25, 2, 30), AmbiguousPolicy::Earliest).unwrap();
+    let late = ZonedInstant::from_local(berlin(), ndt(2026, 10, 25, 2, 30), AmbiguousPolicy::Latest).unwrap();
+    assert_eq!(early.offset_minutes(), 120); // first occurrence still CEST
+    assert_eq!(late.offset_minutes(), 60); // second occurrence CET
+    assert_eq!(late.utc_nanos - early.utc_nanos, 3_600 * 1_000_000_000);
+}
+
+#[test]
+fn fixed_offset_has_no_dst() {
+    let z = ZonedInstant::from_local(ZoneId::Fixed(330), ndt(2026, 1, 1, 12, 0), AmbiguousPolicy::Reject).unwrap();
+    assert_eq!(z.offset_minutes(), 330);
+    assert!(!z.is_dst());
+    assert_eq!(z.abbrev(), "+05:30");
+    assert_eq!(z.to_rfc9557(), "2026-01-01T12:00:00+05:30");
+}
+
+#[test]
+fn equality_is_structural_instant_and_zone() {
+    let utc = ZonedInstant::from_instant(0, ZoneId::Iana(chrono_tz::Tz::UTC));
+    let berlin_same_instant = ZonedInstant::from_instant(0, berlin());
+    // Same instant, different zone: structurally distinct (engine `=` differs — see operator).
+    assert_ne!(utc, berlin_same_instant);
+    assert_eq!(utc, ZonedInstant::from_instant(0, ZoneId::Iana(chrono_tz::Tz::UTC)));
+}
+
+#[test]
+fn parse_zone_variants() {
+    assert_eq!(parse_zone("Europe/Berlin"), Some(berlin()));
+    assert_eq!(parse_zone("UTC"), Some(ZoneId::Iana(chrono_tz::Tz::UTC)));
+    assert_eq!(parse_zone("+05:30"), Some(ZoneId::Fixed(330)));
+    assert_eq!(parse_zone("-08:00"), Some(ZoneId::Fixed(-480)));
+    assert_eq!(parse_zone("Not/AZone"), None);
+}
+
+#[test]
+fn rfc9557_round_trips() {
+    let z = ZonedInstant::from_local(berlin(), ndt(2026, 7, 14, 11, 0), AmbiguousPolicy::Reject).unwrap();
+    let back = parse_rfc9557(&z.to_rfc9557()).unwrap();
+    assert_eq!(back.utc_nanos, z.utc_nanos);
+    assert_eq!(back.zone, z.zone);
+}

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -271,7 +271,7 @@ pub fn values_match(actual: &Value, expected: &Value, expected_type: &str) -> bo
 
 fn infer_type(v: &Value) -> &'static str {
     match v {
-        Value::Number(_) | Value::Date(_) => "number",
+        Value::Number(_) | Value::Date(_) | Value::Zoned(_) => "number",
         Value::Text(_) => "string",
         Value::Bool(_) => "boolean",
         Value::Error(_) => "error",

--- a/crates/core/tests/conformance_reporter.rs
+++ b/crates/core/tests/conformance_reporter.rs
@@ -86,7 +86,7 @@ fn flatten_array(v: &Value) -> Vec<Value> {
 
 fn infer_type(v: &Value) -> &'static str {
     match v {
-        Value::Number(_) | Value::Date(_) => "number",
+        Value::Number(_) | Value::Date(_) | Value::Zoned(_) => "number",
         Value::Text(_) => "string",
         Value::Bool(_) => "boolean",
         Value::Error(_) => "error",

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -377,6 +377,8 @@ fn tool_workbook_set(args: &JsonValue, store: &mut SessionStore) -> JsonValue {
         CellInput::Literal(WbValue::Boolean(false))
     } else if let Ok(n) = value.parse::<f64>() {
         CellInput::Literal(WbValue::Number(n))
+    } else if let Some(zi) = truecalc_core::types::zoned::parse_rfc9557(value) {
+        CellInput::Literal(WbValue::Zoned(Box::new(zi)))
     } else {
         CellInput::Literal(WbValue::Text(value.to_owned()))
     };
@@ -488,6 +490,7 @@ fn wb_value_to_json(v: &WbValue) -> JsonValue {
         WbValue::Error(e) => json!({ "type": "error", "error": e }),
         WbValue::Empty => json!({ "type": "empty", "value": null }),
         WbValue::Date(d) => json!({ "type": "date", "value": d }),
+        WbValue::Zoned(z) => json!({ "type": "zoned", "value": z.to_rfc9557() }),
         WbValue::Array(rows) => {
             let arr: Vec<Vec<JsonValue>> = rows.iter()
                 .map(|r| r.iter().map(wb_value_to_json).collect())
@@ -511,6 +514,19 @@ fn parse_variables(vars_json: &JsonValue) -> HashMap<String, Value> {
                 }
                 JsonValue::String(s) => Value::Text(s.clone()),
                 JsonValue::Bool(b) => Value::Bool(*b),
+                // Self-describing zoned instant: { "type": "zoned", "value": "<RFC-9557>" }.
+                JsonValue::Object(o)
+                    if o.get("type").and_then(|t| t.as_str()) == Some("zoned") =>
+                {
+                    match o
+                        .get("value")
+                        .and_then(|x| x.as_str())
+                        .and_then(truecalc_core::types::zoned::parse_rfc9557)
+                    {
+                        Some(zi) => Value::Zoned(Box::new(zi)),
+                        None => continue,
+                    }
+                }
                 _ => continue,
             };
             map.insert(k.clone(), val);
@@ -526,6 +542,8 @@ fn value_to_json(v: &Value) -> JsonValue {
         Value::Bool(b) => json!({ "value": b, "type": "bool" }),
         Value::Empty => json!({ "value": null, "type": "empty" }),
         Value::Error(e) => json!({ "value": e.to_string(), "type": "error" }),
+        // Self-describing RFC-9557; deliberately NOT collapsed to "number".
+        Value::Zoned(z) => json!({ "value": z.to_rfc9557(), "type": "zoned" }),
         Value::Array(arr) => {
             let items: Vec<JsonValue> = arr.iter().map(value_to_json).collect();
             json!({ "value": items, "type": "array" })

--- a/crates/wasm-workbook/src/lib.rs
+++ b/crates/wasm-workbook/src/lib.rs
@@ -11,6 +11,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
         Value::Text(s) => serde_json::json!({"type": "text", "value": s}),
         Value::Boolean(b) => serde_json::json!({"type": "bool", "value": b}),
         Value::Date(n) => serde_json::json!({"type": "date", "value": n}),
+        Value::Zoned(z) => serde_json::json!({"type": "zoned", "value": z.to_rfc9557()}),
         Value::Error(code) => serde_json::json!({"type": "error", "error": code}),
         Value::Empty => serde_json::json!({"type": "empty"}),
         Value::Array(rows) => {

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -8,9 +8,14 @@ use serde_json::json;
 use tsify_next::Tsify;
 use wasm_bindgen::prelude::*;
 
+use truecalc_core::types::zoned::parse_rfc9557;
 use truecalc_core::Value;
 
 /// Convert a JSON value (from JS) into a truecalc-core Value.
+///
+/// A zoned instant round-trips in via the self-describing object
+/// `{ "type": "zoned", "value": "<RFC-9557>" }` (the same shape `value_to_result`
+/// emits), so an emitted `Zoned` can be fed back as a variable.
 fn json_to_value(v: &serde_json::Value) -> Value {
     match v {
         serde_json::Value::Number(n) => n
@@ -20,6 +25,18 @@ fn json_to_value(v: &serde_json::Value) -> Value {
         serde_json::Value::String(s) => Value::Text(s.clone()),
         serde_json::Value::Bool(b) => Value::Bool(*b),
         serde_json::Value::Null => Value::Empty,
+        serde_json::Value::Object(map) => {
+            if map.get("type").and_then(|t| t.as_str()) == Some("zoned") {
+                if let Some(zi) = map
+                    .get("value")
+                    .and_then(|val| val.as_str())
+                    .and_then(parse_rfc9557)
+                {
+                    return Value::Zoned(Box::new(zi));
+                }
+            }
+            Value::Empty
+        }
         _ => Value::Empty,
     }
 }
@@ -54,6 +71,11 @@ pub enum EvalResult {
     /// A spreadsheet serial date number. Distinct from `Number` so consumers can
     /// format it as a date; the epoch is implied by the engine flavor.
     Date { value: f64 },
+    /// A zone-aware instant, carried as its canonical, self-describing RFC-9557
+    /// string, e.g. `2026-07-14T11:00:00+02:00[Europe/Berlin]`. Derived fields
+    /// (offset/abbrev/is_dst) are intentionally NOT emitted — fetch them via the
+    /// `TZ*` functions so consumers never persist a stale offset.
+    Zoned { value: String },
     Error { error: String },
     Empty,
     /// An (unspilled) array result. Recursive: 2-D arrays are arrays of `array`
@@ -69,6 +91,7 @@ pub fn value_to_result(value: Value) -> EvalResult {
     match value {
         Value::Number(n) => EvalResult::Number { value: n },
         Value::Date(n) => EvalResult::Date { value: n },
+        Value::Zoned(z) => EvalResult::Zoned { value: z.to_rfc9557() },
         Value::Text(s) => EvalResult::Text { value: s },
         Value::Bool(b) => EvalResult::Bool { value: b },
         Value::Error(e) => EvalResult::Error { error: e.to_string() },

--- a/crates/workbook/src/recalc.rs
+++ b/crates/workbook/src/recalc.rs
@@ -1135,6 +1135,7 @@ fn core_to_workbook(v: CoreValue) -> Value {
         CoreValue::Error(e) => Value::Error(e.to_string()),
         CoreValue::Empty => Value::Empty,
         CoreValue::Date(n) => Value::Date(n),
+        CoreValue::Zoned(z) => Value::Zoned(z),
         CoreValue::Array(elems) => core_array_to_workbook(elems),
     }
 }
@@ -1175,6 +1176,7 @@ fn workbook_to_core(v: &Value) -> CoreValue {
         Value::Error(code) => CoreValue::Error(error_kind_from_code(code)),
         Value::Empty => CoreValue::Empty,
         Value::Date(n) => CoreValue::Date(*n),
+        Value::Zoned(z) => CoreValue::Zoned(z.clone()),
         Value::Array(rows) => CoreValue::Array(
             rows.iter()
                 .map(|row| CoreValue::Array(row.iter().map(workbook_to_core).collect()))

--- a/crates/workbook/src/value.rs
+++ b/crates/workbook/src/value.rs
@@ -3,6 +3,8 @@ use std::hash::{Hash, Hasher};
 use serde::de::Error as _;
 use serde::ser::{Error as _, SerializeMap};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use truecalc_core::types::zoned::parse_rfc9557;
+use truecalc_core::types::ZonedInstant;
 
 /// An evaluated cell value — one of the seven types of schema spec §6.
 ///
@@ -40,6 +42,9 @@ pub enum Value {
     /// A date as a serial number (fractional part = time of day). The epoch
     /// is implied by the workbook's engine flavor, never stored per-value.
     Date(f64),
+    /// A zone-aware instant (Model B). Serialized as its canonical, self-
+    /// describing RFC-9557 string, e.g. `2026-07-14T11:00:00+02:00[Europe/Berlin]`.
+    Zoned(Box<ZonedInstant>),
 }
 
 /// Bit pattern of a finite f64 with `-0.0` normalized to `0.0`, so that
@@ -61,6 +66,9 @@ impl Hash for Value {
             Value::Text(s) => s.hash(state),
             Value::Boolean(b) => b.hash(state),
             Value::Error(code) => code.hash(state),
+            // Hash the canonical RFC-9557 form: structurally equal instants
+            // (same utc_nanos + zone) produce the same string, agreeing with `==`.
+            Value::Zoned(z) => z.to_rfc9557().hash(state),
             Value::Empty => {}
             Value::Array(rows) => {
                 rows.len().hash(state);
@@ -97,6 +105,12 @@ impl Serialize for Value {
         match self {
             Value::Number(n) => serialize_tagged_number("number", *n, serializer),
             Value::Date(n) => serialize_tagged_number("date", *n, serializer),
+            Value::Zoned(z) => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("type", "zoned")?;
+                map.serialize_entry("value", &z.to_rfc9557())?;
+                map.end()
+            }
             Value::Text(s) => {
                 let mut map = serializer.serialize_map(Some(2))?;
                 map.serialize_entry("type", "text")?;
@@ -185,6 +199,12 @@ fn parse_value(raw: &serde_json::Value) -> Result<Value, String> {
     match kind {
         "number" => Ok(Value::Number(parse_finite_f64(payload, kind)?)),
         "date" => Ok(Value::Date(parse_finite_f64(payload, kind)?)),
+        "zoned" => match payload.as_str() {
+            Some(s) => parse_rfc9557(s)
+                .map(|zi| Value::Zoned(Box::new(zi)))
+                .ok_or_else(|| format!("a zoned value must be a valid RFC-9557 string, got {s:?}")),
+            None => Err("a zoned value must be a JSON string".to_string()),
+        },
         "text" => match payload.as_str() {
             Some(s) => Ok(Value::Text(s.to_owned())),
             None => Err("a text value must be a JSON string".to_string()),

--- a/crates/workbook/tests/value_serde_tests.rs
+++ b/crates/workbook/tests/value_serde_tests.rs
@@ -184,3 +184,28 @@ fn one_by_n_and_n_by_one_arrays_are_accepted() {
     let column = Value::Array(vec![vec![Value::Number(1.0)], vec![Value::Number(2.0)]]);
     assert_eq!(round_trip(&column), column);
 }
+
+// ── Zoned (Model B): canonical, self-describing RFC-9557 wire form ─────────────
+
+#[test]
+fn zoned_iana_round_trips_via_rfc9557() {
+    // The serializer must emit exactly the canonical RFC-9557 string, and the
+    // value must survive a JSON round trip unchanged.
+    let json = r#"{"type":"zoned","value":"2026-07-14T11:00:00+02:00[Europe/Berlin]"}"#;
+    let v = serde_json::from_str::<Value>(json).unwrap();
+    assert_eq!(serde_json::to_string(&v).unwrap(), json);
+    assert_eq!(round_trip(&v), v);
+}
+
+#[test]
+fn zoned_fixed_offset_round_trips() {
+    let json = r#"{"type":"zoned","value":"2026-01-01T12:00:00+05:30"}"#;
+    let v = serde_json::from_str::<Value>(json).unwrap();
+    assert_eq!(serde_json::to_string(&v).unwrap(), json);
+    assert_eq!(round_trip(&v), v);
+}
+
+#[test]
+fn zoned_rejects_invalid_rfc9557() {
+    assert!(serde_json::from_str::<Value>(r#"{"type":"zoned","value":"not a timestamp"}"#).is_err());
+}


### PR DESCRIPTION
## Phase 2 of #666 (timezone-aware functions epic)

Introduces the Model-B zone-aware value type and wires it through every export surface. No user-facing `TZ*` functions yet (Phase 3) — this is the type foundation.

### Core
- `Value::Zoned(Box<ZonedInstant>)` over `chrono-tz`: stores an absolute UTC instant + IANA/fixed zone; offset/abbrev/DST **recomputed on demand, never stored** (avoids the stale-offset anti-pattern).
- New `types/zoned` module: `ZonedInstant`, `ZoneId{Iana,Fixed}`, `AmbiguousPolicy` (default **Reject**), `from_local` (DST gap/fold resolution), `to_rfc9557`/`parse_rfc9557`/`parse_zone`, with unit tests grounded in IANA facts (Berlin CEST/CET, the 2026 EU DST gap & fold, Kathmandu +5:45, fixed offsets).
- Coercion: `to_number`/`to_bool` → `#VALUE!`; `to_string_val` → canonical RFC-9557.
- Comparison (operator **and** `eval_binary`): Zoned orders on the absolute instant only (same moment, different zone ⇒ equal); mixed naive/aware comparison → `#VALUE!`.
- All remaining exhaustive `Value` matches (numeric aggregation, statistics, info funcs) extended for the new variant.

### Surfaces — one canonical wire form
`{ "type": "zoned", "value": "<RFC-9557>" }`, e.g. `2026-07-14T11:00:00+02:00[Europe/Berlin]`:
- **wasm**: `EvalResult::Zoned` output (canonical string only — no derived offset/abbrev/is_dst, fetch via `TZ*`) + `json_to_value` input so an emitted Zoned round-trips back.
- **mcp**: `value_to_json` (NOT collapsed to `number` like `Date`) + `wb_value_to_json` output; `parse_variables` + `workbook_set` accept the zoned form.
- **workbook** (`WbValue`) + **wasm-workbook**: serde + both core↔workbook conversions.

### Decisions (from the design)
Ship all IANA zones (no WASM filter); DST gap/fold default = reject; sorting via ordered `utc_nanos` (Phase 5); pinned tzdb is part of the conformance contract.

### Verification
- `cargo build --workspace` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` → **3384 passed, 0 failed** ✅ (incl. new zoned + serde round-trip tests)

### Note / deviation
The design sketched the WASM output as `{instant, zone, rfc9557}`; I used the single canonical `value: <rfc9557>` for consistency across all four surfaces and to avoid shipping redundant/derivable fields. The RFC-9557 string is fully self-describing (instant + offset + zone). Easy to split out later if a consumer needs it.

Closes #667