### PR TITLE
feat: timezone construction, introspection & extraction functions

### DIFF
--- a/crates/core/src/eval/functions/timezone/mod.rs
+++ b/crates/core/src/eval/functions/timezone/mod.rs
@@ -2,12 +2,14 @@
 //! display [`Value::Zoned`] instants. The naive<->zoned boundary is always an
 //! explicit call here: `TZDATETIME`/`TZLOCALIZE` up, `TZSERIAL` down.
 
-use chrono::{NaiveDate, Timelike};
+use chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike};
 
 use crate::eval::coercion::to_number;
-use crate::eval::functions::date::serial::{date_to_serial, time_to_serial};
+use crate::eval::functions::date::serial::{
+    date_to_serial, serial_to_date, serial_to_time, time_to_serial,
+};
 use crate::eval::functions::{check_arity, FunctionMeta, Registry};
-use crate::types::zoned::{parse_zone, AmbiguousPolicy};
+use crate::types::zoned::{parse_rfc9557, parse_zone, AmbiguousPolicy};
 use crate::types::{ErrorKind, Value, ZoneId, ZonedInstant};
 
 #[cfg(test)]
@@ -22,6 +24,13 @@ pub fn register_timezone(registry: &mut Registry) {
     registry.register_eager("TZSERIAL", tzserial_fn, FunctionMeta { category: "timezone", signature: "TZSERIAL(zoned)", description: "Drops the zone, returning the wall-clock time as a plain date serial" });
     registry.register_eager("TZOFFSET", tzoffset_fn, FunctionMeta { category: "timezone", signature: "TZOFFSET(zoned)", description: "Offset from UTC in minutes at this instant (DST-resolved)" });
     registry.register_eager("TZSTRING", tzstring_fn, FunctionMeta { category: "timezone", signature: "TZSTRING(zoned)", description: "Canonical RFC-9557 string for a zone-aware instant" });
+    registry.register_eager("TZLOCALIZE", tzlocalize_fn, FunctionMeta { category: "timezone", signature: "TZLOCALIZE(date_serial,zone,[policy])", description: "Interprets a plain date/time serial as a wall-clock reading in a zone" });
+    registry.register_eager("TZFROMEPOCH", tzfromepoch_fn, FunctionMeta { category: "timezone", signature: "TZFROMEPOCH(unix_seconds,zone)", description: "Builds a zone-aware instant from a Unix timestamp" });
+    registry.register_eager("TZPARSE", tzparse_fn, FunctionMeta { category: "timezone", signature: "TZPARSE(text,[zone])", description: "Parses an ISO/RFC-9557 timestamp into a zone-aware instant" });
+    registry.register_eager("TZISDST", tzisdst_fn, FunctionMeta { category: "timezone", signature: "TZISDST(zoned)", description: "TRUE if daylight-saving is in effect at this instant" });
+    registry.register_eager("TZABBR", tzabbr_fn, FunctionMeta { category: "timezone", signature: "TZABBR(zoned)", description: "Zone abbreviation at this instant (e.g. CEST), display only" });
+    registry.register_eager("TZOFFSETDIFF", tzoffsetdiff_fn, FunctionMeta { category: "timezone", signature: "TZOFFSETDIFF(zoned_a,zoned_b)", description: "Signed difference in minutes between two zones' offsets" });
+    registry.register_eager("TZPART", tzpart_fn, FunctionMeta { category: "timezone", signature: "TZPART(zoned,unit)", description: "Local wall-clock field: year|month|day|hour|minute|second|weekday" });
 }
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
@@ -89,16 +98,9 @@ pub fn tzdatetime_fn(args: &[Value]) -> Value {
         Ok(z) => z,
         Err(e) => return e,
     };
-    let policy = if args.len() == 8 {
-        match &args[7] {
-            Value::Text(s) => match parse_policy(s) {
-                Some(p) => p,
-                None => return Value::Error(ErrorKind::Value),
-            },
-            _ => return Value::Error(ErrorKind::Value),
-        }
-    } else {
-        AmbiguousPolicy::Reject
+    let policy = match optional_policy(args.get(7)) {
+        Ok(p) => p,
+        Err(e) => return e,
     };
 
     let (year, month, day, hour, minute, second) =
@@ -172,6 +174,174 @@ pub fn tzstring_fn(args: &[Value]) -> Value {
         Ok(zi) => Value::Text(zi.to_rfc9557()),
         Err(e) => e,
     }
+}
+
+pub fn tzlocalize_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 2, 3) {
+        return e;
+    }
+    let serial = match to_number(args[0].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let zone = match arg_zone(&args[1]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let policy = match optional_policy(args.get(2)) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let naive = match serial_to_naive(serial) {
+        Some(n) => n,
+        None => return Value::Error(ErrorKind::Value),
+    };
+    match ZonedInstant::from_local(zone, naive, policy) {
+        Some(zi) => zoned(zi),
+        None => Value::Error(ErrorKind::Value),
+    }
+}
+
+pub fn tzfromepoch_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 2, 2) {
+        return e;
+    }
+    let secs = match to_number(args[0].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let zone = match arg_zone(&args[1]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let nanos = (secs.trunc() as i64)
+        .checked_mul(1_000_000_000)
+        .and_then(|whole| whole.checked_add((secs.fract() * 1e9).round() as i64));
+    match nanos {
+        Some(n) => zoned(ZonedInstant::from_instant(n, zone)),
+        None => Value::Error(ErrorKind::Num),
+    }
+}
+
+pub fn tzparse_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 1, 2) {
+        return e;
+    }
+    let text = match &args[0] {
+        Value::Text(s) => s.as_str(),
+        _ => return Value::Error(ErrorKind::Value),
+    };
+    // Offset-bearing or bracketed strings are self-describing.
+    if let Some(zi) = parse_rfc9557(text) {
+        return zoned(zi);
+    }
+    // A naive datetime needs an explicit zone to become an instant.
+    if args.len() == 2 {
+        let zone = match arg_zone(&args[1]) {
+            Ok(z) => z,
+            Err(e) => return e,
+        };
+        if let Some(naive) = parse_naive_datetime(text) {
+            return match ZonedInstant::from_local(zone, naive, AmbiguousPolicy::Reject) {
+                Some(zi) => zoned(zi),
+                None => Value::Error(ErrorKind::Value),
+            };
+        }
+    }
+    Value::Error(ErrorKind::Value)
+}
+
+pub fn tzisdst_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 1, 1) {
+        return e;
+    }
+    match arg_zoned(&args[0]) {
+        Ok(zi) => Value::Bool(zi.is_dst()),
+        Err(e) => e,
+    }
+}
+
+pub fn tzabbr_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 1, 1) {
+        return e;
+    }
+    match arg_zoned(&args[0]) {
+        Ok(zi) => Value::Text(zi.abbrev()),
+        Err(e) => e,
+    }
+}
+
+pub fn tzoffsetdiff_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 2, 2) {
+        return e;
+    }
+    let a = match arg_zoned(&args[0]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let b = match arg_zoned(&args[1]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    Value::Number((a.offset_minutes() - b.offset_minutes()) as f64)
+}
+
+pub fn tzpart_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 2, 2) {
+        return e;
+    }
+    let zi = match arg_zoned(&args[0]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let unit = match &args[1] {
+        Value::Text(s) => s.to_ascii_lowercase(),
+        _ => return Value::Error(ErrorKind::Value),
+    };
+    let local = zi.local();
+    let value = match unit.as_str() {
+        "year" => local.year() as f64,
+        "month" => local.month() as f64,
+        "day" => local.day() as f64,
+        "hour" => local.hour() as f64,
+        "minute" => local.minute() as f64,
+        "second" => local.second() as f64,
+        // Sheets WEEKDAY default: Sunday = 1 .. Saturday = 7.
+        "weekday" => (local.weekday().num_days_from_sunday() + 1) as f64,
+        _ => return Value::Error(ErrorKind::Value),
+    };
+    Value::Number(value)
+}
+
+/// Resolve the optional ambiguous-policy argument shared by the construction
+/// functions. Absent ⇒ [`AmbiguousPolicy::Reject`]; non-text or unknown ⇒ `#VALUE!`.
+fn optional_policy(arg: Option<&Value>) -> Result<AmbiguousPolicy, Value> {
+    match arg {
+        None => Ok(AmbiguousPolicy::Reject),
+        Some(Value::Text(s)) => parse_policy(s).ok_or(Value::Error(ErrorKind::Value)),
+        Some(_) => Err(Value::Error(ErrorKind::Value)),
+    }
+}
+
+/// Compose a date serial into a `NaiveDateTime` (integer part = date, fractional
+/// part = time of day).
+fn serial_to_naive(serial: f64) -> Option<NaiveDateTime> {
+    let date = serial_to_date(serial)?;
+    let (h, m, s) = serial_to_time(serial);
+    date.and_hms_opt(h, m, s)
+}
+
+/// Parse a zone-less ISO-ish datetime (or bare date) into a `NaiveDateTime`.
+fn parse_naive_datetime(s: &str) -> Option<NaiveDateTime> {
+    let s = s.trim();
+    for fmt in ["%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M"] {
+        if let Ok(dt) = NaiveDateTime::parse_from_str(s, fmt) {
+            return Some(dt);
+        }
+    }
+    NaiveDate::parse_from_str(s, "%Y-%m-%d")
+        .ok()
+        .and_then(|d| d.and_hms_opt(0, 0, 0))
 }
 
 fn parse_policy(s: &str) -> Option<AmbiguousPolicy> {

--- a/crates/core/src/eval/functions/timezone/tests.rs
+++ b/crates/core/src/eval/functions/timezone/tests.rs
@@ -132,3 +132,96 @@ fn wrong_arity_returns_na() {
     assert_eq!(tzdbversion_fn(&[num(1.0)]), Value::Error(ErrorKind::NA));
     assert_eq!(tzdatetime_fn(&[num(2026.0)]), Value::Error(ErrorKind::NA));
 }
+
+// ── Batch 2: alt construction, introspection, extraction ──────────────────────
+
+#[test]
+fn tzlocalize_round_trips_with_tzserial() {
+    let z = dt(&[num(2026.0), num(7.0), num(14.0), num(11.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    let serial = match tzserial_fn(&[z.clone()]) {
+        Value::Date(s) => s,
+        other => panic!("expected Date, got {other:?}"),
+    };
+    let z2 = tzlocalize_fn(&[Value::Date(serial), txt("Europe/Berlin")]);
+    match (&z, &z2) {
+        (Value::Zoned(a), Value::Zoned(b)) => assert_eq!(a.utc_nanos, b.utc_nanos),
+        _ => panic!("expected two Zoned values"),
+    }
+}
+
+#[test]
+fn tzlocalize_invalid_zone_is_value_error() {
+    assert_eq!(tzlocalize_fn(&[num(46000.0), txt("Mars/Olympus")]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn tzfromepoch_unix_zero_in_new_york() {
+    // Unix 0 = 1970-01-01T00:00:00Z = 1969-12-31 19:00 EST.
+    let z = tzfromepoch_fn(&[num(0.0), txt("America/New_York")]);
+    assert_eq!(tzoffset_fn(&[z.clone()]), Value::Number(-300.0));
+    assert_eq!(
+        tzstring_fn(&[z]),
+        Value::Text("1969-12-31T19:00:00-05:00[America/New_York]".to_string())
+    );
+}
+
+#[test]
+fn tzparse_handles_rfc9557_naive_and_offset_only() {
+    // Bracketed RFC-9557.
+    assert_eq!(
+        tzoffset_fn(&[tzparse_fn(&[txt("2026-07-14T11:00:00+02:00[Europe/Berlin]")])]),
+        Value::Number(120.0)
+    );
+    // Naive datetime + explicit zone.
+    assert_eq!(
+        tzstring_fn(&[tzparse_fn(&[txt("2026-07-14 11:00:00"), txt("Europe/Berlin")])]),
+        Value::Text("2026-07-14T11:00:00+02:00[Europe/Berlin]".to_string())
+    );
+    // Offset-only -> fixed zone.
+    assert_eq!(
+        tzoffset_fn(&[tzparse_fn(&[txt("2026-01-01T12:00:00+05:30")])]),
+        Value::Number(330.0)
+    );
+    // Naive without a zone, and garbage, are errors.
+    assert_eq!(tzparse_fn(&[txt("2026-07-14 11:00:00")]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzparse_fn(&[txt("garbage")]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn tzisdst_and_tzabbr_track_dst() {
+    let summer = dt(&[num(2026.0), num(7.0), num(14.0), num(11.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    let winter = dt(&[num(2026.0), num(1.0), num(14.0), num(9.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    assert_eq!(tzisdst_fn(&[summer.clone()]), Value::Bool(true));
+    assert_eq!(tzisdst_fn(&[winter.clone()]), Value::Bool(false));
+    assert_eq!(tzabbr_fn(&[summer]), Value::Text("CEST".to_string()));
+    assert_eq!(tzabbr_fn(&[winter]), Value::Text("CET".to_string()));
+}
+
+#[test]
+fn tzoffsetdiff_between_zones() {
+    let berlin = dt(&[num(2026.0), num(7.0), num(14.0), num(11.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    let tokyo = tzconvert_fn(&[berlin.clone(), txt("Asia/Tokyo")]);
+    // Tokyo +540, Berlin +120 -> +420.
+    assert_eq!(tzoffsetdiff_fn(&[tokyo, berlin]), Value::Number(420.0));
+}
+
+#[test]
+fn tzpart_extracts_local_fields() {
+    let z = dt(&[num(2026.0), num(7.0), num(14.0), num(11.0), num(30.0), num(45.0), txt("Europe/Berlin")]);
+    assert_eq!(tzpart_fn(&[z.clone(), txt("year")]), Value::Number(2026.0));
+    assert_eq!(tzpart_fn(&[z.clone(), txt("month")]), Value::Number(7.0));
+    assert_eq!(tzpart_fn(&[z.clone(), txt("hour")]), Value::Number(11.0));
+    assert_eq!(tzpart_fn(&[z.clone(), txt("minute")]), Value::Number(30.0));
+    assert_eq!(tzpart_fn(&[z.clone(), txt("second")]), Value::Number(45.0));
+    // 2026-07-14 is a Tuesday -> Sunday=1 convention gives 3.
+    assert_eq!(tzpart_fn(&[z.clone(), txt("weekday")]), Value::Number(3.0));
+    assert_eq!(tzpart_fn(&[z, txt("bogus")]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn batch2_rejects_non_zoned() {
+    assert_eq!(tzisdst_fn(&[num(1.0)]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzabbr_fn(&[num(1.0)]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzpart_fn(&[num(1.0), txt("year")]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzoffsetdiff_fn(&[num(1.0), num(2.0)]), Value::Error(ErrorKind::Value));
+}

--- a/functions.json
+++ b/functions.json
@@ -6772,6 +6772,13 @@
     ]
   },
   {
+    "name": "TZABBR",
+    "category": "timezone",
+    "syntax": "TZABBR(zoned)",
+    "description": "Zone abbreviation at this instant (e.g. CEST), display only",
+    "examples": []
+  },
+  {
     "name": "TZCONVERT",
     "category": "timezone",
     "syntax": "TZCONVERT(zoned,target_zone)",
@@ -6793,10 +6800,52 @@
     "examples": []
   },
   {
+    "name": "TZFROMEPOCH",
+    "category": "timezone",
+    "syntax": "TZFROMEPOCH(unix_seconds,zone)",
+    "description": "Builds a zone-aware instant from a Unix timestamp",
+    "examples": []
+  },
+  {
+    "name": "TZISDST",
+    "category": "timezone",
+    "syntax": "TZISDST(zoned)",
+    "description": "TRUE if daylight-saving is in effect at this instant",
+    "examples": []
+  },
+  {
+    "name": "TZLOCALIZE",
+    "category": "timezone",
+    "syntax": "TZLOCALIZE(date_serial,zone,[policy])",
+    "description": "Interprets a plain date/time serial as a wall-clock reading in a zone",
+    "examples": []
+  },
+  {
     "name": "TZOFFSET",
     "category": "timezone",
     "syntax": "TZOFFSET(zoned)",
     "description": "Offset from UTC in minutes at this instant (DST-resolved)",
+    "examples": []
+  },
+  {
+    "name": "TZOFFSETDIFF",
+    "category": "timezone",
+    "syntax": "TZOFFSETDIFF(zoned_a,zoned_b)",
+    "description": "Signed difference in minutes between two zones' offsets",
+    "examples": []
+  },
+  {
+    "name": "TZPARSE",
+    "category": "timezone",
+    "syntax": "TZPARSE(text,[zone])",
+    "description": "Parses an ISO/RFC-9557 timestamp into a zone-aware instant",
+    "examples": []
+  },
+  {
+    "name": "TZPART",
+    "category": "timezone",
+    "syntax": "TZPART(zoned,unit)",
+    "description": "Local wall-clock field: year|month|day|hour|minute|second|weekday",
     "examples": []
   },
   {


### PR DESCRIPTION
## Phase 3 (part 2) of #666 — more `TZ*` functions on `Value::Zoned`

| Function | Purpose |
|---|---|
| `TZLOCALIZE(date_serial, zone, [policy])` | Interpret a plain date/time serial as a wall-clock reading in a zone (shared DST gap/fold policy, default reject). |
| `TZFROMEPOCH(unix_seconds, zone)` | Build an instant from a Unix timestamp. |
| `TZPARSE(text, [zone])` | Parse RFC-9557/RFC-3339 (offset or `[Zone]`), or a naive datetime + explicit zone. |
| `TZISDST(zoned)` | Is DST in effect at this instant? |
| `TZABBR(zoned)` | Zone abbreviation (e.g. `CEST`) — display only. |
| `TZOFFSETDIFF(a, b)` | Signed minutes between two zones' offsets. |
| `TZPART(zoned, unit)` | Local field: `year`/`month`/`day`/`hour`/`minute`/`second`/`weekday`. |

### Notes
- Adds a shared `optional_policy` helper (also adopted by `TZDATETIME`, refactored).
- Tests grounded in IANA facts: Berlin CEST/CET, New York EST at the Unix epoch (`TZFROMEPOCH(0,"America/New_York")` → `1969-12-31T19:00:00-05:00`), Tokyo↔Berlin offset diff, `TZPARSE` round-trips.
- `functions.json` regenerated (504 functions). Timezone category remains excluded from the Sheets-conformance gate (truecalc-only; unit-tested against IANA).

### Verification
- `cargo test -p truecalc-core` → **3105 passed**
- `cargo clippy --workspace -- -D warnings` → clean

### Remaining in Phase 3 (follow-up)
`TZNOW` (needs a deterministic-clock decision), `TZADD`/`TZDIFF` (arithmetic), `TZINWINDOW`, `TZCANONICAL`.

Part of #668