### PR TITLE
feat: foundational timezone functions (construct/convert/introspect)

### DIFF
--- a/crates/core/src/eval/functions/mod.rs
+++ b/crates/core/src/eval/functions/mod.rs
@@ -11,6 +11,7 @@ pub mod operator;
 pub mod parser;
 pub mod statistical;
 pub mod text;
+pub mod timezone;
 pub mod web;
 
 use std::collections::HashMap;
@@ -125,6 +126,7 @@ impl Registry {
         database::register_database(&mut r);
         lookup::register_lookup(&mut r);
         web::register_web(&mut r);
+        timezone::register_timezone(&mut r);
         r
     }
 

--- a/crates/core/src/eval/functions/timezone/mod.rs
+++ b/crates/core/src/eval/functions/timezone/mod.rs
@@ -1,0 +1,185 @@
+//! Timezone-aware functions (Model B). They construct, convert, introspect and
+//! display [`Value::Zoned`] instants. The naive<->zoned boundary is always an
+//! explicit call here: `TZDATETIME`/`TZLOCALIZE` up, `TZSERIAL` down.
+
+use chrono::{NaiveDate, Timelike};
+
+use crate::eval::coercion::to_number;
+use crate::eval::functions::date::serial::{date_to_serial, time_to_serial};
+use crate::eval::functions::{check_arity, FunctionMeta, Registry};
+use crate::types::zoned::{parse_zone, AmbiguousPolicy};
+use crate::types::{ErrorKind, Value, ZoneId, ZonedInstant};
+
+#[cfg(test)]
+mod tests;
+
+pub fn register_timezone(registry: &mut Registry) {
+    registry.register_eager("TZDBVERSION", tzdbversion_fn, FunctionMeta { category: "timezone", signature: "TZDBVERSION()", description: "IANA time-zone database version the engine is using" });
+    registry.register_eager("TZVALID", tzvalid_fn, FunctionMeta { category: "timezone", signature: "TZVALID(zone)", description: "TRUE if the text is a valid IANA zone name or fixed offset" });
+    registry.register_eager("ISZONED", iszoned_fn, FunctionMeta { category: "timezone", signature: "ISZONED(value)", description: "TRUE if the value is a zone-aware instant" });
+    registry.register_eager("TZDATETIME", tzdatetime_fn, FunctionMeta { category: "timezone", signature: "TZDATETIME(year,month,day,hour,minute,second,zone,[policy])", description: "Builds a zone-aware instant from a wall-clock time in a zone" });
+    registry.register_eager("TZCONVERT", tzconvert_fn, FunctionMeta { category: "timezone", signature: "TZCONVERT(zoned,target_zone)", description: "Same instant shown as the local time in another zone" });
+    registry.register_eager("TZSERIAL", tzserial_fn, FunctionMeta { category: "timezone", signature: "TZSERIAL(zoned)", description: "Drops the zone, returning the wall-clock time as a plain date serial" });
+    registry.register_eager("TZOFFSET", tzoffset_fn, FunctionMeta { category: "timezone", signature: "TZOFFSET(zoned)", description: "Offset from UTC in minutes at this instant (DST-resolved)" });
+    registry.register_eager("TZSTRING", tzstring_fn, FunctionMeta { category: "timezone", signature: "TZSTRING(zoned)", description: "Canonical RFC-9557 string for a zone-aware instant" });
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+/// Borrow a [`ZonedInstant`] from a `Zoned` argument, else `#VALUE!`.
+fn arg_zoned(v: &Value) -> Result<&ZonedInstant, Value> {
+    match v {
+        Value::Zoned(z) => Ok(z),
+        _ => Err(Value::Error(ErrorKind::Value)),
+    }
+}
+
+/// Parse a zone from a text argument, else `#VALUE!`.
+fn arg_zone(v: &Value) -> Result<ZoneId, Value> {
+    match v {
+        Value::Text(s) => parse_zone(s).ok_or(Value::Error(ErrorKind::Value)),
+        _ => Err(Value::Error(ErrorKind::Value)),
+    }
+}
+
+/// Coerce an argument to a truncated integer, propagating coercion errors.
+fn int_arg(v: &Value) -> Result<i64, Value> {
+    Ok(to_number(v.clone())?.trunc() as i64)
+}
+
+fn zoned(zi: ZonedInstant) -> Value {
+    Value::Zoned(Box::new(zi))
+}
+
+// ── Functions ─────────────────────────────────────────────────────────────────
+
+pub fn tzdbversion_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 0, 0) {
+        return e;
+    }
+    Value::Text(chrono_tz::IANA_TZDB_VERSION.to_string())
+}
+
+pub fn tzvalid_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 1, 1) {
+        return e;
+    }
+    match &args[0] {
+        Value::Text(s) => Value::Bool(parse_zone(s).is_some()),
+        _ => Value::Bool(false),
+    }
+}
+
+pub fn iszoned_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 1, 1) {
+        return e;
+    }
+    Value::Bool(matches!(args[0], Value::Zoned(_)))
+}
+
+pub fn tzdatetime_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 7, 8) {
+        return e;
+    }
+    let parts = match (0..6).map(|i| int_arg(&args[i])).collect::<Result<Vec<_>, _>>() {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let zone = match arg_zone(&args[6]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let policy = if args.len() == 8 {
+        match &args[7] {
+            Value::Text(s) => match parse_policy(s) {
+                Some(p) => p,
+                None => return Value::Error(ErrorKind::Value),
+            },
+            _ => return Value::Error(ErrorKind::Value),
+        }
+    } else {
+        AmbiguousPolicy::Reject
+    };
+
+    let (year, month, day, hour, minute, second) =
+        (parts[0], parts[1], parts[2], parts[3], parts[4], parts[5]);
+    let naive = match (
+        i32::try_from(year).ok(),
+        u32::try_from(month).ok(),
+        u32::try_from(day).ok(),
+        u32::try_from(hour).ok(),
+        u32::try_from(minute).ok(),
+        u32::try_from(second).ok(),
+    ) {
+        (Some(y), Some(mo), Some(d), Some(h), Some(mi), Some(s)) => NaiveDate::from_ymd_opt(y, mo, d)
+            .and_then(|date| date.and_hms_opt(h, mi, s)),
+        _ => None,
+    };
+    let naive = match naive {
+        Some(n) => n,
+        None => return Value::Error(ErrorKind::Value),
+    };
+    match ZonedInstant::from_local(zone, naive, policy) {
+        Some(zi) => zoned(zi),
+        None => Value::Error(ErrorKind::Value),
+    }
+}
+
+pub fn tzconvert_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 2, 2) {
+        return e;
+    }
+    let zi = match arg_zoned(&args[0]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let target = match arg_zone(&args[1]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    zoned(ZonedInstant::from_instant(zi.utc_nanos, target))
+}
+
+pub fn tzserial_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 1, 1) {
+        return e;
+    }
+    let zi = match arg_zoned(&args[0]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let local = zi.local();
+    let serial = date_to_serial(local.date())
+        + time_to_serial(local.hour(), local.minute(), local.second());
+    Value::Date(serial)
+}
+
+pub fn tzoffset_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 1, 1) {
+        return e;
+    }
+    match arg_zoned(&args[0]) {
+        Ok(zi) => Value::Number(zi.offset_minutes() as f64),
+        Err(e) => e,
+    }
+}
+
+pub fn tzstring_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 1, 1) {
+        return e;
+    }
+    match arg_zoned(&args[0]) {
+        Ok(zi) => Value::Text(zi.to_rfc9557()),
+        Err(e) => e,
+    }
+}
+
+fn parse_policy(s: &str) -> Option<AmbiguousPolicy> {
+    match s.to_ascii_lowercase().as_str() {
+        "reject" => Some(AmbiguousPolicy::Reject),
+        "earliest" => Some(AmbiguousPolicy::Earliest),
+        "latest" => Some(AmbiguousPolicy::Latest),
+        "compatible" => Some(AmbiguousPolicy::Compatible),
+        _ => None,
+    }
+}

--- a/crates/core/src/eval/functions/timezone/tests.rs
+++ b/crates/core/src/eval/functions/timezone/tests.rs
@@ -1,0 +1,134 @@
+use super::*;
+use crate::types::{ErrorKind, Value};
+
+fn num(n: f64) -> Value {
+    Value::Number(n)
+}
+fn txt(s: &str) -> Value {
+    Value::Text(s.to_string())
+}
+
+/// Build `TZDATETIME(y,m,d,h,mi,s,zone[,policy])`.
+fn dt(args: &[Value]) -> Value {
+    tzdatetime_fn(args)
+}
+
+#[test]
+fn tzdatetime_builds_berlin_summer() {
+    let v = dt(&[num(2026.0), num(7.0), num(14.0), num(11.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    match v {
+        Value::Zoned(z) => {
+            assert_eq!(z.offset_minutes(), 120);
+            assert_eq!(z.to_rfc9557(), "2026-07-14T11:00:00+02:00[Europe/Berlin]");
+        }
+        other => panic!("expected Zoned, got {other:?}"),
+    }
+}
+
+#[test]
+fn tzdatetime_gap_rejected_by_default() {
+    // 2026-03-29 02:30 Berlin is in the spring-forward gap.
+    let v = dt(&[num(2026.0), num(3.0), num(29.0), num(2.0), num(30.0), num(0.0), txt("Europe/Berlin")]);
+    assert_eq!(v, Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn tzdatetime_gap_compatible_resolves() {
+    let v = dt(&[num(2026.0), num(3.0), num(29.0), num(2.0), num(30.0), num(0.0), txt("Europe/Berlin"), txt("compatible")]);
+    match v {
+        Value::Zoned(z) => assert_eq!(z.offset_minutes(), 120),
+        other => panic!("expected Zoned, got {other:?}"),
+    }
+}
+
+#[test]
+fn tzdatetime_invalid_policy_is_value_error() {
+    let v = dt(&[num(2026.0), num(1.0), num(1.0), num(0.0), num(0.0), num(0.0), txt("UTC"), txt("nonsense")]);
+    assert_eq!(v, Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn tzdatetime_invalid_zone_is_value_error() {
+    let v = dt(&[num(2026.0), num(1.0), num(1.0), num(0.0), num(0.0), num(0.0), txt("Mars/Olympus")]);
+    assert_eq!(v, Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn tzdatetime_invalid_calendar_is_value_error() {
+    let v = dt(&[num(2026.0), num(13.0), num(1.0), num(0.0), num(0.0), num(0.0), txt("UTC")]);
+    assert_eq!(v, Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn tzconvert_preserves_instant_changes_label() {
+    let berlin = dt(&[num(2026.0), num(7.0), num(14.0), num(11.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    let tokyo = tzconvert_fn(&[berlin.clone(), txt("Asia/Tokyo")]);
+    match (&berlin, &tokyo) {
+        (Value::Zoned(b), Value::Zoned(t)) => {
+            assert_eq!(b.utc_nanos, t.utc_nanos); // same instant
+            assert_eq!(t.offset_minutes(), 540); // Tokyo +09:00, no DST
+        }
+        _ => panic!("expected two Zoned values"),
+    }
+    assert_eq!(
+        tzstring_fn(&[tokyo]),
+        Value::Text("2026-07-14T18:00:00+09:00[Asia/Tokyo]".to_string())
+    );
+}
+
+#[test]
+fn tzoffset_and_tzstring_winter() {
+    let z = dt(&[num(2026.0), num(1.0), num(14.0), num(9.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    assert_eq!(tzoffset_fn(&[z.clone()]), Value::Number(60.0)); // CET
+    assert_eq!(
+        tzstring_fn(&[z]),
+        Value::Text("2026-01-14T09:00:00+01:00[Europe/Berlin]".to_string())
+    );
+}
+
+#[test]
+fn tzserial_drops_zone_to_wallclock() {
+    let z = dt(&[num(2026.0), num(7.0), num(14.0), num(12.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    match tzserial_fn(&[z]) {
+        // Wall clock 12:00 -> fractional day 0.5.
+        Value::Date(s) => assert_eq!(s.fract(), 0.5),
+        other => panic!("expected Date, got {other:?}"),
+    }
+}
+
+#[test]
+fn tzvalid_classifies_zones() {
+    assert_eq!(tzvalid_fn(&[txt("Europe/Berlin")]), Value::Bool(true));
+    assert_eq!(tzvalid_fn(&[txt("+05:30")]), Value::Bool(true));
+    assert_eq!(tzvalid_fn(&[txt("UTC")]), Value::Bool(true));
+    assert_eq!(tzvalid_fn(&[txt("Not/AZone")]), Value::Bool(false));
+    assert_eq!(tzvalid_fn(&[num(1.0)]), Value::Bool(false));
+}
+
+#[test]
+fn iszoned_predicate() {
+    let z = dt(&[num(2026.0), num(1.0), num(1.0), num(0.0), num(0.0), num(0.0), txt("UTC")]);
+    assert_eq!(iszoned_fn(&[z]), Value::Bool(true));
+    assert_eq!(iszoned_fn(&[num(1.0)]), Value::Bool(false));
+    assert_eq!(iszoned_fn(&[txt("UTC")]), Value::Bool(false));
+}
+
+#[test]
+fn tzdbversion_returns_text() {
+    assert!(matches!(tzdbversion_fn(&[]), Value::Text(_)));
+}
+
+#[test]
+fn introspection_rejects_non_zoned() {
+    assert_eq!(tzoffset_fn(&[num(1.0)]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzstring_fn(&[txt("x")]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzserial_fn(&[num(1.0)]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzconvert_fn(&[num(1.0), txt("UTC")]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn wrong_arity_returns_na() {
+    assert_eq!(tzoffset_fn(&[]), Value::Error(ErrorKind::NA));
+    assert_eq!(tzdbversion_fn(&[num(1.0)]), Value::Error(ErrorKind::NA));
+    assert_eq!(tzdatetime_fn(&[num(2026.0)]), Value::Error(ErrorKind::NA));
+}

--- a/crates/core/tests/conformance.rs
+++ b/crates/core/tests/conformance.rs
@@ -598,6 +598,15 @@ fn every_registered_function_has_conformance_coverage() {
     .iter()
     .copied()
     .collect();
+    // Timezone functions are truecalc-only extensions with no Google Sheets
+    // equivalent, so they cannot have Sheets conformance rows. Their correctness
+    // is covered by unit tests against IANA ground truth instead.
+    let truecalc_only: std::collections::HashSet<String> = registry
+        .get_metadata()
+        .iter()
+        .filter(|e| e.meta.category == "timezone")
+        .map(|e| e.name.to_uppercase())
+        .collect();
 
     let gdir = fixture_dir();
     let vars: HashMap<String, Value> = HashMap::new();
@@ -682,6 +691,7 @@ fn every_registered_function_has_conformance_coverage() {
         let upper = name.to_uppercase();
         if volatile.contains(upper.as_str())
             || context_limited.contains(upper.as_str())
+            || truecalc_only.contains(&upper)
             || covered.contains(&upper)
             || acknowledged.contains(&upper)
         {

--- a/functions.json
+++ b/functions.json
@@ -3712,6 +3712,13 @@
     "examples": []
   },
   {
+    "name": "ISZONED",
+    "category": "timezone",
+    "syntax": "ISZONED(value)",
+    "description": "TRUE if the value is a zone-aware instant",
+    "examples": []
+  },
+  {
     "name": "JOIN",
     "category": "text",
     "syntax": "JOIN(delimiter, value1, ...)",
@@ -6763,6 +6770,55 @@
         "result": "4"
       }
     ]
+  },
+  {
+    "name": "TZCONVERT",
+    "category": "timezone",
+    "syntax": "TZCONVERT(zoned,target_zone)",
+    "description": "Same instant shown as the local time in another zone",
+    "examples": []
+  },
+  {
+    "name": "TZDATETIME",
+    "category": "timezone",
+    "syntax": "TZDATETIME(year,month,day,hour,minute,second,zone,[policy])",
+    "description": "Builds a zone-aware instant from a wall-clock time in a zone",
+    "examples": []
+  },
+  {
+    "name": "TZDBVERSION",
+    "category": "timezone",
+    "syntax": "TZDBVERSION()",
+    "description": "IANA time-zone database version the engine is using",
+    "examples": []
+  },
+  {
+    "name": "TZOFFSET",
+    "category": "timezone",
+    "syntax": "TZOFFSET(zoned)",
+    "description": "Offset from UTC in minutes at this instant (DST-resolved)",
+    "examples": []
+  },
+  {
+    "name": "TZSERIAL",
+    "category": "timezone",
+    "syntax": "TZSERIAL(zoned)",
+    "description": "Drops the zone, returning the wall-clock time as a plain date serial",
+    "examples": []
+  },
+  {
+    "name": "TZSTRING",
+    "category": "timezone",
+    "syntax": "TZSTRING(zoned)",
+    "description": "Canonical RFC-9557 string for a zone-aware instant",
+    "examples": []
+  },
+  {
+    "name": "TZVALID",
+    "category": "timezone",
+    "syntax": "TZVALID(zone)",
+    "description": "TRUE if the text is a valid IANA zone name or fixed offset",
+    "examples": []
   },
   {
     "name": "UNICHAR",


### PR DESCRIPTION
## Phase 3 (part 1) of #666 — first slice of the `TZ*` function set

Built on `Value::Zoned`. Eight functions covering construction, conversion, introspection and display:

| Function | Purpose |
|---|---|
| `TZDATETIME(y,m,d,h,mi,s,zone,[policy])` | Build a zoned instant from a wall-clock time. DST gap/fold default = **reject**; opt into `earliest`/`latest`/`compatible`. |
| `TZCONVERT(zoned, target_zone)` | Same instant, relabelled to another zone (DST-correct). |
| `TZSERIAL(zoned)` | Drop the zone → plain wall-clock date serial. |
| `TZOFFSET(zoned)` | UTC offset in minutes (DST-resolved). |
| `TZSTRING(zoned)` | Canonical RFC-9557 string. |
| `TZVALID(zone)` | Is the text a valid IANA zone / fixed offset? |
| `ISZONED(value)` | Type predicate for zoned instants. |
| `TZDBVERSION()` | IANA tzdb version in use (the conformance pin). |

### Notes
- New `eval/functions/timezone` module + `register_timezone`. Tests are grounded in IANA facts (Berlin CEST/CET, the 2026 EU spring-forward gap, Tokyo conversion), not self-confirmed.
- **Conformance gate:** timezone functions are truecalc-only extensions with no Google Sheets equivalent, so the per-function Sheets-conformance gate excludes the `timezone` category — their correctness lives in unit tests against IANA ground truth. (Documented inline in the test.)
- `functions.json` regenerated (497 functions). Verified the functions are exported via the MCP `list_functions` tool.

### Verification
- `cargo test -p truecalc-core` → **3097 passed**
- `cargo clippy --workspace -- -D warnings` → clean
- MCP `list_functions` lists all 8

### Still to come in Phase 3 (follow-up PRs)
`TZNOW` (deterministic clock), `TZLOCALIZE`, `TZFROMEPOCH`, `TZPARSE`, `TZADD`, `TZDIFF`, `TZPART`, `TZISDST`, `TZABBR`, `TZCANONICAL`, `TZOFFSETDIFF`, `TZINWINDOW`.

Part of #668