### PR TITLE
feat: flagship N-timezone compare (TZBOARD/TZWORLDCLOCK) + display

### DIFF
--- a/crates/core/src/eval/functions/timezone/mod.rs
+++ b/crates/core/src/eval/functions/timezone/mod.rs
@@ -2,7 +2,8 @@
 //! display [`Value::Zoned`] instants. The naive<->zoned boundary is always an
 //! explicit call here: `TZDATETIME`/`TZLOCALIZE` up, `TZSERIAL` down.
 
-use chrono::{Datelike, Duration, Months, NaiveDate, NaiveDateTime, Timelike, Utc};
+use chrono::format::{Item, StrftimeItems};
+use chrono::{Datelike, Duration, Months, NaiveDate, NaiveDateTime, TimeZone, Timelike, Utc};
 
 use crate::eval::coercion::to_number;
 use crate::eval::evaluate_expr;
@@ -38,6 +39,12 @@ pub fn register_timezone(registry: &mut Registry) {
     registry.register_lazy("TZNOW", tznow_fn, FunctionMeta { category: "timezone", signature: "TZNOW(zone)", description: "The current moment stamped with the given zone (volatile; pinned during recalc)" });
     registry.register_eager("TZINWINDOW", tzinwindow_fn, FunctionMeta { category: "timezone", signature: "TZINWINDOW(zoned,start_local,end_local,[days_mask])", description: "TRUE if the local time-of-day falls in [start,end); days_mask is 7 chars Sun..Sat" });
     registry.register_eager("TZCANONICAL", tzcanonical_fn, FunctionMeta { category: "timezone", signature: "TZCANONICAL(zone)", description: "Validates and normalizes a zone name (best-effort; IANA links are not resolved)" });
+    registry.register_eager("TZLOCALSTATUS", tzlocalstatus_fn, FunctionMeta { category: "timezone", signature: "TZLOCALSTATUS(year,month,day,hour,minute,zone)", description: "Classifies a local time as unique, gap (nonexistent) or fold (ambiguous)" });
+    registry.register_eager("TZTEXT", tztext_fn, FunctionMeta { category: "timezone", signature: "TZTEXT(zoned,[format])", description: "Human-friendly local string; optional strftime format" });
+    registry.register_eager("TZBOARD", tzboard_fn, FunctionMeta { category: "timezone", signature: "TZBOARD(anchor,zones,[base])", description: "Technical world-clock board: one row per zone {zone,local,offset,delta,rollover,abbrev,dst}" });
+    registry.register_eager("TZTABLE", tzboard_fn, FunctionMeta { category: "timezone", signature: "TZTABLE(anchor,zones,[base])", description: "Alias of TZBOARD" });
+    registry.register_eager("TZWORLDCLOCK", tzworldclock_fn, FunctionMeta { category: "timezone", signature: "TZWORLDCLOCK(anchor,zones,[base])", description: "Friendly one-line summary comparing the time across N zones" });
+    registry.register_eager("TZCOMPARETEXT", tzworldclock_fn, FunctionMeta { category: "timezone", signature: "TZCOMPARETEXT(anchor,zones,[base])", description: "Alias of TZWORLDCLOCK" });
 }
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
@@ -496,6 +503,235 @@ pub fn tzcanonical_fn(args: &[Value]) -> Value {
             None => Value::Error(ErrorKind::Value),
         },
         _ => Value::Error(ErrorKind::Value),
+    }
+}
+
+pub fn tzlocalstatus_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 6, 6) {
+        return e;
+    }
+    let parts = match (0..5).map(|i| int_arg(&args[i])).collect::<Result<Vec<_>, _>>() {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let zone = match arg_zone(&args[5]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let naive = match build_naive(parts[0], parts[1], parts[2], parts[3], parts[4], 0) {
+        Some(n) => n,
+        None => return Value::Error(ErrorKind::Value),
+    };
+    let status = match zone {
+        ZoneId::Fixed(_) => "unique",
+        ZoneId::Iana(tz) => {
+            use chrono::LocalResult;
+            match tz.from_local_datetime(&naive) {
+                LocalResult::Single(_) => "unique",
+                LocalResult::Ambiguous(_, _) => "fold",
+                LocalResult::None => "gap",
+            }
+        }
+    };
+    Value::Text(status.to_string())
+}
+
+pub fn tztext_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 1, 2) {
+        return e;
+    }
+    let zi = match arg_zoned(&args[0]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let local = zi.local();
+    match args.get(1) {
+        None => Value::Text(format!("{} {}", local.format("%a %b %d %Y %H:%M"), zi.abbrev())),
+        Some(Value::Text(fmt)) => {
+            if StrftimeItems::new(fmt).any(|item| matches!(item, Item::Error)) {
+                return Value::Error(ErrorKind::Value);
+            }
+            Value::Text(local.format(fmt).to_string())
+        }
+        Some(_) => Value::Error(ErrorKind::Value),
+    }
+}
+
+pub fn tzboard_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 2, 3) {
+        return e;
+    }
+    let anchor = match arg_zoned(&args[0]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let instant = anchor.utc_nanos;
+    let names = match collect_zone_names(&args[1]) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let base_zone = match args.get(2) {
+        None => anchor.zone.clone(),
+        Some(v) => match zone_of_arg(v) {
+            Ok(z) => z,
+            Err(e) => return e,
+        },
+    };
+    let base = ZonedInstant::from_instant(instant, base_zone);
+    let base_offset = base.offset_minutes();
+    let base_date = base.local().date();
+
+    let mut rows = Vec::with_capacity(names.len());
+    for name in &names {
+        let zone = match parse_zone(name) {
+            Some(z) => z,
+            None => return Value::Error(ErrorKind::Value),
+        };
+        let zi = ZonedInstant::from_instant(instant, zone);
+        let offset = zi.offset_minutes();
+        let rollover = zi.local().date().signed_duration_since(base_date).num_days();
+        rows.push(Value::Array(vec![
+            Value::Text(name.clone()),
+            Value::Text(zi.to_rfc9557()),
+            Value::Number(offset as f64),
+            Value::Number((offset - base_offset) as f64),
+            Value::Number(rollover as f64),
+            Value::Text(zi.abbrev()),
+            Value::Bool(zi.is_dst()),
+        ]));
+    }
+    Value::Array(rows)
+}
+
+pub fn tzworldclock_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 2, 3) {
+        return e;
+    }
+    let anchor = match arg_zoned(&args[0]) {
+        Ok(z) => z,
+        Err(e) => return e,
+    };
+    let instant = anchor.utc_nanos;
+    let names = match collect_zone_names(&args[1]) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let base_zone = match args.get(2) {
+        None => anchor.zone.clone(),
+        Some(v) => match zone_of_arg(v) {
+            Ok(z) => z,
+            Err(e) => return e,
+        },
+    };
+    let base = ZonedInstant::from_instant(instant, base_zone.clone());
+    let base_offset = base.offset_minutes();
+    let base_date = base.local().date();
+
+    let mut out = format!(
+        "It is {} {} for you ({}).",
+        base.local().format("%H:%M"),
+        base.local().format("%a"),
+        zone_label(&base_zone),
+    );
+    for name in &names {
+        let zone = match parse_zone(name) {
+            Some(z) => z,
+            None => return Value::Error(ErrorKind::Value),
+        };
+        let zi = ZonedInstant::from_instant(instant, zone);
+        let delta = zi.offset_minutes() - base_offset;
+        let rollover = zi.local().date().signed_duration_since(base_date).num_days();
+        out.push_str(&format!(
+            " {} is {} ({}{}).",
+            name,
+            friendly_delta(delta),
+            zi.local().format("%H:%M"),
+            day_phrase(rollover),
+        ));
+    }
+    Value::Text(out)
+}
+
+/// Compose date/time integer parts into a `NaiveDateTime`, validating ranges.
+fn build_naive(y: i64, mo: i64, d: i64, h: i64, mi: i64, s: i64) -> Option<NaiveDateTime> {
+    let y = i32::try_from(y).ok()?;
+    let mo = u32::try_from(mo).ok()?;
+    let d = u32::try_from(d).ok()?;
+    let h = u32::try_from(h).ok()?;
+    let mi = u32::try_from(mi).ok()?;
+    let s = u32::try_from(s).ok()?;
+    NaiveDate::from_ymd_opt(y, mo, d)?.and_hms_opt(h, mi, s)
+}
+
+/// Collect zone-name strings from a value, flattening arrays. Errors on any
+/// non-text leaf or an empty list.
+fn collect_zone_names(v: &Value) -> Result<Vec<String>, Value> {
+    fn walk(v: &Value, out: &mut Vec<String>) -> Result<(), Value> {
+        match v {
+            Value::Text(s) => {
+                out.push(s.clone());
+                Ok(())
+            }
+            Value::Array(items) => {
+                for it in items {
+                    walk(it, out)?;
+                }
+                Ok(())
+            }
+            Value::Error(_) => Err(v.clone()),
+            _ => Err(Value::Error(ErrorKind::Value)),
+        }
+    }
+    let mut out = Vec::new();
+    walk(v, &mut out)?;
+    if out.is_empty() {
+        return Err(Value::Error(ErrorKind::Value));
+    }
+    Ok(out)
+}
+
+/// Resolve a base-zone argument: a zone name, or an existing zoned instant.
+fn zone_of_arg(v: &Value) -> Result<ZoneId, Value> {
+    match v {
+        Value::Text(s) => parse_zone(s).ok_or(Value::Error(ErrorKind::Value)),
+        Value::Zoned(z) => Ok(z.zone.clone()),
+        _ => Err(Value::Error(ErrorKind::Value)),
+    }
+}
+
+/// Display label for a zone: IANA name or `±HH:MM`.
+fn zone_label(zone: &ZoneId) -> String {
+    match zone {
+        ZoneId::Iana(tz) => tz.name().to_string(),
+        ZoneId::Fixed(m) => {
+            let a = m.abs();
+            format!("{}{:02}:{:02}", if *m < 0 { '-' } else { '+' }, a / 60, a % 60)
+        }
+    }
+}
+
+/// Friendly offset delta, e.g. `3h ahead`, `5:45 ahead`, `2h behind`.
+fn friendly_delta(minutes: i32) -> String {
+    if minutes == 0 {
+        return "the same time".to_string();
+    }
+    let a = minutes.abs();
+    let mag = if a % 60 == 0 {
+        format!("{}h", a / 60)
+    } else {
+        format!("{}:{:02}", a / 60, a % 60)
+    };
+    format!("{} {}", mag, if minutes > 0 { "ahead" } else { "behind" })
+}
+
+/// Calendar-day rollover phrase relative to the base zone.
+fn day_phrase(days: i64) -> String {
+    match days {
+        0 => String::new(),
+        1 => ", next day".to_string(),
+        -1 => ", previous day".to_string(),
+        n if n > 0 => format!(", +{n} days"),
+        n => format!(", {n} days"),
     }
 }
 

--- a/crates/core/src/eval/functions/timezone/tests.rs
+++ b/crates/core/src/eval/functions/timezone/tests.rs
@@ -372,3 +372,111 @@ fn batch4_rejects_bad_inputs() {
     assert_eq!(tzcanonical_fn(&[num(1.0)]), Value::Error(ErrorKind::Value));
     assert_eq!(tzinwindow_fn(&[txt("x")]), Value::Error(ErrorKind::NA));
 }
+
+// ── Phase 4: flagship + display (TZLOCALSTATUS, TZTEXT, TZBOARD, TZWORLDCLOCK) ─
+
+#[test]
+fn tzlocalstatus_classifies_dst_seams() {
+    let unique = [num(2026.0), num(7.0), num(14.0), num(11.0), num(0.0), txt("Europe/Berlin")];
+    let gap = [num(2026.0), num(3.0), num(29.0), num(2.0), num(30.0), txt("Europe/Berlin")];
+    let fold = [num(2026.0), num(10.0), num(25.0), num(2.0), num(30.0), txt("Europe/Berlin")];
+    assert_eq!(tzlocalstatus_fn(&unique), Value::Text("unique".to_string()));
+    assert_eq!(tzlocalstatus_fn(&gap), Value::Text("gap".to_string()));
+    assert_eq!(tzlocalstatus_fn(&fold), Value::Text("fold".to_string()));
+    // Fixed offsets never have a gap/fold.
+    let fixed = [num(2026.0), num(3.0), num(29.0), num(2.0), num(30.0), txt("+05:30")];
+    assert_eq!(tzlocalstatus_fn(&fixed), Value::Text("unique".to_string()));
+}
+
+#[test]
+fn tztext_default_and_custom_format() {
+    let z = dt(&[num(2026.0), num(7.0), num(14.0), num(11.0), num(0.0), num(0.0), txt("Europe/Berlin")]);
+    assert_eq!(tztext_fn(&[z.clone()]), Value::Text("Tue Jul 14 2026 11:00 CEST".to_string()));
+    assert_eq!(tztext_fn(&[z.clone(), txt("%Y-%m-%d")]), Value::Text("2026-07-14".to_string()));
+    // A malformed strftime string is rejected rather than panicking.
+    assert_eq!(tztext_fn(&[z, txt("%")]), Value::Error(ErrorKind::Value));
+}
+
+#[test]
+fn tzboard_rows_are_internally_consistent() {
+    // Anchor instant = 2026-07-14T09:00:00Z; base defaults to the anchor zone (UTC).
+    let anchor = dt(&[num(2026.0), num(7.0), num(14.0), num(9.0), num(0.0), num(0.0), txt("UTC")]);
+    let zones = Value::Array(vec![txt("Europe/Berlin"), txt("Asia/Tokyo")]);
+    match tzboard_fn(&[anchor, zones]) {
+        Value::Array(rows) => {
+            assert_eq!(rows.len(), 2);
+            match &rows[0] {
+                Value::Array(r) => {
+                    assert_eq!(r[0], txt("Europe/Berlin"));
+                    assert_eq!(r[1], txt("2026-07-14T11:00:00+02:00[Europe/Berlin]"));
+                    assert_eq!(r[2], num(120.0)); // offset
+                    assert_eq!(r[3], num(120.0)); // delta vs UTC base
+                    assert_eq!(r[4], num(0.0)); // rollover
+                    assert_eq!(r[5], txt("CEST"));
+                    assert_eq!(r[6], Value::Bool(true));
+                }
+                other => panic!("expected row array, got {other:?}"),
+            }
+            match &rows[1] {
+                Value::Array(r) => {
+                    assert_eq!(r[2], num(540.0)); // Tokyo +09:00
+                    assert_eq!(r[6], Value::Bool(false));
+                }
+                other => panic!("expected row array, got {other:?}"),
+            }
+        }
+        other => panic!("expected array, got {other:?}"),
+    }
+}
+
+#[test]
+fn tzboard_base_override_changes_delta() {
+    let anchor = dt(&[num(2026.0), num(7.0), num(14.0), num(9.0), num(0.0), num(0.0), txt("UTC")]);
+    let zones = Value::Array(vec![txt("Europe/Berlin")]);
+    match tzboard_fn(&[anchor, zones, txt("Asia/Tokyo")]) {
+        Value::Array(rows) => match &rows[0] {
+            // Berlin +120 vs Tokyo +540 base = -420.
+            Value::Array(r) => assert_eq!(r[3], num(-420.0)),
+            _ => panic!(),
+        },
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn tzworldclock_friendly_sentence() {
+    // Anchor 02:00 Los Angeles (PDT, -7h) on a Tuesday = 09:00Z.
+    let anchor = dt(&[num(2026.0), num(7.0), num(14.0), num(2.0), num(0.0), num(0.0), txt("America/Los_Angeles")]);
+    let zones = Value::Array(vec![txt("Europe/Berlin"), txt("Asia/Tokyo"), txt("Asia/Kathmandu")]);
+    assert_eq!(
+        tzworldclock_fn(&[anchor, zones]),
+        Value::Text(
+            "It is 02:00 Tue for you (America/Los_Angeles). \
+             Europe/Berlin is 9h ahead (11:00). \
+             Asia/Tokyo is 16h ahead (18:00). \
+             Asia/Kathmandu is 12:45 ahead (14:45)."
+                .to_string()
+        )
+    );
+}
+
+#[test]
+fn flagship_aliases_and_registration() {
+    use crate::eval::functions::Registry;
+    let r = Registry::new();
+    for name in ["TZBOARD", "TZTABLE", "TZWORLDCLOCK", "TZCOMPARETEXT", "TZLOCALSTATUS", "TZTEXT"] {
+        assert!(r.functions.contains_key(name), "{name} should be registered");
+    }
+}
+
+#[test]
+fn flagship_rejects_bad_inputs() {
+    let zones = Value::Array(vec![txt("Europe/Berlin")]);
+    assert_eq!(tzboard_fn(&[num(1.0), zones.clone()]), Value::Error(ErrorKind::Value)); // non-zoned anchor
+    let anchor = dt(&[num(2026.0), num(1.0), num(1.0), num(0.0), num(0.0), num(0.0), txt("UTC")]);
+    assert_eq!(
+        tzboard_fn(&[anchor.clone(), Value::Array(vec![txt("Mars/Olympus")])]),
+        Value::Error(ErrorKind::Value)
+    );
+    assert_eq!(tzworldclock_fn(&[anchor, num(5.0)]), Value::Error(ErrorKind::Value)); // zones not text/array
+}

--- a/functions.json
+++ b/functions.json
@@ -6786,10 +6786,24 @@
     "examples": []
   },
   {
+    "name": "TZBOARD",
+    "category": "timezone",
+    "syntax": "TZBOARD(anchor,zones,[base])",
+    "description": "Technical world-clock board: one row per zone {zone,local,offset,delta,rollover,abbrev,dst}",
+    "examples": []
+  },
+  {
     "name": "TZCANONICAL",
     "category": "timezone",
     "syntax": "TZCANONICAL(zone)",
     "description": "Validates and normalizes a zone name (best-effort; IANA links are not resolved)",
+    "examples": []
+  },
+  {
+    "name": "TZCOMPARETEXT",
+    "category": "timezone",
+    "syntax": "TZCOMPARETEXT(anchor,zones,[base])",
+    "description": "Alias of TZWORLDCLOCK",
     "examples": []
   },
   {
@@ -6849,6 +6863,13 @@
     "examples": []
   },
   {
+    "name": "TZLOCALSTATUS",
+    "category": "timezone",
+    "syntax": "TZLOCALSTATUS(year,month,day,hour,minute,zone)",
+    "description": "Classifies a local time as unique, gap (nonexistent) or fold (ambiguous)",
+    "examples": []
+  },
+  {
     "name": "TZNOW",
     "category": "timezone",
     "syntax": "TZNOW(zone)",
@@ -6898,10 +6919,31 @@
     "examples": []
   },
   {
+    "name": "TZTABLE",
+    "category": "timezone",
+    "syntax": "TZTABLE(anchor,zones,[base])",
+    "description": "Alias of TZBOARD",
+    "examples": []
+  },
+  {
+    "name": "TZTEXT",
+    "category": "timezone",
+    "syntax": "TZTEXT(zoned,[format])",
+    "description": "Human-friendly local string; optional strftime format",
+    "examples": []
+  },
+  {
     "name": "TZVALID",
     "category": "timezone",
     "syntax": "TZVALID(zone)",
     "description": "TRUE if the text is a valid IANA zone name or fixed offset",
+    "examples": []
+  },
+  {
+    "name": "TZWORLDCLOCK",
+    "category": "timezone",
+    "syntax": "TZWORLDCLOCK(anchor,zones,[base])",
+    "description": "Friendly one-line summary comparing the time across N zones",
     "examples": []
   },
   {


### PR DESCRIPTION
## Phase 4 of #666 — the flagship: compare N timezones, friendly + technical

This is the headline capability the whole effort was aimed at.

| Function | Purpose |
|---|---|
| `TZBOARD(anchor, zones, [base])` (alias `TZTABLE`) | **Technical** board: one row per zone `{zone, local (RFC-9557), offset_min, delta_vs_base_min, day_rollover, abbrev, is_dst}`, all from one shared instant. |
| `TZWORLDCLOCK(anchor, zones, [base])` (alias `TZCOMPARETEXT`) | **Friendly** one-liner. |
| `TZTEXT(zoned, [format])` | Friendly local string; optional strftime (validated — bad formats return `#VALUE!`, never panic). |
| `TZLOCALSTATUS(y,m,d,h,mi,zone)` | Classify a local time `unique` \| `gap` \| `fold`. |

### Friendly output example
```
It is 02:00 Tue for you (America/Los_Angeles). Europe/Berlin is 9h ahead (11:00). Asia/Tokyo is 16h ahead (18:00). Asia/Kathmandu is 12:45 ahead (14:45).
```
Sub-hour offsets render as `H:MM` (Kathmandu `12:45`); signed day-rollover gives `next day`/`previous day`. Both flagship functions compute from one shared UTC instant, so the board is internally consistent.

### Verification
- `cargo test -p truecalc-core` → **3127 passed**
- `cargo clippy --workspace -- -D warnings` → clean
- `functions.json` regenerated (515 functions); all exported via MCP.

### Remaining in Phase 4 (follow-up)
`TZOVERLAP` — the working-hours overlap / meeting-slot finder across N zones (a range scan; more involved). Then Phase 5 (`MIN`/`MAX`/`SORT` for `Zoned`).

Part of #669