### PR TITLE
feat: TZNOW (deterministic clock), TZINWINDOW, TZCANONICAL — completes Phase 3

### DIFF
--- a/crates/core/src/engine/mod.rs
+++ b/crates/core/src/engine/mod.rs
@@ -190,6 +190,7 @@ impl Engine {
         formula: &str,
         resolver: &mut dyn Resolver,
         now_serial: Option<f64>,
+        now_utc_nanos: Option<i64>,
         rng_cell: Option<(u64, u32, u32, u32)>,
     ) -> Value {
         if let Some(n) = now_serial {
@@ -205,6 +206,7 @@ impl Engine {
             Ok(expr) => {
                 let mut ctx = Context::empty();
                 ctx.now_serial = now_serial;
+                ctx.now_utc_nanos = now_utc_nanos;
                 ctx.rng_cell = rng_cell;
                 let mut eval_ctx = EvalCtx::with_resolver(ctx, &self.registry, resolver);
                 evaluate_expr(&expr, &mut eval_ctx)

--- a/crates/core/src/eval/context/mod.rs
+++ b/crates/core/src/eval/context/mod.rs
@@ -12,6 +12,11 @@ pub struct Context {
     /// fraction = time of day). `None` ⇒ the functions read the ambient
     /// local clock. Set via [`crate::Engine::evaluate_at`] (P1.4, issue #526).
     pub now_serial: Option<f64>,
+    /// Pinned "now" as an absolute UTC instant (nanoseconds since the Unix
+    /// epoch), for the zone-aware `TZNOW`. `None` ⇒ `TZNOW` reads the ambient
+    /// UTC clock. Set from the workbook's `timestamp_ms` during recalc; distinct
+    /// from `now_serial` (a tz-naive local serial for `NOW`/`TODAY`).
+    pub now_utc_nanos: Option<i64>,
     /// Per-cell RNG key for deterministic draws: (seed, sheet_index, row, col).
     /// Set by the workbook recalc loop; None for bare Engine::evaluate calls.
     pub rng_cell: Option<(u64, u32, u32, u32)>,
@@ -24,12 +29,12 @@ impl Context {
         let normalized = vars.into_iter()
             .map(|(k, v)| (k.to_uppercase(), v))
             .collect();
-        Self { vars: normalized, now_serial: None, rng_cell: None }
+        Self { vars: normalized, now_serial: None, now_utc_nanos: None, rng_cell: None }
     }
 
     /// Create an empty `Context` with no variable bindings.
     pub fn empty() -> Self {
-        Self { vars: HashMap::new(), now_serial: None, rng_cell: None }
+        Self { vars: HashMap::new(), now_serial: None, now_utc_nanos: None, rng_cell: None }
     }
 
     /// Look up a variable by name (case-insensitive). Returns `Value::Empty` if not found.

--- a/crates/core/src/eval/functions/mod.rs
+++ b/crates/core/src/eval/functions/mod.rs
@@ -225,7 +225,7 @@ impl Registry {
     /// Volatile functions — outputs change on every evaluation.
     /// Excluded from conformance fixtures; covered by property tests instead.
     pub const VOLATILE_FUNCTIONS: &'static [&'static str] = &[
-        "RAND", "RANDARRAY", "NOW", "TODAY", "RANDBETWEEN",
+        "RAND", "RANDARRAY", "NOW", "TODAY", "RANDBETWEEN", "TZNOW",
     ];
 }
 

--- a/crates/core/src/eval/functions/timezone/mod.rs
+++ b/crates/core/src/eval/functions/timezone/mod.rs
@@ -2,13 +2,15 @@
 //! display [`Value::Zoned`] instants. The naive<->zoned boundary is always an
 //! explicit call here: `TZDATETIME`/`TZLOCALIZE` up, `TZSERIAL` down.
 
-use chrono::{Datelike, Duration, Months, NaiveDate, NaiveDateTime, Timelike};
+use chrono::{Datelike, Duration, Months, NaiveDate, NaiveDateTime, Timelike, Utc};
 
 use crate::eval::coercion::to_number;
+use crate::eval::evaluate_expr;
 use crate::eval::functions::date::serial::{
     date_to_serial, serial_to_date, serial_to_time, time_to_serial,
 };
-use crate::eval::functions::{check_arity, FunctionMeta, Registry};
+use crate::eval::functions::{check_arity, check_arity_len, EvalCtx, FunctionMeta, Registry};
+use crate::parser::ast::Expr;
 use crate::types::zoned::{parse_rfc9557, parse_zone, AmbiguousPolicy};
 use crate::types::{ErrorKind, Value, ZoneId, ZonedInstant};
 
@@ -33,6 +35,9 @@ pub fn register_timezone(registry: &mut Registry) {
     registry.register_eager("TZPART", tzpart_fn, FunctionMeta { category: "timezone", signature: "TZPART(zoned,unit)", description: "Local wall-clock field: year|month|day|hour|minute|second|weekday" });
     registry.register_eager("TZDIFF", tzdiff_fn, FunctionMeta { category: "timezone", signature: "TZDIFF(zoned_a,zoned_b,[unit])", description: "Elapsed time from b to a on the absolute timeline (DST-immune)" });
     registry.register_eager("TZADD", tzadd_fn, FunctionMeta { category: "timezone", signature: "TZADD(zoned,amount,unit,[policy])", description: "Adds time: seconds/minutes/hours are absolute, days/weeks/months/years are DST-aware calendar units" });
+    registry.register_lazy("TZNOW", tznow_fn, FunctionMeta { category: "timezone", signature: "TZNOW(zone)", description: "The current moment stamped with the given zone (volatile; pinned during recalc)" });
+    registry.register_eager("TZINWINDOW", tzinwindow_fn, FunctionMeta { category: "timezone", signature: "TZINWINDOW(zoned,start_local,end_local,[days_mask])", description: "TRUE if the local time-of-day falls in [start,end); days_mask is 7 chars Sun..Sat" });
+    registry.register_eager("TZCANONICAL", tzcanonical_fn, FunctionMeta { category: "timezone", signature: "TZCANONICAL(zone)", description: "Validates and normalizes a zone name (best-effort; IANA links are not resolved)" });
 }
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
@@ -399,6 +404,97 @@ pub fn tzadd_fn(args: &[Value]) -> Value {
                 None => Value::Error(ErrorKind::Value),
             }
         }
+        _ => Value::Error(ErrorKind::Value),
+    }
+}
+
+/// `TZNOW(zone)` — the current instant stamped with `zone`. Volatile and lazy:
+/// it reads the pinned UTC instant from the context (set during recalc), falling
+/// back to the ambient UTC clock when unpinned.
+pub fn tznow_fn(args: &[Expr], ctx: &mut EvalCtx<'_>) -> Value {
+    if let Some(e) = check_arity_len(args.len(), 1, 1) {
+        return e;
+    }
+    let zone_val = evaluate_expr(&args[0], ctx);
+    let zone = match &zone_val {
+        Value::Text(s) => match parse_zone(s) {
+            Some(z) => z,
+            None => return Value::Error(ErrorKind::Value),
+        },
+        Value::Error(_) => return zone_val,
+        _ => return Value::Error(ErrorKind::Value),
+    };
+    let nanos = match ctx.ctx.now_utc_nanos {
+        Some(n) => n,
+        None => match Utc::now().timestamp_nanos_opt() {
+            Some(n) => n,
+            None => return Value::Error(ErrorKind::Num),
+        },
+    };
+    zoned(ZonedInstant::from_instant(nanos, zone))
+}
+
+/// `TZINWINDOW(zoned, start_local, end_local, [days_mask])` — is the local
+/// time-of-day within `[start, end)`? `start`/`end` are time-of-day fractions
+/// (0..1, e.g. `TIME(9,0,0)`). An overnight window (`start > end`) wraps past
+/// midnight. Optional `days_mask` is 7 characters, index 0 = Sunday, '1' = the
+/// day counts.
+pub fn tzinwindow_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 3, 4) {
+        return e;
+    }
+    let zi = match arg_zoned(&args[0]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let start = match to_number(args[1].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let end = match to_number(args[2].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let local = zi.local();
+    if let Some(mask_arg) = args.get(3) {
+        let mask = match mask_arg {
+            Value::Text(s) => s,
+            _ => return Value::Error(ErrorKind::Value),
+        };
+        let idx = local.weekday().num_days_from_sunday() as usize;
+        match mask.chars().nth(idx) {
+            Some('1') => {}
+            Some(_) => return Value::Bool(false),
+            None => return Value::Error(ErrorKind::Value),
+        }
+    }
+    let frac = local.time().num_seconds_from_midnight() as f64 / 86_400.0;
+    let inside = if start <= end {
+        frac >= start && frac < end
+    } else {
+        // Overnight window wraps past midnight.
+        frac >= start || frac < end
+    };
+    Value::Bool(inside)
+}
+
+/// `TZCANONICAL(zone)` — validate and normalize a zone name. Best-effort: a
+/// valid IANA name or fixed offset is returned in canonical form, but chrono-tz
+/// keeps backward-compat links (e.g. `US/Pacific`) as distinct names, so links
+/// are not resolved to their target.
+pub fn tzcanonical_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 1, 1) {
+        return e;
+    }
+    match &args[0] {
+        Value::Text(s) => match parse_zone(s) {
+            Some(ZoneId::Iana(tz)) => Value::Text(tz.name().to_string()),
+            Some(ZoneId::Fixed(m)) => {
+                let a = m.abs();
+                Value::Text(format!("{}{:02}:{:02}", if m < 0 { '-' } else { '+' }, a / 60, a % 60))
+            }
+            None => Value::Error(ErrorKind::Value),
+        },
         _ => Value::Error(ErrorKind::Value),
     }
 }

--- a/crates/core/src/eval/functions/timezone/tests.rs
+++ b/crates/core/src/eval/functions/timezone/tests.rs
@@ -300,3 +300,75 @@ fn arithmetic_error_cases() {
     assert_eq!(tzdiff_fn(&[z, num(1.0)]), Value::Error(ErrorKind::Value));
     assert_eq!(tzdiff_fn(&[num(1.0), num(2.0)]), Value::Error(ErrorKind::Value));
 }
+
+// ── Batch 4: TZNOW, TZINWINDOW, TZCANONICAL ───────────────────────────────────
+
+/// Call the lazy `TZNOW` with a pinned (or absent) UTC instant.
+fn tznow(zone: &str, now_utc_nanos: Option<i64>) -> Value {
+    use crate::eval::functions::{EvalCtx, Registry};
+    use crate::eval::Context;
+    use crate::parser::ast::{Expr, Span};
+    let registry = Registry::new();
+    let mut ctx = Context::empty();
+    ctx.now_utc_nanos = now_utc_nanos;
+    let mut eval_ctx = EvalCtx::new(ctx, &registry);
+    tznow_fn(&[Expr::Text(zone.to_string(), Span::new(0, 0))], &mut eval_ctx)
+}
+
+#[test]
+fn tznow_uses_pinned_utc_instant() {
+    // Pinned to the Unix epoch.
+    assert_eq!(
+        tzstring_fn(&[tznow("UTC", Some(0))]),
+        Value::Text("1970-01-01T00:00:00+00:00[UTC]".to_string())
+    );
+    assert_eq!(tzoffset_fn(&[tznow("America/New_York", Some(0))]), Value::Number(-300.0));
+}
+
+#[test]
+fn tznow_ambient_when_unpinned_is_zoned() {
+    assert!(matches!(tznow("UTC", None), Value::Zoned(_)));
+}
+
+#[test]
+fn tznow_invalid_zone_is_value_error() {
+    assert_eq!(tznow("Mars/Olympus", Some(0)), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn tzinwindow_business_hours() {
+    // 09:00 = 0.375, 18:00 = 0.75.
+    let day = dt(&[num(2026.0), num(7.0), num(14.0), num(11.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    let evening = dt(&[num(2026.0), num(7.0), num(14.0), num(20.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    assert_eq!(tzinwindow_fn(&[day, num(0.375), num(0.75)]), Value::Bool(true));
+    assert_eq!(tzinwindow_fn(&[evening, num(0.375), num(0.75)]), Value::Bool(false));
+}
+
+#[test]
+fn tzinwindow_overnight_wraps_past_midnight() {
+    let z = dt(&[num(2026.0), num(7.0), num(14.0), num(2.0), num(0.0), num(0.0), txt("UTC")]);
+    // 22:00 -> 06:00 window; 02:00 is inside.
+    assert_eq!(tzinwindow_fn(&[z, num(22.0 / 24.0), num(6.0 / 24.0)]), Value::Bool(true));
+}
+
+#[test]
+fn tzinwindow_days_mask_excludes_weekday() {
+    // 2026-07-14 is a Tuesday -> Sunday-indexed position 2.
+    let z = dt(&[num(2026.0), num(7.0), num(14.0), num(11.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    assert_eq!(tzinwindow_fn(&[z.clone(), num(0.375), num(0.75), txt("1101111")]), Value::Bool(false));
+    assert_eq!(tzinwindow_fn(&[z, num(0.375), num(0.75), txt("1111111")]), Value::Bool(true));
+}
+
+#[test]
+fn tzcanonical_validates_and_normalizes() {
+    assert_eq!(tzcanonical_fn(&[txt("Europe/Berlin")]), Value::Text("Europe/Berlin".to_string()));
+    assert_eq!(tzcanonical_fn(&[txt("+05:30")]), Value::Text("+05:30".to_string()));
+    assert_eq!(tzcanonical_fn(&[txt("Mars/Olympus")]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn batch4_rejects_bad_inputs() {
+    assert_eq!(tzinwindow_fn(&[num(1.0), num(0.0), num(1.0)]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzcanonical_fn(&[num(1.0)]), Value::Error(ErrorKind::Value));
+    assert_eq!(tzinwindow_fn(&[txt("x")]), Value::Error(ErrorKind::NA));
+}

--- a/crates/workbook/src/recalc.rs
+++ b/crates/workbook/src/recalc.rs
@@ -146,6 +146,14 @@ impl RecalcContext {
         Some(days + secs / 86_400.0)
     }
 
+    /// The pinned "now" as an absolute UTC instant in nanoseconds, for the
+    /// zone-aware `TZNOW`. Derived from the same `timestamp_ms` as
+    /// [`now_serial`](Self::now_serial), so `NOW()` and `TZNOW()` share one
+    /// deterministic clock.
+    pub fn now_utc_nanos(&self) -> Option<i64> {
+        self.timestamp_ms.checked_mul(1_000_000)
+    }
+
     /// The ADR's per-draw RNG key `prf(rng_seed, sheet_index, row, col,
     /// draw_index)`, a deterministic, order-independent mixing of the cell
     /// identity into the seed.
@@ -335,6 +343,7 @@ impl Workbook {
         to_eval: BTreeSet<CellRef>,
     ) -> Vec<Change> {
         let now_serial = ctx.now_serial();
+        let now_utc_nanos = ctx.now_utc_nanos();
         let rng_seed = ctx.rng_seed();
 
         // Cells on a cycle short-circuit to the circular error; the rest are
@@ -400,6 +409,7 @@ impl Workbook {
                 let raw = self.eval_formula_cell(
                     cell,
                     now_serial,
+                    now_utc_nanos,
                     rng_seed,
                     &next_values,
                     &next_spills,
@@ -441,6 +451,7 @@ impl Workbook {
         &self,
         cell: &CellRef,
         now_serial: Option<f64>,
+        now_utc_nanos: Option<i64>,
         rng_seed: u64,
         new_values: &BTreeMap<CellRef, Value>,
         spills: &BTreeMap<CellRef, SpillRect>,
@@ -478,6 +489,7 @@ impl Workbook {
             &formula,
             &mut resolver,
             now_serial,
+            now_utc_nanos,
             rng_cell,
         );
         core_to_workbook(core)

--- a/functions.json
+++ b/functions.json
@@ -6786,6 +6786,13 @@
     "examples": []
   },
   {
+    "name": "TZCANONICAL",
+    "category": "timezone",
+    "syntax": "TZCANONICAL(zone)",
+    "description": "Validates and normalizes a zone name (best-effort; IANA links are not resolved)",
+    "examples": []
+  },
+  {
     "name": "TZCONVERT",
     "category": "timezone",
     "syntax": "TZCONVERT(zoned,target_zone)",
@@ -6821,6 +6828,13 @@
     "examples": []
   },
   {
+    "name": "TZINWINDOW",
+    "category": "timezone",
+    "syntax": "TZINWINDOW(zoned,start_local,end_local,[days_mask])",
+    "description": "TRUE if the local time-of-day falls in [start,end); days_mask is 7 chars Sun..Sat",
+    "examples": []
+  },
+  {
     "name": "TZISDST",
     "category": "timezone",
     "syntax": "TZISDST(zoned)",
@@ -6832,6 +6846,13 @@
     "category": "timezone",
     "syntax": "TZLOCALIZE(date_serial,zone,[policy])",
     "description": "Interprets a plain date/time serial as a wall-clock reading in a zone",
+    "examples": []
+  },
+  {
+    "name": "TZNOW",
+    "category": "timezone",
+    "syntax": "TZNOW(zone)",
+    "description": "The current moment stamped with the given zone (volatile; pinned during recalc)",
     "examples": []
   },
   {


### PR DESCRIPTION
## Phase 3 (final) of #666 — completes the `TZ*` function set

| Function | Purpose |
|---|---|
| `TZNOW(zone)` | Current moment stamped with a zone. **Volatile + lazy.** |
| `TZINWINDOW(zoned, start_local, end_local, [days_mask])` | Is the local time-of-day in `[start, end)`? Overnight windows wrap past midnight; optional 7-char weekday mask (Sun..Sat). |
| `TZCANONICAL(zone)` | Validate + normalize a zone name. |

### TZNOW deterministic clock (the design decision)
The engine pinned `now` only as a tz-naive **local serial** (`now_serial`, for `NOW()`/`TODAY()`). This adds a **`Context.now_utc_nanos`** carrying a real UTC instant:
- `RecalcContext.now_utc_nanos()` derives it from the same `timestamp_ms` as `now_serial`, so `NOW()` and `TZNOW()` share one deterministic clock.
- Threaded through `evaluate_with_resolver_at_keyed` → the recalc loop.
- Unpinned (bare `Engine::evaluate`), `TZNOW` falls back to the ambient UTC clock and is registered **volatile** (like `NOW`).

### Notes / accepted limitations
- `TZINWINDOW` start/end are time-of-day fractions (0..1, e.g. `TIME(9,0,0)`).
- `TZCANONICAL` is best-effort: chrono-tz keeps IANA backward-compat links (e.g. `US/Pacific`) as distinct names, so links aren't resolved to their target. Documented inline.
- `functions.json` regenerated (509 functions).

### Verification
- `cargo test --workspace` → 0 failures (37 timezone unit tests incl. pinned-`TZNOW`, overnight windows, DST)
- `cargo clippy --workspace -- -D warnings` → clean

### Phase 3 complete — 20 `TZ*` functions
Construct (`TZDATETIME`/`TZLOCALIZE`/`TZFROMEPOCH`/`TZPARSE`/`TZNOW`), convert (`TZCONVERT`/`TZSERIAL`), introspect (`TZOFFSET`/`TZOFFSETDIFF`/`TZISDST`/`TZABBR`/`TZVALID`/`TZCANONICAL`/`TZDBVERSION`/`ISZONED`), arithmetic (`TZDIFF`/`TZADD`), extract/predicate (`TZPART`/`TZINWINDOW`). All exported via MCP.

Closes #668