### PR TITLE
chore: improve package discoverability — metadata + README value layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ WebAssembly-powered spreadsheet formula engine for JavaScript/TypeScript.
 
 [DeepWiki](https://deepwiki.com/truecalc/core)
 
+484 spreadsheet functions. Runs in Node.js, Bun, Deno, and the browser — no server needed. Ground-truth conformance against real Google Sheets. The same engine is also available as a [Rust crate](https://crates.io/crates/truecalc-core) and as an [MCP server](https://crates.io/crates/truecalc-mcp) for AI assistants.
+
+```js
+const { evaluate } = require('@truecalc/core');
+evaluate('SUM(A1, B1)', { A1: 100, B1: 200 })
+// => { type: 'number', value: 300 }
+```
+
 ## Install
 
 ```sh
@@ -109,3 +117,7 @@ Returns metadata for all built-in functions.
 ```js
 const fns = list_functions();
 ```
+
+## Documentation
+
+[docs.truecalc.app](https://docs.truecalc.app)

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -3,9 +3,11 @@ name = "truecalc-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Spreadsheet formula engine — parser and evaluator for Excel-compatible formulas"
+description = "Spreadsheet formula engine — parser and evaluator for Google Sheets–compatible formulas"
 repository.workspace = true
 readme = "README.md"
+keywords = ["spreadsheet", "formula", "google-sheets", "excel", "evaluator"]
+categories = ["parser-implementations", "mathematics", "science"]
 
 [features]
 # serde off by default: keeps the default core build serde-free. Enables

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -4,9 +4,14 @@
 [![docs.rs](https://img.shields.io/docsrs/truecalc-core)](https://docs.rs/truecalc-core)
 [![license](https://img.shields.io/crates/l/truecalc-core)](LICENSE)
 
-Spreadsheet formula engine — parser and evaluator for Excel-compatible formulas with Google Sheets conformance.
+Spreadsheet formula engine — parser and evaluator with Google Sheets conformance.
 
-Also available as a WebAssembly npm package: [`@truecalc/core`](https://www.npmjs.com/package/@truecalc/core)
+484 spreadsheet functions. Ground-truth conformance against real Google Sheets — not self-confirmed values. Stateless and embeddable; no runtime, no server. Also available as a [WebAssembly npm package](https://www.npmjs.com/package/@truecalc/core) and as an [MCP server](https://crates.io/crates/truecalc-mcp) for AI assistants.
+
+```rust
+let result = Engine::sheets().evaluate("=SUM(A1,B1)", &vars);
+// => Value::Number(300.0)
+```
 
 ## Install
 
@@ -180,6 +185,10 @@ were deprecated in 0.7.0. Replace them with `Engine::sheets().evaluate()`.
 
 - [`truecalc-workbook`](https://crates.io/crates/truecalc-workbook): full workbook layer with
   engine-locked workbook, worksheet, cell mutation, and recalc.
+
+## Documentation
+
+[docs.truecalc.app](https://docs.truecalc.app)
 
 ## License
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -6,6 +6,8 @@ license.workspace = true
 description = "MCP server exposing truecalc formula evaluation as a tool for AI assistants"
 repository.workspace = true
 readme = "README.md"
+keywords = ["mcp", "spreadsheet", "formula", "ai", "claude"]
+categories = ["command-line-utilities"]
 
 [[bin]]
 name = "truecalc-mcp"

--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -6,7 +6,13 @@
 
 MCP server that exposes [truecalc](https://crates.io/crates/truecalc-core) spreadsheet formula evaluation as tools for AI assistants.
 
-Plug it into Claude Desktop (or any MCP-compatible client) and your AI can evaluate, validate, and explain Excel-compatible formulas without writing any code.
+484 spreadsheet functions — evaluate, validate, and explain formulas without writing any code. Ground-truth conformance against real Google Sheets. Backed by the same engine used in the [Rust crate](https://crates.io/crates/truecalc-core) and [npm package](https://www.npmjs.com/package/@truecalc/core).
+
+```json
+// Tool: evaluate
+{ "formula": "SUM(A1, B1)", "variables": { "A1": 100, "B1": 200 } }
+// => { "value": 300, "type": "number" }
+```
 
 ## Install
 
@@ -87,6 +93,10 @@ Covers math, logical, text, financial, and statistical categories. For the full 
 
 - [`truecalc-core`](https://crates.io/crates/truecalc-core) — the underlying formula engine (Rust library)
 - [`@truecalc/core`](https://www.npmjs.com/package/@truecalc/core) — WebAssembly package for JavaScript/TypeScript
+
+## Documentation
+
+[docs.truecalc.app](https://docs.truecalc.app)
 
 ## License
 

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -4,8 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish = false  # published to npm via wasm-pack, not crates.io
-description = "Spreadsheet formula engine for the browser — Excel-compatible formula evaluator compiled to WebAssembly"
-keywords = ["spreadsheet", "formula", "excel", "wasm", "evaluator"]
+description = "Spreadsheet formula engine for the browser — Google Sheets–compatible formula evaluator compiled to WebAssembly"
+keywords = ["spreadsheet", "formula", "google-sheets", "excel", "wasm"]
+categories = ["wasm", "web-programming"]
 repository.workspace = true
 
 [lib]

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -7,6 +7,16 @@
 
 WebAssembly-powered spreadsheet formula engine for JavaScript/TypeScript.
 
+[DeepWiki](https://deepwiki.com/truecalc/core)
+
+484 spreadsheet functions. Runs in Node.js, Bun, Deno, and the browser — no server needed. Ground-truth conformance against real Google Sheets. The same engine is also available as a [Rust crate](https://crates.io/crates/truecalc-core) and as an [MCP server](https://crates.io/crates/truecalc-mcp) for AI assistants.
+
+```js
+const { evaluate } = require('@truecalc/core');
+evaluate('SUM(A1, B1)', { A1: 100, B1: 200 })
+// => { type: 'number', value: 300 }
+```
+
 ## Install
 
 ```sh
@@ -163,3 +173,7 @@ const fns = list_functions();
 | text       | LEFT, MID, RIGHT, LEN, LOWER, UPPER, TRIM, CONCATENATE, FIND, SUBSTITUTE, REPLACE, TEXT, VALUE, REPT |
 | financial  | PMT, NPV, IRR, PV, FV, RATE, NPER |
 | statistical | COUNT, COUNTA, MAX, MIN, MEDIAN |
+
+## Documentation
+
+[docs.truecalc.app](https://docs.truecalc.app)

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -7,8 +7,6 @@
 
 WebAssembly-powered spreadsheet formula engine for JavaScript/TypeScript.
 
-[DeepWiki](https://deepwiki.com/truecalc/core)
-
 484 spreadsheet functions. Runs in Node.js, Bun, Deno, and the browser — no server needed. Ground-truth conformance against real Google Sheets. The same engine is also available as a [Rust crate](https://crates.io/crates/truecalc-core) and as an [MCP server](https://crates.io/crates/truecalc-mcp) for AI assistants.
 
 ```js

--- a/crates/wasm/package.json
+++ b/crates/wasm/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@truecalc/core",
+  "description": "WebAssembly spreadsheet formula engine — 484 Google Sheets–compatible functions, runs in any JS runtime",
+  "keywords": ["spreadsheet", "formula", "google-sheets", "excel", "wasm", "webassembly", "evaluator", "calculator"],
+  "homepage": "https://docs.truecalc.app",
   "publishConfig": {
     "provenance": true,
     "access": "public"


### PR DESCRIPTION
## Summary

- Adds `keywords` and `categories` to all three `Cargo.toml` files for better crates.io search ranking
- Adds `description`, `keywords`, and `homepage` to `crates/wasm/package.json` for npm discoverability
- Updates `description` fields to remove "Excel-compatible" (not yet accurate)
- Adds a three-signal value pitch (484 functions, Google Sheets conformance, portability) + quick-start snippet to each package README
- Adds a `## Documentation` footer linking to `docs.truecalc.app` in every README

## Test plan

- [x] `cargo check -p truecalc-core` passes
- [x] `cargo check -p truecalc-mcp` passes
- [x] `node -e "JSON.parse(require('fs').readFileSync('crates/wasm/package.json', 'utf8'))"` prints no error
- [ ] All four READMEs render correctly on GitHub (spot-check the value pitch and snippet)
- [ ] crates.io preview shows keywords after publish (verify at next release)

closes #680