### PR TITLE
feat: timezone arithmetic (TZDIFF, TZADD)

### DIFF
--- a/crates/core/src/eval/functions/timezone/mod.rs
+++ b/crates/core/src/eval/functions/timezone/mod.rs
@@ -2,7 +2,7 @@
 //! display [`Value::Zoned`] instants. The naive<->zoned boundary is always an
 //! explicit call here: `TZDATETIME`/`TZLOCALIZE` up, `TZSERIAL` down.
 
-use chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike};
+use chrono::{Datelike, Duration, Months, NaiveDate, NaiveDateTime, Timelike};
 
 use crate::eval::coercion::to_number;
 use crate::eval::functions::date::serial::{
@@ -31,6 +31,8 @@ pub fn register_timezone(registry: &mut Registry) {
     registry.register_eager("TZABBR", tzabbr_fn, FunctionMeta { category: "timezone", signature: "TZABBR(zoned)", description: "Zone abbreviation at this instant (e.g. CEST), display only" });
     registry.register_eager("TZOFFSETDIFF", tzoffsetdiff_fn, FunctionMeta { category: "timezone", signature: "TZOFFSETDIFF(zoned_a,zoned_b)", description: "Signed difference in minutes between two zones' offsets" });
     registry.register_eager("TZPART", tzpart_fn, FunctionMeta { category: "timezone", signature: "TZPART(zoned,unit)", description: "Local wall-clock field: year|month|day|hour|minute|second|weekday" });
+    registry.register_eager("TZDIFF", tzdiff_fn, FunctionMeta { category: "timezone", signature: "TZDIFF(zoned_a,zoned_b,[unit])", description: "Elapsed time from b to a on the absolute timeline (DST-immune)" });
+    registry.register_eager("TZADD", tzadd_fn, FunctionMeta { category: "timezone", signature: "TZADD(zoned,amount,unit,[policy])", description: "Adds time: seconds/minutes/hours are absolute, days/weeks/months/years are DST-aware calendar units" });
 }
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
@@ -311,6 +313,103 @@ pub fn tzpart_fn(args: &[Value]) -> Value {
         _ => return Value::Error(ErrorKind::Value),
     };
     Value::Number(value)
+}
+
+pub fn tzdiff_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 2, 3) {
+        return e;
+    }
+    let a = match arg_zoned(&args[0]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let b = match arg_zoned(&args[1]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let unit = match args.get(2) {
+        None => "seconds".to_string(),
+        Some(Value::Text(s)) => s.to_ascii_lowercase(),
+        Some(_) => return Value::Error(ErrorKind::Value),
+    };
+    // i128 avoids overflow on the difference of two i64 nanosecond counts.
+    let diff_ns = a.utc_nanos as i128 - b.utc_nanos as i128;
+    let value = match unit.as_str() {
+        "nanoseconds" => diff_ns as f64,
+        "seconds" => diff_ns as f64 / 1e9,
+        "minutes" => diff_ns as f64 / 6e10,
+        "hours" => diff_ns as f64 / 3.6e12,
+        // Absolute days = 86400 s; calendar-day length is a TZADD concern.
+        "days" => diff_ns as f64 / 8.64e13,
+        _ => return Value::Error(ErrorKind::Value),
+    };
+    Value::Number(value)
+}
+
+pub fn tzadd_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 3, 4) {
+        return e;
+    }
+    let zi = match arg_zoned(&args[0]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let amount = match to_number(args[1].clone()) {
+        Ok(n) => n.trunc() as i64,
+        Err(e) => return e,
+    };
+    let unit = match &args[2] {
+        Value::Text(s) => s.to_ascii_lowercase(),
+        _ => return Value::Error(ErrorKind::Value),
+    };
+    let policy = match optional_policy(args.get(3)) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+
+    match unit.as_str() {
+        // Absolute units shift the instant directly (DST-immune).
+        "seconds" | "minutes" | "hours" => {
+            let factor: i64 = match unit.as_str() {
+                "minutes" => 60,
+                "hours" => 3600,
+                _ => 1,
+            };
+            let nanos = amount
+                .checked_mul(factor)
+                .and_then(|s| s.checked_mul(1_000_000_000))
+                .and_then(|d| zi.utc_nanos.checked_add(d));
+            match nanos {
+                Some(n) => zoned(ZonedInstant::from_instant(n, zi.zone.clone())),
+                None => Value::Error(ErrorKind::Num),
+            }
+        }
+        // Calendar units shift the wall clock then re-resolve (DST-aware): a
+        // calendar day may be 23 or 25 hours across a transition.
+        "days" | "weeks" | "months" | "years" => {
+            let local = zi.local();
+            let new_local = match unit.as_str() {
+                "days" => local.checked_add_signed(Duration::days(amount)),
+                "weeks" => local.checked_add_signed(Duration::weeks(amount)),
+                "months" => add_months(local, amount),
+                _ => amount.checked_mul(12).and_then(|m| add_months(local, m)), // years
+            };
+            match new_local.and_then(|nl| ZonedInstant::from_local(zi.zone.clone(), nl, policy)) {
+                Some(z) => zoned(z),
+                None => Value::Error(ErrorKind::Value),
+            }
+        }
+        _ => Value::Error(ErrorKind::Value),
+    }
+}
+
+/// Add (or subtract, when negative) a whole number of calendar months.
+fn add_months(dt: NaiveDateTime, months: i64) -> Option<NaiveDateTime> {
+    if months >= 0 {
+        u32::try_from(months).ok().and_then(|m| dt.checked_add_months(Months::new(m)))
+    } else {
+        u32::try_from(-months).ok().and_then(|m| dt.checked_sub_months(Months::new(m)))
+    }
 }
 
 /// Resolve the optional ambiguous-policy argument shared by the construction

--- a/crates/core/src/eval/functions/timezone/tests.rs
+++ b/crates/core/src/eval/functions/timezone/tests.rs
@@ -225,3 +225,78 @@ fn batch2_rejects_non_zoned() {
     assert_eq!(tzpart_fn(&[num(1.0), txt("year")]), Value::Error(ErrorKind::Value));
     assert_eq!(tzoffsetdiff_fn(&[num(1.0), num(2.0)]), Value::Error(ErrorKind::Value));
 }
+
+// ── Batch 3: arithmetic (TZDIFF / TZADD) ──────────────────────────────────────
+
+fn utc_dt(y: f64, mo: f64, d: f64, h: f64, mi: f64) -> Value {
+    dt(&[num(y), num(mo), num(d), num(h), num(mi), num(0.0), txt("UTC")])
+}
+
+#[test]
+fn tzdiff_units_and_sign() {
+    let a = utc_dt(2026.0, 1.0, 15.0, 15.0, 0.0);
+    let b = utc_dt(2026.0, 1.0, 15.0, 12.0, 0.0);
+    assert_eq!(tzdiff_fn(&[a.clone(), b.clone()]), Value::Number(10_800.0)); // default seconds
+    assert_eq!(tzdiff_fn(&[a.clone(), b.clone(), txt("hours")]), Value::Number(3.0));
+    assert_eq!(tzdiff_fn(&[a.clone(), b.clone(), txt("minutes")]), Value::Number(180.0));
+    assert_eq!(tzdiff_fn(&[b, a, txt("hours")]), Value::Number(-3.0)); // sign flips
+}
+
+#[test]
+fn tzadd_absolute_hours_is_dst_immune() {
+    let z = utc_dt(2026.0, 1.0, 15.0, 12.0, 0.0);
+    let r = tzadd_fn(&[z, num(3.0), txt("hours")]);
+    assert_eq!(tzpart_fn(&[r.clone(), txt("hour")]), Value::Number(15.0));
+    assert!(matches!(r, Value::Zoned(_)));
+}
+
+#[test]
+fn tzadd_calendar_day_keeps_wallclock_across_dst() {
+    // 2026-03-29 is the Berlin spring-forward day (the 02:00->03:00 jump).
+    let start = dt(&[num(2026.0), num(3.0), num(28.0), num(12.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    let next = tzadd_fn(&[start.clone(), num(1.0), txt("days")]);
+    // Calendar add keeps the wall clock at 12:00 the next day...
+    assert_eq!(tzpart_fn(&[next.clone(), txt("hour")]), Value::Number(12.0));
+    assert_eq!(tzpart_fn(&[next.clone(), txt("day")]), Value::Number(29.0));
+    // ...but that calendar day was only 23 hours long on the absolute timeline.
+    assert_eq!(tzdiff_fn(&[next, start, txt("hours")]), Value::Number(23.0));
+}
+
+#[test]
+fn tzadd_absolute_24h_lands_one_hour_ahead_across_spring_forward() {
+    let start = dt(&[num(2026.0), num(3.0), num(28.0), num(12.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    let later = tzadd_fn(&[start, num(24.0), txt("hours")]);
+    // +24h absolute over a 23h day -> wall clock is 13:00, not 12:00.
+    assert_eq!(tzpart_fn(&[later, txt("hour")]), Value::Number(13.0));
+}
+
+#[test]
+fn tzadd_months_and_years() {
+    let z = utc_dt(2026.0, 1.0, 15.0, 12.0, 0.0);
+    let m = tzadd_fn(&[z.clone(), num(1.0), txt("months")]);
+    assert_eq!(tzpart_fn(&[m.clone(), txt("month")]), Value::Number(2.0));
+    assert_eq!(tzpart_fn(&[m, txt("day")]), Value::Number(15.0));
+    let y = tzadd_fn(&[z.clone(), num(2.0), txt("years")]);
+    assert_eq!(tzpart_fn(&[y, txt("year")]), Value::Number(2028.0));
+    // Negative amounts subtract.
+    let back = tzadd_fn(&[z, num(-1.0), txt("days")]);
+    assert_eq!(tzpart_fn(&[back, txt("day")]), Value::Number(14.0));
+}
+
+#[test]
+fn tzadd_month_end_clamps() {
+    // Jan 31 + 1 month clamps to Feb 28 (2026 is not a leap year).
+    let z = utc_dt(2026.0, 1.0, 31.0, 9.0, 0.0);
+    let m = tzadd_fn(&[z, num(1.0), txt("months")]);
+    assert_eq!(tzpart_fn(&[m.clone(), txt("month")]), Value::Number(2.0));
+    assert_eq!(tzpart_fn(&[m, txt("day")]), Value::Number(28.0));
+}
+
+#[test]
+fn arithmetic_error_cases() {
+    let z = utc_dt(2026.0, 1.0, 15.0, 12.0, 0.0);
+    assert_eq!(tzadd_fn(&[z.clone(), num(1.0), txt("fortnights")]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzadd_fn(&[num(1.0), num(1.0), txt("days")]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzdiff_fn(&[z, num(1.0)]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzdiff_fn(&[num(1.0), num(2.0)]), Value::Error(ErrorKind::Value));
+}

--- a/functions.json
+++ b/functions.json
@@ -6779,6 +6779,13 @@
     "examples": []
   },
   {
+    "name": "TZADD",
+    "category": "timezone",
+    "syntax": "TZADD(zoned,amount,unit,[policy])",
+    "description": "Adds time: seconds/minutes/hours are absolute, days/weeks/months/years are DST-aware calendar units",
+    "examples": []
+  },
+  {
     "name": "TZCONVERT",
     "category": "timezone",
     "syntax": "TZCONVERT(zoned,target_zone)",
@@ -6797,6 +6804,13 @@
     "category": "timezone",
     "syntax": "TZDBVERSION()",
     "description": "IANA time-zone database version the engine is using",
+    "examples": []
+  },
+  {
+    "name": "TZDIFF",
+    "category": "timezone",
+    "syntax": "TZDIFF(zoned_a,zoned_b,[unit])",
+    "description": "Elapsed time from b to a on the absolute timeline (DST-immune)",
     "examples": []
   },
   {


### PR DESCRIPTION
## Phase 3 (part 3) of #666 — timezone arithmetic on `Value::Zoned`

| Function | Purpose |
|---|---|
| `TZDIFF(a, b, [unit])` | Elapsed time from `b` to `a` on the absolute timeline (DST-immune). Units: `nanoseconds`/`seconds` (default)/`minutes`/`hours`/`days`. |
| `TZADD(zoned, amount, unit, [policy])` | `seconds`/`minutes`/`hours` are **absolute** (shift the instant); `days`/`weeks`/`months`/`years` are **DST-aware calendar** units (shift the wall clock, then re-resolve). |

### The calendar-vs-absolute distinction (the core design point)
Across the Berlin spring-forward (2026-03-29, clocks jump 02:00→03:00):
- `TZADD(2026-03-28 12:00 Berlin, 1, "days")` → wall clock stays **12:00** the next day, but that calendar day spans only **23 h** on the absolute timeline.
- `TZADD(2026-03-28 12:00 Berlin, 24, "hours")` → absolute, lands at **13:00** local.

Month-end clamps (`Jan 31 + 1 month` → `Feb 28`). Negative amounts subtract. Calendar re-resolution uses the shared gap/fold policy (default reject).

### Verification
- `cargo test -p truecalc-core` → **3112 passed**
- `cargo clippy --workspace -- -D warnings` → clean
- `functions.json` regenerated (506 functions)

### Phase 3 remaining (follow-up)
- `TZNOW` — needs a deterministic-clock decision (engine pins a tz-naive local serial, not a UTC instant).
- `TZINWINDOW` — business-hours predicate (argument semantics to settle).
- `TZCANONICAL` — IANA link resolution (chrono-tz keeps links as distinct names; needs an alias strategy).

Part of #668