### PR TITLE
feat: MIN/MAX/SORT participation for zone-aware values (Phase 5)

### DIFF
--- a/crates/core/src/eval/functions/array/mod.rs
+++ b/crates/core/src/eval/functions/array/mod.rs
@@ -487,6 +487,8 @@ fn compare_values_sort(a: &Value, b: &Value) -> std::cmp::Ordering {
         (Value::Number(x), Value::Number(y)) => x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal),
         (Value::Text(x), Value::Text(y)) => x.cmp(y),
         (Value::Bool(x), Value::Bool(y)) => x.cmp(y),
+        // Zone-aware instants sort by the absolute instant.
+        (Value::Zoned(x), Value::Zoned(y)) => x.utc_nanos.cmp(&y.utc_nanos),
         _ => std::cmp::Ordering::Equal,
     }
 }

--- a/crates/core/src/eval/functions/statistical/max/mod.rs
+++ b/crates/core/src/eval/functions/statistical/max/mod.rs
@@ -8,6 +8,11 @@ pub fn max_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
+    // Zone-aware participation: a column of Zoned instants returns the latest
+    // (as a Zoned); mixing naive and aware values is #VALUE!.
+    if let Some(r) = super::stat_helpers::zoned_extreme(args, false) {
+        return r;
+    }
     let mut result: Option<f64> = None;
     let mut had_array = false;
     for arg in args {

--- a/crates/core/src/eval/functions/statistical/min/mod.rs
+++ b/crates/core/src/eval/functions/statistical/min/mod.rs
@@ -8,6 +8,11 @@ pub fn min_fn(args: &[Value]) -> Value {
     if args.is_empty() {
         return Value::Error(ErrorKind::NA);
     }
+    // Zone-aware participation: a column of Zoned instants returns the earliest
+    // (as a Zoned); mixing naive and aware values is #VALUE!.
+    if let Some(r) = super::stat_helpers::zoned_extreme(args, true) {
+        return r;
+    }
     let mut result: Option<f64> = None;
     for arg in args {
         match arg {

--- a/crates/core/src/eval/functions/statistical/stat_helpers.rs
+++ b/crates/core/src/eval/functions/statistical/stat_helpers.rs
@@ -1,4 +1,71 @@
-use crate::types::{ErrorKind, Value};
+use crate::types::{ErrorKind, Value, ZonedInstant};
+
+/// Resolve `MIN`/`MAX` over zone-aware values.
+///
+/// Returns `None` when no `Zoned` value participates (the caller falls through
+/// to the numeric path). Otherwise: a propagated error if one is present;
+/// `#VALUE!` if `Zoned` is mixed with any numeric-contributing value
+/// (Number/Bool/Text); else the earliest (`want_min`) or latest `Zoned`,
+/// preserving the winning value's own zone.
+pub fn zoned_extreme(args: &[Value], want_min: bool) -> Option<Value> {
+    fn walk(
+        v: &Value,
+        best: &mut Option<ZonedInstant>,
+        saw_zoned: &mut bool,
+        saw_numeric: &mut bool,
+        error: &mut Option<Value>,
+        want_min: bool,
+    ) {
+        match v {
+            Value::Zoned(z) => {
+                *saw_zoned = true;
+                let take = match best.as_ref() {
+                    None => true,
+                    Some(c) => {
+                        if want_min {
+                            z.utc_nanos < c.utc_nanos
+                        } else {
+                            z.utc_nanos > c.utc_nanos
+                        }
+                    }
+                };
+                if take {
+                    *best = Some((**z).clone());
+                }
+            }
+            Value::Number(_) | Value::Date(_) | Value::Bool(_) | Value::Text(_) => *saw_numeric = true,
+            Value::Error(e) => {
+                if error.is_none() {
+                    *error = Some(Value::Error(e.clone()));
+                }
+            }
+            Value::Empty => {}
+            Value::Array(elems) => {
+                for e in elems {
+                    walk(e, best, saw_zoned, saw_numeric, error, want_min);
+                }
+            }
+        }
+    }
+
+    let mut best: Option<ZonedInstant> = None;
+    let mut saw_zoned = false;
+    let mut saw_numeric = false;
+    let mut error: Option<Value> = None;
+    for a in args {
+        walk(a, &mut best, &mut saw_zoned, &mut saw_numeric, &mut error, want_min);
+    }
+    if !saw_zoned {
+        return None;
+    }
+    if let Some(e) = error {
+        return Some(e);
+    }
+    if saw_numeric {
+        return Some(Value::Error(ErrorKind::Value));
+    }
+    best.map(|z| Value::Zoned(Box::new(z)))
+}
 
 /// Collect numeric values from args, flattening arrays.
 /// Numbers and Dates are included. Bool/Text/Empty are ignored.

--- a/crates/core/tests/timezone_aggregates.rs
+++ b/crates/core/tests/timezone_aggregates.rs
@@ -1,0 +1,55 @@
+//! Phase 5: MIN/MAX/SORT participation for zone-aware (`Value::Zoned`) values.
+//! Exercised end-to-end through the engine.
+
+use std::collections::HashMap;
+use truecalc_core::{Engine, ErrorKind, Value};
+
+fn eval(formula: &str) -> Value {
+    Engine::sheets().evaluate(formula, &HashMap::new())
+}
+
+#[test]
+fn min_and_max_over_zoned_return_zoned() {
+    let earlier = "TZDATETIME(2026,7,14,9,0,0,\"Europe/Berlin\")";
+    let later = "TZDATETIME(2026,7,14,11,0,0,\"Europe/Berlin\")";
+    assert_eq!(
+        eval(&format!("=TZSTRING(MIN({later},{earlier}))")),
+        Value::Text("2026-07-14T09:00:00+02:00[Europe/Berlin]".to_string())
+    );
+    assert_eq!(
+        eval(&format!("=TZSTRING(MAX({earlier},{later}))")),
+        Value::Text("2026-07-14T11:00:00+02:00[Europe/Berlin]".to_string())
+    );
+}
+
+#[test]
+fn min_compares_on_the_instant_across_zones() {
+    // 09:00 Berlin (07:00Z) is earlier than 09:00 New York (13:00Z).
+    let berlin = "TZDATETIME(2026,7,14,9,0,0,\"Europe/Berlin\")";
+    let ny = "TZDATETIME(2026,7,14,9,0,0,\"America/New_York\")";
+    assert_eq!(
+        eval(&format!("=TZOFFSET(MIN({ny},{berlin}))")),
+        Value::Number(120.0) // the Berlin one wins (earlier instant)
+    );
+}
+
+#[test]
+fn mixing_naive_and_zoned_is_value_error() {
+    assert_eq!(
+        eval("=MIN(TZDATETIME(2026,1,1,0,0,0,\"UTC\"), 5)"),
+        Value::Error(ErrorKind::Value)
+    );
+    assert_eq!(
+        eval("=MAX(7, TZDATETIME(2026,1,1,0,0,0,\"UTC\"))"),
+        Value::Error(ErrorKind::Value)
+    );
+}
+
+#[test]
+fn sort_orders_zoned_by_instant() {
+    // Inline column of two instants (later first); SORT ascending puts the
+    // earlier one first -- proving instant ordering, not insertion order.
+    let f = "=TZSTRING(INDEX(SORT({TZDATETIME(2026,7,14,11,0,0,\"UTC\");\
+             TZDATETIME(2026,7,14,9,0,0,\"UTC\")}),1,1))";
+    assert_eq!(eval(f), Value::Text("2026-07-14T09:00:00+00:00[UTC]".to_string()));
+}


### PR DESCRIPTION
## Phase 5 of #666 — the final piece

Gives `Value::Zoned` ordered participation in aggregates via its absolute instant (`utc_nanos`).

- **`MIN`/`MAX`** — a column of `Zoned` instants returns the earliest/latest **as a `Zoned`** (preserving the winning value's own zone). Mixing naive and aware values → `#VALUE!`. The existing numeric path is byte-identical when no `Zoned` participates (zero regression risk); shared `stat_helpers::zoned_extreme`.
- **`SORT`** — `compare_values_sort` orders `Zoned` by instant.

Because comparison is on the instant, `MIN` across zones picks the truly earliest moment — e.g. `MIN(09:00 New York, 09:00 Berlin)` → the Berlin one (07:00Z beats 13:00Z). This avoids the lossy `TZSERIAL`-then-sort footgun.

### Verification
- `cargo test -p truecalc-core` → **3134 passed** (incl. end-to-end engine tests for MIN/MAX/SORT over `Zoned`)
- `cargo clippy --workspace -- -D warnings` → clean
- No new functions (MIN/MAX/SORT already existed); `functions.json` unchanged.

Closes #670

---
**This completes the timezone epic (#666).** Final tally: a `Value::Zoned` type over chrono-tz, exported across WASM/MCP/workbook, 27 `TZ*` functions including the flagship N-timezone compare, and aggregate/sort support.