### PR TITLE
feat: TZOVERLAP — working-hours overlap across N zones

### DIFF
--- a/crates/core/src/eval/functions/timezone/mod.rs
+++ b/crates/core/src/eval/functions/timezone/mod.rs
@@ -45,6 +45,7 @@ pub fn register_timezone(registry: &mut Registry) {
     registry.register_eager("TZTABLE", tzboard_fn, FunctionMeta { category: "timezone", signature: "TZTABLE(anchor,zones,[base])", description: "Alias of TZBOARD" });
     registry.register_eager("TZWORLDCLOCK", tzworldclock_fn, FunctionMeta { category: "timezone", signature: "TZWORLDCLOCK(anchor,zones,[base])", description: "Friendly one-line summary comparing the time across N zones" });
     registry.register_eager("TZCOMPARETEXT", tzworldclock_fn, FunctionMeta { category: "timezone", signature: "TZCOMPARETEXT(anchor,zones,[base])", description: "Alias of TZWORLDCLOCK" });
+    registry.register_eager("TZOVERLAP", tzoverlap_fn, FunctionMeta { category: "timezone", signature: "TZOVERLAP(zones,start_local,end_local,date_serial,[granularity_min])", description: "First daily window when the local time is within [start,end) in ALL zones; [start,end] instants or 'No overlap'" });
 }
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
@@ -476,13 +477,99 @@ pub fn tzinwindow_fn(args: &[Value]) -> Value {
         }
     }
     let frac = local.time().num_seconds_from_midnight() as f64 / 86_400.0;
-    let inside = if start <= end {
+    Value::Bool(in_window(frac, start, end))
+}
+
+/// Time-of-day membership in `[start, end)`; an overnight window (`start > end`)
+/// wraps past midnight.
+fn in_window(frac: f64, start: f64, end: f64) -> bool {
+    if start <= end {
         frac >= start && frac < end
     } else {
-        // Overnight window wraps past midnight.
         frac >= start || frac < end
+    }
+}
+
+pub fn tzoverlap_fn(args: &[Value]) -> Value {
+    if let Some(e) = check_arity(args, 4, 5) {
+        return e;
+    }
+    let names = match collect_zone_names(&args[0]) {
+        Ok(n) => n,
+        Err(e) => return e,
     };
-    Value::Bool(inside)
+    let start = match to_number(args[1].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let end = match to_number(args[2].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let date_serial = match to_number(args[3].clone()) {
+        Ok(n) => n,
+        Err(e) => return e,
+    };
+    let gran_min = match args.get(4) {
+        None => 30.0,
+        Some(v) => match to_number(v.clone()) {
+            Ok(n) => n,
+            Err(e) => return e,
+        },
+    };
+    if gran_min < 1.0 {
+        return Value::Error(ErrorKind::Value);
+    }
+    let zones: Vec<ZoneId> = match names.iter().map(|n| parse_zone(n).ok_or(())).collect() {
+        Ok(z) => z,
+        Err(()) => return Value::Error(ErrorKind::Value),
+    };
+    let first = zones[0].clone();
+
+    // Anchor the scan at local midnight of `date_serial` in the first zone, then
+    // step across the next 48 hours looking for the first contiguous run where
+    // every zone is within the window.
+    let date = match serial_to_date(date_serial) {
+        Some(d) => d,
+        None => return Value::Error(ErrorKind::Value),
+    };
+    let midnight = match date.and_hms_opt(0, 0, 0) {
+        Some(m) => m,
+        None => return Value::Error(ErrorKind::Value),
+    };
+    let scan_start = match ZonedInstant::from_local(first.clone(), midnight, AmbiguousPolicy::Compatible) {
+        Some(z) => z.utc_nanos,
+        None => return Value::Error(ErrorKind::Value),
+    };
+    let step = (gran_min * 60.0 * 1e9) as i64;
+    let scan_end = scan_start + 48 * 3_600 * 1_000_000_000;
+
+    let mut overlap_start: Option<i64> = None;
+    let mut overlap_last: Option<i64> = None;
+    let mut t = scan_start;
+    while t <= scan_end {
+        let all_in = zones.iter().all(|z| {
+            let local = ZonedInstant::from_instant(t, z.clone()).local();
+            let frac = local.time().num_seconds_from_midnight() as f64 / 86_400.0;
+            in_window(frac, start, end)
+        });
+        if all_in {
+            overlap_start.get_or_insert(t);
+            overlap_last = Some(t);
+        } else if overlap_start.is_some() {
+            break; // end of the first contiguous overlap run
+        }
+        t += step;
+    }
+
+    match (overlap_start, overlap_last) {
+        (Some(s), Some(last)) => Value::Array(vec![
+            zoned(ZonedInstant::from_instant(s, first.clone())),
+            // Exclusive end: one granularity step past the last in-window sample.
+            zoned(ZonedInstant::from_instant(last + step, first)),
+        ]),
+        _ => Value::Text("No overlap".to_string()),
+    }
 }
 
 /// `TZCANONICAL(zone)` — validate and normalize a zone name. Best-effort: a

--- a/crates/core/src/eval/functions/timezone/tests.rs
+++ b/crates/core/src/eval/functions/timezone/tests.rs
@@ -480,3 +480,54 @@ fn flagship_rejects_bad_inputs() {
     );
     assert_eq!(tzworldclock_fn(&[anchor, num(5.0)]), Value::Error(ErrorKind::Value)); // zones not text/array
 }
+
+// ── TZOVERLAP — working-hours overlap across N zones ──────────────────────────
+
+/// Date serial for a UTC calendar date at midnight.
+fn date_serial(y: f64, mo: f64, d: f64) -> Value {
+    match tzserial_fn(&[dt(&[num(y), num(mo), num(d), num(0.0), num(0.0), num(0.0), txt("UTC")])]) {
+        Value::Date(s) => Value::Date(s),
+        other => panic!("expected Date, got {other:?}"),
+    }
+}
+
+#[test]
+fn tzoverlap_new_york_berlin_winter() {
+    // 09:00-18:00 local in both. Winter: NY EST(-5), Berlin CET(+1) -> 6h apart.
+    // Overlap = 14:00Z-17:00Z = NY 09:00-12:00.
+    let zones = Value::Array(vec![txt("America/New_York"), txt("Europe/Berlin")]);
+    let res = tzoverlap_fn(&[zones, num(9.0 / 24.0), num(18.0 / 24.0), date_serial(2026.0, 1.0, 15.0)]);
+    match res {
+        Value::Array(iv) => {
+            assert_eq!(iv.len(), 2);
+            assert_eq!(tzstring_fn(&[iv[0].clone()]), txt("2026-01-15T09:00:00-05:00[America/New_York]"));
+            assert_eq!(tzstring_fn(&[iv[1].clone()]), txt("2026-01-15T12:00:00-05:00[America/New_York]"));
+        }
+        other => panic!("expected overlap interval, got {other:?}"),
+    }
+}
+
+#[test]
+fn tzoverlap_none_for_opposite_zones() {
+    // UTC and a fixed +12 zone never share 09:00-18:00 local.
+    let zones = Value::Array(vec![txt("UTC"), txt("+12:00")]);
+    assert_eq!(
+        tzoverlap_fn(&[zones, num(9.0 / 24.0), num(18.0 / 24.0), date_serial(2026.0, 1.0, 15.0)]),
+        Value::Text("No overlap".to_string())
+    );
+}
+
+#[test]
+fn tzoverlap_error_cases() {
+    let s = date_serial(2026.0, 1.0, 15.0);
+    // Invalid zone.
+    assert_eq!(
+        tzoverlap_fn(&[Value::Array(vec![txt("Mars/Olympus")]), num(0.375), num(0.75), s.clone()]),
+        Value::Error(ErrorKind::Value)
+    );
+    // Granularity below 1 minute.
+    assert_eq!(
+        tzoverlap_fn(&[Value::Array(vec![txt("UTC")]), num(0.375), num(0.75), s, num(0.0)]),
+        Value::Error(ErrorKind::Value)
+    );
+}

--- a/functions.json
+++ b/functions.json
@@ -6891,6 +6891,13 @@
     "examples": []
   },
   {
+    "name": "TZOVERLAP",
+    "category": "timezone",
+    "syntax": "TZOVERLAP(zones,start_local,end_local,date_serial,[granularity_min])",
+    "description": "First daily window when the local time is within [start,end) in ALL zones; [start,end] instants or 'No overlap'",
+    "examples": []
+  },
+  {
     "name": "TZPARSE",
     "category": "timezone",
     "syntax": "TZPARSE(text,[zone])",


### PR DESCRIPTION
## Phase 4 (final) of #666 — the meeting-slot finder

`TZOVERLAP(zones, start_local, end_local, date_serial, [granularity_min])` finds the first daily window when the local time is within `[start, end)` in **all** listed zones at once.

- Returns the overlap as `[Zoned(start), Zoned(end)]` instants (labelled in the first zone), or the text `"No overlap"`.
- Anchors at local midnight of `date_serial` in the first zone, scans the next 48 h at `granularity_min` (default 30); each sample is DST-resolved per zone independently. Exclusive end is one step past the last in-window sample (granularity-bounded precision, documented).
- Factors a shared `in_window` helper (also used by `TZINWINDOW`).

### Worked example (verified in tests)
`TZOVERLAP({"America/New_York","Europe/Berlin"}, TIME(9,0,0), TIME(18,0,0), <2026-01-15>)` → NY 09:00–12:00 (= 14:00Z–17:00Z), the 3-hour winter overlap. Opposite zones (`UTC` + `+12:00`) → `"No overlap"`.

### Verification
- `cargo test -p truecalc-core` → **3130 passed**
- `cargo clippy --workspace -- -D warnings` → clean
- `functions.json` regenerated (516 functions); exported via MCP.

Closes #669